### PR TITLE
Renames @XmlArrayItem decorator to @XmlArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ console.log(deserializedPerson);
 | `@XmlAttribute` | Map to attribute | `@XmlAttribute({ name: 'id' })` |
 | `@XmlText` | Map to text content | `@XmlText()` |
 | `@XmlComment` | Add XML comments | `@XmlComment()` |
-| `@XmlArrayItem` | Configure arrays | `@XmlArrayItem({ itemName: 'Item' })` |
+| `@XmlArray` | Configure arrays | `@XmlArray({ itemName: 'Item' })` |
 | `@XmlQueryable` | Enable query API | `@XmlQueryable()` |
 
 [**Full API Reference →**](docs/api-reference.md)
@@ -201,12 +201,12 @@ const siblings = catalog.query.children[0].siblings;
 ### Arrays - Flexible Collection Handling
 ```typescript
 // Wrapped array
-@XmlArrayItem({ containerName: 'Books', itemName: 'Book', type: Book })
+@XmlArray({ containerName: 'Books', itemName: 'Book', type: Book })
 books: Book[] = [];
 // <Books><Book>...</Book><Book>...</Book></Books>
 
 // Unwrapped array
-@XmlArrayItem({ itemName: 'Item', type: Item })
+@XmlArray({ itemName: 'Item', type: Item })
 items: Item[] = [];
 // <Item>...</Item><Item>...</Item>
 ```
@@ -277,7 +277,7 @@ createdAt: Date = new Date();
 
 2. **Specify types for arrays**: Use the `type` parameter for complex objects
    ```typescript
-   @XmlArrayItem({ itemName: 'Item', type: Item })
+   @XmlArray({ itemName: 'Item', type: Item })
    items: Item[] = [];
    ```
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -241,23 +241,23 @@ class Message {
 // <Message type="info">Hello World</Message>
 ```
 
-### @XmlArrayItem
+### @XmlArray
 
 Configures array serialization.
 
 ```typescript
 // Unwrapped array
-@XmlArrayItem({ itemName: 'Item' })
+@XmlArray({ itemName: 'Item' })
 items: string[] = [];
 
 // Wrapped array
-@XmlArrayItem({ containerName: 'Items', itemName: 'Item' })
+@XmlArray({ containerName: 'Items', itemName: 'Item' })
 items: string[] = [];
 ```
 
 **Options:**
 ```typescript
-interface XmlArrayItemOptions {
+interface XmlArrayOptions {
     itemName: string;              // Name for each array item
     containerName?: string;        // Optional container element
     type?: Function;               // Type constructor for complex objects
@@ -583,7 +583,7 @@ class Book {
 @XmlRoot({ elementName: 'Library' })
 class Library {
     // ✅ Specify type for complex objects
-    @XmlArrayItem({ itemName: 'Book', type: Book })
+    @XmlArray({ itemName: 'Book', type: Book })
     books: Book[] = [];
 }
 ```

--- a/docs/features/arrays.md
+++ b/docs/features/arrays.md
@@ -1,11 +1,11 @@
 # Arrays & Collections
 
-Learn how to serialize and deserialize arrays using the `@XmlArrayItem` decorator.
+Learn how to serialize and deserialize arrays using the `@XmlArray` decorator.
 
 ## Table of Contents
 
 - [Overview](#overview)
-- [@XmlArrayItem Decorator](#xmlarrayitem-decorator)
+- [@XmlArray Decorator](#XmlArray-decorator)
 - [Wrapped vs Unwrapped Arrays](#wrapped-vs-unwrapped-arrays)
 - [Simple Arrays](#simple-arrays)
 - [Complex Object Arrays](#complex-object-arrays)
@@ -36,18 +36,18 @@ XML arrays can be structured in two ways:
 </Library>
 ```
 
-The `@XmlArrayItem` decorator handles both patterns.
+The `@XmlArray` decorator handles both patterns.
 
 [↑ Back to top](#table-of-contents)
 
-## @XmlArrayItem Decorator
+## @XmlArray Decorator
 
-The `@XmlArrayItem` decorator configures how arrays are serialized to XML.
+The `@XmlArray` decorator configures how arrays are serialized to XML.
 
 ### Options
 
 ```typescript
-interface XmlArrayItemOptions {
+interface XmlArrayOptions {
     itemName: string;              // Name for each array element (required)
     containerName?: string;        // Optional wrapper element name
     type?: Function;               // Type constructor for complex objects
@@ -59,7 +59,7 @@ interface XmlArrayItemOptions {
 ### Basic Usage
 
 ```typescript
-import { XmlRoot, XmlArrayItem, XmlSerializer } from '@cerios/xml-poto';
+import { XmlRoot, XmlArray, XmlSerializer } from '@cerios/xml-poto';
 
 @XmlRoot({ elementName: 'Library' })
 class Library {
@@ -67,7 +67,7 @@ class Library {
     name: string = '';
 
     // Unwrapped array (no container)
-    @XmlArrayItem({ itemName: 'Book' })
+    @XmlArray({ itemName: 'Book' })
     books: string[] = [];
 }
 
@@ -100,7 +100,7 @@ Array items appear directly under the parent element (no wrapper):
 ```typescript
 @XmlRoot({ elementName: 'Playlist' })
 class Playlist {
-    @XmlArrayItem({ itemName: 'Song' })
+    @XmlArray({ itemName: 'Song' })
     songs: string[] = [];
 }
 ```
@@ -120,7 +120,7 @@ Array items are contained in a wrapper element:
 ```typescript
 @XmlRoot({ elementName: 'Playlist' })
 class Playlist {
-    @XmlArrayItem({ containerName: 'Songs', itemName: 'Song' })
+    @XmlArray({ containerName: 'Songs', itemName: 'Song' })
     songs: string[] = [];
 }
 ```
@@ -156,7 +156,7 @@ class Playlist {
 ```typescript
 @XmlRoot({ elementName: 'Tags' })
 class Tags {
-    @XmlArrayItem({ itemName: 'Tag' })
+    @XmlArray({ itemName: 'Tag' })
     items: string[] = [];
 }
 
@@ -178,7 +178,7 @@ tags.items = ['typescript', 'xml', 'serialization'];
 ```typescript
 @XmlRoot({ elementName: 'Scores' })
 class Scores {
-    @XmlArrayItem({ containerName: 'Values', itemName: 'Score' })
+    @XmlArray({ containerName: 'Values', itemName: 'Score' })
     values: number[] = [];
 }
 
@@ -222,7 +222,7 @@ class Book {
 @XmlRoot({ elementName: 'Library' })
 class Library {
     // ✅ Specify type for complex objects
-    @XmlArrayItem({ containerName: 'Books', itemName: 'Book', type: Book })
+    @XmlArray({ containerName: 'Books', itemName: 'Book', type: Book })
     books: Book[] = [];
 }
 
@@ -269,7 +269,7 @@ class Feed {
     title: string = '';
 
     // Unwrapped array - common in RSS feeds
-    @XmlArrayItem({ itemName: 'Item', type: Item })
+    @XmlArray({ itemName: 'Item', type: Item })
     items: Item[] = [];
 }
 
@@ -325,10 +325,10 @@ class Cat {
 
 @XmlRoot({ elementName: 'Pets' })
 class Pets {
-    @XmlArrayItem({ itemName: 'Dog', type: Dog })
+    @XmlArray({ itemName: 'Dog', type: Dog })
     dogs: Dog[] = [];
 
-    @XmlArrayItem({ itemName: 'Cat', type: Cat })
+    @XmlArray({ itemName: 'Cat', type: Cat })
     cats: Cat[] = [];
 }
 ```
@@ -360,7 +360,7 @@ Arrays can contain objects that themselves have arrays:
 ```typescript
 @XmlElement({ elementName: 'Row' })
 class Row {
-    @XmlArrayItem({ itemName: 'Cell', type: Cell })
+    @XmlArray({ itemName: 'Cell', type: Cell })
     cells: Cell[] = [];
 }
 
@@ -372,7 +372,7 @@ class Cell {
 
 @XmlRoot({ elementName: 'Table' })
 class Table {
-    @XmlArrayItem({ itemName: 'Row', type: Row })
+    @XmlArray({ itemName: 'Row', type: Row })
     rows: Row[] = [];
 }
 
@@ -428,7 +428,7 @@ const itemNs = { uri: 'http://example.com/items', prefix: 'item' };
 
 @XmlRoot({ elementName: 'Container' })
 class Container {
-    @XmlArrayItem({
+    @XmlArray({
         containerName: 'Items',
         itemName: 'Item',
         type: Item,
@@ -466,11 +466,11 @@ class Item {
 
 ```typescript
 // ✅ Good - type specified
-@XmlArrayItem({ itemName: 'Book', type: Book })
+@XmlArray({ itemName: 'Book', type: Book })
 books: Book[] = [];
 
 // ❌ Bad - will not deserialize correctly
-@XmlArrayItem({ itemName: 'Book' })
+@XmlArray({ itemName: 'Book' })
 books: Book[] = [];
 ```
 
@@ -478,11 +478,11 @@ books: Book[] = [];
 
 ```typescript
 // ✅ Good - initialized
-@XmlArrayItem({ itemName: 'Item' })
+@XmlArray({ itemName: 'Item' })
 items: string[] = [];
 
 // ❌ Bad - uninitialized
-@XmlArrayItem({ itemName: 'Item' })
+@XmlArray({ itemName: 'Item' })
 items: string[];
 ```
 
@@ -490,11 +490,11 @@ items: string[];
 
 ```typescript
 // ✅ Good - clear singular form
-@XmlArrayItem({ itemName: 'Product' })
+@XmlArray({ itemName: 'Product' })
 products: Product[] = [];
 
 // ❌ Bad - unclear
-@XmlArrayItem({ itemName: 'Prod' })
+@XmlArray({ itemName: 'Prod' })
 products: Product[] = [];
 ```
 
@@ -502,11 +502,11 @@ products: Product[] = [];
 
 ```typescript
 // ✅ Good - plural container, singular item
-@XmlArrayItem({ containerName: 'Books', itemName: 'Book', type: Book })
+@XmlArray({ containerName: 'Books', itemName: 'Book', type: Book })
 books: Book[] = [];
 
 // ❌ Bad - confusing naming
-@XmlArrayItem({ containerName: 'Book', itemName: 'BookItem', type: Book })
+@XmlArray({ containerName: 'Book', itemName: 'BookItem', type: Book })
 books: Book[] = [];
 ```
 
@@ -516,20 +516,20 @@ books: Book[] = [];
 // ✅ Good - consistent style
 @XmlRoot({ elementName: 'Library' })
 class Library {
-    @XmlArrayItem({ containerName: 'Books', itemName: 'Book', type: Book })
+    @XmlArray({ containerName: 'Books', itemName: 'Book', type: Book })
     books: Book[] = [];
 
-    @XmlArrayItem({ containerName: 'Authors', itemName: 'Author' })
+    @XmlArray({ containerName: 'Authors', itemName: 'Author' })
     authors: string[] = [];
 }
 
 // ❌ Bad - inconsistent
 @XmlRoot({ elementName: 'Library' })
 class Library {
-    @XmlArrayItem({ containerName: 'Books', itemName: 'Book', type: Book })
+    @XmlArray({ containerName: 'Books', itemName: 'Book', type: Book })
     books: Book[] = [];
 
-    @XmlArrayItem({ itemName: 'Author' })  // No container
+    @XmlArray({ itemName: 'Author' })  // No container
     authors: string[] = [];
 }
 ```

--- a/docs/features/comments.md
+++ b/docs/features/comments.md
@@ -353,7 +353,7 @@ class Catalog {
     @XmlComment()
     comment: string = '';
 
-    @XmlArrayItem({ itemName: 'Item' })
+    @XmlArray({ itemName: 'Item' })
     items: string[] = [];
 }
 

--- a/docs/features/namespaces.md
+++ b/docs/features/namespaces.md
@@ -329,7 +329,7 @@ class Item {
 
 @XmlRoot({ elementName: 'Container' })
 class Container {
-    @XmlArrayItem({
+    @XmlArray({
         itemName: 'Item',
         type: Item,
         namespace: itemNs

--- a/docs/features/nested-objects.md
+++ b/docs/features/nested-objects.md
@@ -251,13 +251,13 @@ class Contact {
     @XmlElement({ name: 'Name' })
     name: string = '';
 
-    @XmlArrayItem({ containerName: 'PhoneNumbers', itemName: 'Phone', type: PhoneNumber })
+    @XmlArray({ containerName: 'PhoneNumbers', itemName: 'Phone', type: PhoneNumber })
     phones: PhoneNumber[] = [];
 }
 
 @XmlRoot({ elementName: 'AddressBook' })
 class AddressBook {
-    @XmlArrayItem({ itemName: 'Contact', type: Contact })
+    @XmlArray({ itemName: 'Contact', type: Contact })
     contacts: Contact[] = [];
 }
 
@@ -310,13 +310,13 @@ class Category {
     @XmlElement({ name: 'Name' })
     name: string = '';
 
-    @XmlArrayItem({ itemName: 'Item', type: Item })
+    @XmlArray({ itemName: 'Item', type: Item })
     items: Item[] = [];
 }
 
 @XmlRoot({ elementName: 'Catalog' })
 class Catalog {
-    @XmlArrayItem({ itemName: 'Category', type: Category })
+    @XmlArray({ itemName: 'Category', type: Category })
     categories: Category[] = [];
 }
 
@@ -463,7 +463,7 @@ class Person {
 
 @XmlRoot({ elementName: 'People' })
 class People {
-    @XmlArrayItem({ itemName: 'Person', type: Person })
+    @XmlArray({ itemName: 'Person', type: Person })
     persons: Person[] = [];
 }
 ```

--- a/docs/features/querying.md
+++ b/docs/features/querying.md
@@ -185,7 +185,7 @@ class Library {
     @XmlElement()
     name!: string;
 
-    @XmlArrayItem({ itemName: 'Book', containerName: 'Books' })
+    @XmlArray({ itemName: 'Book', containerName: 'Books' })
     books!: Book[];
 
     // Query just the Books container
@@ -953,7 +953,7 @@ const products = catalog.query.find('Product');
 ```typescript
 @XmlRoot({ elementName: 'Library' })
 class Library {
-    @XmlArrayItem({ containerName: 'Books', itemName: 'Book' })
+    @XmlArray({ containerName: 'Books', itemName: 'Book' })
     books!: Book[];
 
     // Query only the Books container, not entire document

--- a/docs/features/validation.md
+++ b/docs/features/validation.md
@@ -911,7 +911,7 @@ class Config {
     port: number = 0;
 
     // ✅ Arrays of primitives - no validation needed
-    @XmlArrayItem({ itemName: 'tag' })
+    @XmlArray({ itemName: 'tag' })
     tags: string[] = [];
 
     // ⚠️ Nested object - validation applies

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -274,7 +274,7 @@ class Library {
     @XmlElement({ name: 'Name' })
     name: string = '';
 
-    @XmlArrayItem({ itemName: 'Book' })
+    @XmlArray({ itemName: 'Book' })
     books: string[] = [];
 }
 

--- a/src/decorators/getters/metadata-getters.ts
+++ b/src/decorators/getters/metadata-getters.ts
@@ -1,7 +1,7 @@
 import type { ClassMetadata } from "../storage/metadata-storage";
 import { getMetadata, hasMetadata } from "../storage/metadata-storage";
 import {
-	XmlArrayItemMetadata,
+	XmlArrayMetadata,
 	XmlAttributeMetadata,
 	XmlCommentMetadata,
 	XmlElementMetadata,
@@ -156,16 +156,16 @@ export function getXmlRootMetadata(target: any): XmlRootMetadata | undefined {
 }
 
 /**
- * Get XML array item metadata (optimized - single lookup)
+ * Get XML array metadata (optimized - single lookup)
  * @param target The class constructor
- * @returns Record of array item metadata arrays keyed by property name
+ * @returns Record of array metadata arrays keyed by property name
  */
-export function getXmlArrayItemMetadata(target: any): Record<string, XmlArrayItemMetadata[]> {
+export function getXmlArrayMetadata(target: any): Record<string, XmlArrayMetadata[]> {
 	// Check unified storage if it has data
 	if (hasMetadata(target)) {
-		const arrayItems = getMetadata(target).arrayItems;
-		if (Object.keys(arrayItems).length > 0) {
-			return arrayItems;
+		const arrays = getMetadata(target).arrays;
+		if (Object.keys(arrays).length > 0) {
+			return arrays;
 		}
 	}
 
@@ -174,7 +174,7 @@ export function getXmlArrayItemMetadata(target: any): Record<string, XmlArrayIte
 
 	// Check unified storage again after instantiation
 	if (hasMetadata(target)) {
-		return getMetadata(target).arrayItems;
+		return getMetadata(target).arrays;
 	}
 
 	// Return empty object - class has no decorated fields

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -6,7 +6,7 @@ export * from "./getters";
 export * from "./storage";
 // Type exports
 export * from "./types";
-export * from "./xml-array-item";
+export * from "./xml-array";
 export * from "./xml-attribute";
 export * from "./xml-comment";
 export * from "./xml-element";

--- a/src/decorators/storage/helpers.ts
+++ b/src/decorators/storage/helpers.ts
@@ -1,5 +1,5 @@
 import {
-	XmlArrayItemMetadata,
+	XmlArrayMetadata,
 	XmlAttributeMetadata,
 	XmlCommentMetadata,
 	XmlElementMetadata,
@@ -20,30 +20,30 @@ export function registerAttributeMetadata(ctor: any, propertyKey: string, metada
 }
 
 /**
- * Helper function to register array item metadata
+ * Helper function to register array metadata
  * @param ctor The class constructor
  * @param propertyKey The property name
- * @param metadata The XML array item metadata
+ * @param metadata The XML array metadata
  */
-export function registerArrayItemMetadata(ctor: any, propertyKey: string, metadata: XmlArrayItemMetadata) {
+export function registerArrayMetadata(ctor: any, propertyKey: string, metadata: XmlArrayMetadata) {
 	// Store in unified metadata (single WeakMap lookup)
 	const classMetadata = getMetadata(ctor);
 
-	if (!classMetadata.arrayItems[propertyKey]) {
-		classMetadata.arrayItems[propertyKey] = [];
+	if (!classMetadata.arrays[propertyKey]) {
+		classMetadata.arrays[propertyKey] = [];
 	}
 
 	// Check if this exact metadata is already stored to avoid duplicates
-	const existing = classMetadata.arrayItems[propertyKey];
+	const existing = classMetadata.arrays[propertyKey];
 	const isDuplicate = existing.some(
-		(item: XmlArrayItemMetadata) =>
+		(item: XmlArrayMetadata) =>
 			item.itemName === metadata.itemName &&
 			item.type === metadata.type &&
 			item.containerName === metadata.containerName
 	);
 
 	if (!isDuplicate) {
-		classMetadata.arrayItems[propertyKey].push(metadata);
+		classMetadata.arrays[propertyKey].push(metadata);
 	}
 }
 

--- a/src/decorators/storage/metadata-storage.ts
+++ b/src/decorators/storage/metadata-storage.ts
@@ -1,5 +1,5 @@
 import type {
-	XmlArrayItemMetadata,
+	XmlArrayMetadata,
 	XmlAttributeMetadata,
 	XmlCommentMetadata,
 	XmlElementMetadata,
@@ -28,8 +28,8 @@ export interface ClassMetadata {
 	attributes: Record<string, XmlAttributeMetadata>;
 	/** Field-level element metadata (with namespace info) */
 	fieldElements: Record<string, XmlElementMetadata>;
-	/** Array item metadata from @XmlArrayItem decorators */
-	arrayItems: Record<string, XmlArrayItemMetadata[]>;
+	/** Array metadata from @XmlArray decorators */
+	arrays: Record<string, XmlArrayMetadata[]>;
 	/** Property name to XML element name mappings */
 	propertyMappings: Record<string, string>;
 	/** Property name that holds text content from @XmlText */
@@ -101,7 +101,7 @@ export function getMetadata(target: Constructor): ClassMetadata {
 	return metadataStorage.getOrCreate(target, () => ({
 		attributes: {},
 		fieldElements: {},
-		arrayItems: {},
+		arrays: {},
 		propertyMappings: {},
 		queryables: [],
 		ignoredProperties: new Set(),

--- a/src/decorators/types/index.ts
+++ b/src/decorators/types/index.ts
@@ -3,7 +3,7 @@
 
 // Metadata types
 export type {
-	XmlArrayItemMetadata,
+	XmlArrayMetadata,
 	XmlAttributeMetadata,
 	XmlCommentMetadata,
 	XmlElementMetadata,

--- a/src/decorators/types/metadata.ts
+++ b/src/decorators/types/metadata.ts
@@ -66,7 +66,7 @@ export interface XmlAttributeMetadata {
  */
 export interface XmlRootMetadata {
 	/** Root element name */
-	elementName?: string;
+	name?: string;
 	/** Root namespace */
 	namespace?: XmlNamespace;
 	/** XML Schema data type */
@@ -75,6 +75,10 @@ export interface XmlRootMetadata {
 	isNullable?: boolean;
 	/** Control whitespace handling with xml:space attribute ('preserve' or 'default') */
 	xmlSpace?: "preserve" | "default";
+
+	// Legacy support - will be deprecated
+	/** @deprecated Use name instead */
+	elementName?: string;
 }
 
 /**
@@ -95,9 +99,9 @@ export interface XmlTextMetadata {
 }
 
 /**
- * Array item metadata
+ * Array metadata
  */
-export interface XmlArrayItemMetadata {
+export interface XmlArrayMetadata {
 	/** Name for the array container element (overrides property name) */
 	containerName?: string;
 	/** Element name for individual array items */

--- a/src/decorators/types/options.ts
+++ b/src/decorators/types/options.ts
@@ -86,7 +86,7 @@ export interface XmlTextOptions {
  */
 export interface XmlRootOptions {
 	/** Root element name */
-	elementName?: string;
+	name?: string;
 	/** Root namespace */
 	namespace?: XmlNamespace;
 	/** XML Schema data type */
@@ -95,12 +95,15 @@ export interface XmlRootOptions {
 	isNullable?: boolean;
 	/** Control whitespace handling with xml:space attribute ('preserve' or 'default') */
 	xmlSpace?: "preserve" | "default";
+
+	/** @deprecated Use name instead */
+	elementName?: string;
 }
 
 /**
  * Array item options
  */
-export interface XmlArrayItemOptions {
+export interface XmlArrayOptions {
 	/**
 	 * Name for the array container element (overrides property name).
 	 * If not provided, array items will be unwrapped (no container).
@@ -134,6 +137,10 @@ export interface XmlArrayItemOptions {
 	/** @deprecated Use itemName instead */
 	elementName?: string;
 }
+
+// Legacy support - will be deprecated
+/** @deprecated Use name XmlArrayOptions */
+export interface XmlArrayItemOptions extends XmlArrayOptions {}
 
 /**
  * Options for XmlComment decorator
@@ -175,10 +182,12 @@ export type ReadonlyXmlElementOptions = DeepReadonly<XmlElementOptions>;
 export type ReadonlyXmlAttributeOptions = DeepReadonly<XmlAttributeOptions>;
 export type ReadonlyXmlTextOptions = DeepReadonly<XmlTextOptions>;
 export type ReadonlyXmlRootOptions = DeepReadonly<XmlRootOptions>;
-export type ReadonlyXmlArrayItemOptions = DeepReadonly<XmlArrayItemOptions>;
+export type ReadonlyXmlArrayOptions = DeepReadonly<XmlArrayOptions>;
 export type ReadonlyXmlCommentOptions = DeepReadonly<XmlCommentOptions>;
 export type ReadonlyXmlQueryableOptions = DeepReadonly<XmlQueryableOptions>;
 
+/** @deprecated Use ReadonlyXmlArrayOptions instead */
+export type ReadonlyXmlArrayItemOptions = DeepReadonly<XmlArrayItemOptions>;
 /**
  * Immutable namespace definition for better type safety
  */

--- a/src/decorators/types/type-utils.ts
+++ b/src/decorators/types/type-utils.ts
@@ -14,4 +14,4 @@ export type DeepReadonly<T> = {
 /**
  * Extract decorator names from metadata
  */
-export type DecoratorKeys = "element" | "attribute" | "text" | "root" | "arrayItem" | "comment" | "queryable";
+export type DecoratorKeys = "element" | "attribute" | "text" | "root" | "array" | "comment" | "queryable";

--- a/src/decorators/xml-array.ts
+++ b/src/decorators/xml-array.ts
@@ -1,8 +1,8 @@
-import { registerArrayItemMetadata } from "./storage";
-import { XmlArrayItemMetadata, XmlArrayItemOptions } from "./types";
+import { registerArrayMetadata } from "./storage";
+import { XmlArrayItemOptions, XmlArrayMetadata, XmlArrayOptions } from "./types";
 
 /**
- * XmlArrayItem decorator for polymorphic array support
+ * XmlArray decorator for polymorphic array support
  *
  * Allows customization of both the array container element name and individual array item element names.
  * When no containerName is provided, arrays are automatically unwrapped (items added directly to parent).
@@ -12,15 +12,15 @@ import { XmlArrayItemMetadata, XmlArrayItemOptions } from "./types";
  * @XmlElement({ name: 'Document' })
  * class Document {
  *   // Wrapped arrays (with container)
- *   @XmlArrayItem({ containerName: 'BookCollection', itemName: 'Book' })
+ *   @XmlArray({ containerName: 'BookCollection', itemName: 'Book' })
  *   books: string[] = ['Book 1', 'Book 2'];
  *
  *   // Unwrapped arrays (no container - items directly in parent)
- *   @XmlArrayItem({ itemName: 'Author' })
+ *   @XmlArray({ itemName: 'Author' })
  *   authors: string[] = ['Author 1', 'Author 2'];
  *
  *   // Explicit unwrap control
- *   @XmlArrayItem({ containerName: 'Genres', itemName: 'Genre', unwrapped: true })
+ *   @XmlArray({ containerName: 'Genres', itemName: 'Genre', unwrapped: true })
  *   genres: string[] = ['Fiction', 'Drama'];
  * }
  *
@@ -40,14 +40,14 @@ import { XmlArrayItemMetadata, XmlArrayItemOptions } from "./types";
  * @param options Configuration options for array items
  * @returns A field decorator function
  */
-export function XmlArrayItem(options: XmlArrayItemOptions = {}) {
+export function XmlArray(options: XmlArrayOptions = {}) {
 	return <T, V>(_target: undefined, context: ClassFieldDecoratorContext<T, V>): ((initialValue: V) => V) => {
 		const propertyKey = String(context.name);
 
 		// Validate: can't have both unwrapped:true and containerName
 		if (options.unwrapped === true && options.containerName) {
 			throw new Error(
-				`Invalid @XmlArrayItem configuration on '${propertyKey}': cannot specify 'containerName' when 'unwrapped' is true. ` +
+				`Invalid @XmlArray configuration on '${propertyKey}': cannot specify 'containerName' when 'unwrapped' is true. ` +
 					`Unwrapped arrays have items directly in the parent element without a container.`
 			);
 		}
@@ -55,7 +55,7 @@ export function XmlArrayItem(options: XmlArrayItemOptions = {}) {
 		// Automatic unwrapping: if no containerName is provided, unwrap automatically
 		const shouldUnwrap = options.unwrapped !== undefined ? options.unwrapped : !options.containerName;
 
-		const arrayItemMetadata: XmlArrayItemMetadata = {
+		const arrayMetadata: XmlArrayMetadata = {
 			containerName: options.containerName,
 			itemName: options.itemName,
 			type: options.type,
@@ -71,9 +71,15 @@ export function XmlArrayItem(options: XmlArrayItemOptions = {}) {
 			const ctor = this.constructor;
 
 			// Use helper function to register metadata
-			registerArrayItemMetadata(ctor, propertyKey, arrayItemMetadata);
+			registerArrayMetadata(ctor, propertyKey, arrayMetadata);
 
 			return initialValue;
 		};
 	};
+}
+
+// Legacy support - will be deprecated
+/** @deprecated Use XmlArray instead */
+export function XmlArrayItem(options: XmlArrayItemOptions = {}) {
+	return XmlArray(options);
 }

--- a/src/decorators/xml-queryable.ts
+++ b/src/decorators/xml-queryable.ts
@@ -53,7 +53,7 @@ export const PENDING_QUERYABLES_SYMBOL = Symbol.for("xml-poto:pending-queryables
  * @XmlRoot({ elementName: 'Library' })
  * class Library {
  *   @XmlElement() name!: string;
- *   @XmlArrayItem({ itemName: 'Book', containerName: 'Books' })
+ *   @XmlArray({ itemName: 'Book', containerName: 'Books' })
  *   books!: Book[];
  *
  *   @XmlQueryable({ targetProperty: 'books' })

--- a/src/decorators/xml-root.ts
+++ b/src/decorators/xml-root.ts
@@ -9,7 +9,8 @@ import { XmlRootMetadata, XmlRootOptions } from "./types";
  * Required for classes used with {@link XmlDecoratorSerializer.toXml} and {@link XmlDecoratorSerializer.fromXml}.
  *
  * @param options Configuration options for the root element
- * @param options.elementName - Custom XML element name (defaults to class name)
+ * @param options.name - Custom XML element name (defaults to class name)
+ * @param options.elementName - DEPRECATED: Use options.name instead
  * @param options.namespace - XML namespace configuration with URI and prefix
  * @param options.dataType - Expected data type for validation
  * @param options.isNullable - Whether null values are allowed
@@ -19,7 +20,7 @@ import { XmlRootMetadata, XmlRootOptions } from "./types";
  * @example
  * ```
  * // Basic root element
- * @XmlRoot({ elementName: 'Person' })
+ * @XmlRoot({ name: 'Person' })
  * class Person {
  *   @XmlElement() name!: string;
  *   @XmlElement() age!: number;
@@ -32,7 +33,7 @@ import { XmlRootMetadata, XmlRootOptions } from "./types";
  * ```
  * // With namespace
  * @XmlRoot({
- *   elementName: 'Document',
+ *   name: 'Document',
  *   namespace: { uri: 'http://example.com/doc', prefix: 'doc' }
  * })
  * class Document {
@@ -46,7 +47,7 @@ import { XmlRootMetadata, XmlRootOptions } from "./types";
  * ```
  * // Preserve whitespace in all child elements
  * @XmlRoot({
- *   elementName: 'Code',
+ *   name: 'Code',
  *   xmlSpace: 'preserve'
  * })
  * class CodeBlock {
@@ -69,12 +70,17 @@ export function XmlRoot(
 	options: XmlRootOptions = {}
 ): <T extends abstract new (...args: any) => any>(target: T, context: ClassDecoratorContext<T>) => T {
 	return <T extends abstract new (...args: any) => any>(target: T, context: ClassDecoratorContext<T>): T => {
+		// Support both new 'name' and legacy 'elementName' properties
+		const elementName = options.name || options.elementName || String(context.name);
+
 		const rootMetadata: XmlRootMetadata = {
-			elementName: options.elementName || String(context.name),
+			name: elementName,
 			namespace: options.namespace,
 			dataType: options.dataType,
 			isNullable: options.isNullable,
 			xmlSpace: options.xmlSpace,
+			// Keep elementName for backward compatibility
+			elementName: elementName,
 		};
 
 		// Store root metadata in unified storage

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type {
 	DecoratorKeys,
 	DeepReadonly,
 	XmlArrayItemOptions,
+	XmlArrayOptions,
 	XmlAttributeOptions,
 	XmlCommentOptions,
 	XmlElementOptions,
@@ -18,7 +19,7 @@ export type {
 	XmlRootOptions,
 	XmlTextOptions,
 } from "./decorators/types";
-export { XmlArrayItem } from "./decorators/xml-array-item";
+export { XmlArray, XmlArrayItem } from "./decorators/xml-array";
 export { XmlAttribute } from "./decorators/xml-attribute";
 export { XmlComment } from "./decorators/xml-comment";
 export { XmlElement } from "./decorators/xml-element";
@@ -30,5 +31,5 @@ export { QueryableElement, XmlQuery } from "./query/xml-query";
 export { XmlQueryParser, XmlQueryParserOptions } from "./query/xml-query-parser";
 export type { SerializationOptions } from "./serialization-options";
 export { XmlBuilder } from "./xml-builder";
-export { XmlDecoratorParser as XmlParser } from "./xml-decorator-parser";
+export { XmlDecoratorParser, XmlDecoratorParser as XmlParser } from "./xml-decorator-parser";
 export { XmlDecoratorSerializer, XmlDecoratorSerializer as XmlSerializer } from "./xml-decorator-serializer";

--- a/src/utils/xml-namespace-util.ts
+++ b/src/utils/xml-namespace-util.ts
@@ -1,5 +1,5 @@
 import {
-	getXmlArrayItemMetadata,
+	getXmlArrayMetadata,
 	getXmlAttributeMetadata,
 	getXmlElementMetadata,
 	getXmlFieldElementMetadata,
@@ -47,8 +47,8 @@ export class XmlNamespaceUtil {
 		});
 
 		// Collect namespaces from array items
-		const arrayItemMetadata = getXmlArrayItemMetadata(ctor);
-		Object.values(arrayItemMetadata).forEach((metadataArray: any) => {
+		const arrayMetadata = getXmlArrayMetadata(ctor);
+		Object.values(arrayMetadata).forEach((metadataArray: any) => {
 			if (Array.isArray(metadataArray)) {
 				metadataArray.forEach((metadata: any) => {
 					if (metadata.namespace?.prefix) {
@@ -112,8 +112,8 @@ export class XmlNamespaceUtil {
 			}
 		});
 
-		const arrayItemMetadata = getXmlArrayItemMetadata(ctor);
-		Object.values(arrayItemMetadata).forEach((metadataArray: any) => {
+		const arrayMetadata = getXmlArrayMetadata(ctor);
+		Object.values(arrayMetadata).forEach((metadataArray: any) => {
 			if (Array.isArray(metadataArray)) {
 				metadataArray.forEach((metadata: any) => {
 					if (metadata.namespace?.prefix) {

--- a/src/xml-decorator-serializer.ts
+++ b/src/xml-decorator-serializer.ts
@@ -116,7 +116,7 @@ export class XmlDecoratorSerializer {
 		const existingRoot = getXmlRootMetadata(ctor);
 		if (existingRoot) {
 			return {
-				name: existingRoot.elementName || ctor.name || "Element",
+				name: existingRoot.name || existingRoot.elementName || ctor.name || "Element",
 				namespace: existingRoot.namespace,
 				required: false,
 				dataType: existingRoot.dataType,
@@ -179,7 +179,7 @@ export class XmlDecoratorSerializer {
 	 * @XmlRoot({ elementName: 'Library' })
 	 * class Library {
 	 *   @XmlElement() name!: string;
-	 *   @XmlArrayItem({ itemName: 'Book', containerName: 'Books' })
+	 *   @XmlArray({ itemName: 'Book', containerName: 'Books' })
 	 *   books!: Book[];
 	 * }
 	 *
@@ -289,7 +289,7 @@ export class XmlDecoratorSerializer {
 	 * @XmlRoot({ elementName: 'Library' })
 	 * class Library {
 	 *   @XmlElement() name: string = 'City Library';
-	 *   @XmlArrayItem({ itemName: 'Book', containerName: 'Books' })
+	 *   @XmlArray({ itemName: 'Book', containerName: 'Books' })
 	 *   books: Book[] = [
 	 *     { isbn: '123', title: 'Book 1' },
 	 *     { isbn: '456', title: 'Book 2' }

--- a/tests/decorators/metadata-getters.test.ts
+++ b/tests/decorators/metadata-getters.test.ts
@@ -1,5 +1,5 @@
 import {
-	getXmlArrayItemMetadata,
+	getXmlArrayMetadata,
 	getXmlAttributeMetadata,
 	getXmlElementMetadata,
 	getXmlFieldElementMetadata,
@@ -302,16 +302,16 @@ describe("Metadata Getters", () => {
 		});
 	});
 
-	describe("getXmlArrayItemMetadata", () => {
+	describe("getXmlArrayMetadata", () => {
 		describe("WeakMap storage retrieval", () => {
 			it("should retrieve metadata from WeakMap storage", () => {
 				class TestClass {}
 				const metadata = {
 					items: [{ itemName: "item", type: String }],
 				};
-				getMetadata(TestClass).arrayItems = metadata;
+				getMetadata(TestClass).arrays = metadata;
 
-				const result = getXmlArrayItemMetadata(TestClass);
+				const result = getXmlArrayMetadata(TestClass);
 
 				expect(result).toEqual(metadata);
 			});
@@ -322,9 +322,9 @@ describe("Metadata Getters", () => {
 					items: [{ itemName: "item", type: String }],
 					products: [{ itemName: "product", type: Number }],
 				};
-				getMetadata(TestClass).arrayItems = metadata;
+				getMetadata(TestClass).arrays = metadata;
 
-				const result = getXmlArrayItemMetadata(TestClass);
+				const result = getXmlArrayMetadata(TestClass);
 
 				expect(Object.keys(result)).toHaveLength(2);
 			});
@@ -334,7 +334,7 @@ describe("Metadata Getters", () => {
 			it("should return empty object when no metadata exists", () => {
 				class TestClass {}
 
-				const result = getXmlArrayItemMetadata(TestClass);
+				const result = getXmlArrayMetadata(TestClass);
 
 				expect(result).toEqual({});
 			});
@@ -348,7 +348,7 @@ describe("Metadata Getters", () => {
 					}
 				}
 
-				const result = getXmlArrayItemMetadata(TestClass);
+				const result = getXmlArrayMetadata(TestClass);
 
 				expect(result).toEqual({});
 			});
@@ -368,9 +368,9 @@ describe("Metadata Getters", () => {
 						},
 					],
 				};
-				getMetadata(TestClass).arrayItems = metadata;
+				getMetadata(TestClass).arrays = metadata;
 
-				const result = getXmlArrayItemMetadata(TestClass);
+				const result = getXmlArrayMetadata(TestClass);
 
 				expect(result.items).toHaveLength(1);
 				expect(result.items[0].namespace).toEqual({ uri: "http://example.com" });
@@ -387,9 +387,9 @@ describe("Metadata Getters", () => {
 						{ itemName: "itemB", type: ItemB },
 					],
 				};
-				getMetadata(TestClass).arrayItems = metadata;
+				getMetadata(TestClass).arrays = metadata;
 
-				const result = getXmlArrayItemMetadata(TestClass);
+				const result = getXmlArrayMetadata(TestClass);
 
 				expect(result.items).toHaveLength(2);
 				expect(result.items[0].type).toBe(ItemA);
@@ -411,7 +411,7 @@ describe("Metadata Getters", () => {
 			const textMetadata = getXmlTextMetadata(TestClass);
 			const mappings = getXmlPropertyMappings(TestClass);
 			const fieldMetadata = getXmlFieldElementMetadata(TestClass);
-			const arrayMetadata = getXmlArrayItemMetadata(TestClass);
+			const arrayMetadata = getXmlArrayMetadata(TestClass);
 
 			expect(typeof attrMetadata).toBe("object");
 			expect(textMetadata === undefined || typeof textMetadata).toBeTruthy();

--- a/tests/decorators/xml-array.test.ts
+++ b/tests/decorators/xml-array.test.ts
@@ -1,7 +1,7 @@
-import { getXmlArrayItemMetadata } from "../../src/decorators/getters";
-import { XmlArrayItem } from "../../src/decorators/xml-array-item";
+import { getXmlArrayMetadata } from "../../src/decorators/getters";
+import { XmlArray } from "../../src/decorators/xml-array";
 
-describe("XmlArrayItem decorator", () => {
+describe("XmlArray decorator", () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
@@ -9,12 +9,12 @@ describe("XmlArrayItem decorator", () => {
 	describe("Basic functionality", () => {
 		it("should store array item metadata with default options", () => {
 			class TestClass {
-				@XmlArrayItem()
+				@XmlArray()
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items).toBeDefined();
 			expect(metadata.items).toHaveLength(1);
@@ -23,12 +23,12 @@ describe("XmlArrayItem decorator", () => {
 
 		it("should store containerName", () => {
 			class TestClass {
-				@XmlArrayItem({ containerName: "Items" })
+				@XmlArray({ containerName: "Items" })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].containerName).toBe("Items");
 			expect(metadata.items[0].unwrapped).toBe(false); // Don't unwrap with container
@@ -36,24 +36,24 @@ describe("XmlArrayItem decorator", () => {
 
 		it("should store itemName", () => {
 			class TestClass {
-				@XmlArrayItem({ itemName: "Item" })
+				@XmlArray({ itemName: "Item" })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].itemName).toBe("Item");
 		});
 
 		it("should store both containerName and itemName", () => {
 			class TestClass {
-				@XmlArrayItem({ containerName: "Books", itemName: "Book" })
+				@XmlArray({ containerName: "Books", itemName: "Book" })
 				books: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.books?.[0]?.containerName).toBe("Books");
 			expect(metadata.books?.[0]?.itemName).toBe("Book");
@@ -61,7 +61,7 @@ describe("XmlArrayItem decorator", () => {
 
 		it("should preserve initial value", () => {
 			class TestClass {
-				@XmlArrayItem({ itemName: "Item" })
+				@XmlArray({ itemName: "Item" })
 				items: string[] = ["a", "b", "c"];
 			}
 
@@ -73,36 +73,36 @@ describe("XmlArrayItem decorator", () => {
 	describe("Unwrapping behavior", () => {
 		it("should auto-unwrap when no containerName", () => {
 			class TestClass {
-				@XmlArrayItem({ itemName: "Item" })
+				@XmlArray({ itemName: "Item" })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].unwrapped).toBe(true);
 		});
 
 		it("should not unwrap when containerName is provided", () => {
 			class TestClass {
-				@XmlArrayItem({ containerName: "Container", itemName: "Item" })
+				@XmlArray({ containerName: "Container", itemName: "Item" })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].unwrapped).toBe(false);
 		});
 
 		it("should respect explicit unwrapped flag without containerName", () => {
 			class TestClass {
-				@XmlArrayItem({ itemName: "Item", unwrapped: true })
+				@XmlArray({ itemName: "Item", unwrapped: true })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].unwrapped).toBe(true);
 			expect(metadata.items[0].containerName).toBeUndefined();
@@ -110,12 +110,12 @@ describe("XmlArrayItem decorator", () => {
 
 		it("should allow explicit wrapping", () => {
 			class TestClass {
-				@XmlArrayItem({ itemName: "Item", unwrapped: false })
+				@XmlArray({ itemName: "Item", unwrapped: false })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].unwrapped).toBe(false);
 		});
@@ -126,19 +126,19 @@ describe("XmlArrayItem decorator", () => {
 			class ItemType {}
 
 			class TestClass {
-				@XmlArrayItem({ type: ItemType, itemName: "Item" })
+				@XmlArray({ type: ItemType, itemName: "Item" })
 				items: ItemType[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].type).toBe(ItemType);
 		});
 
 		it("should store namespace", () => {
 			class TestClass {
-				@XmlArrayItem({
+				@XmlArray({
 					containerName: "Items",
 					namespace: { uri: "http://example.com", prefix: "ex" },
 				})
@@ -146,7 +146,7 @@ describe("XmlArrayItem decorator", () => {
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].namespace).toEqual({
 				uri: "http://example.com",
@@ -156,48 +156,48 @@ describe("XmlArrayItem decorator", () => {
 
 		it("should store nestingLevel", () => {
 			class TestClass {
-				@XmlArrayItem({ nestingLevel: 2, itemName: "Item" })
+				@XmlArray({ nestingLevel: 2, itemName: "Item" })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].nestingLevel).toBe(2);
 		});
 
 		it("should default nestingLevel to 0", () => {
 			class TestClass {
-				@XmlArrayItem({ itemName: "Item" })
+				@XmlArray({ itemName: "Item" })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].nestingLevel).toBe(0);
 		});
 
 		it("should store isNullable", () => {
 			class TestClass {
-				@XmlArrayItem({ isNullable: true, itemName: "Item" })
+				@XmlArray({ isNullable: true, itemName: "Item" })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].isNullable).toBe(true);
 		});
 
 		it("should store dataType", () => {
 			class TestClass {
-				@XmlArrayItem({ dataType: "xs:string", itemName: "Item" })
+				@XmlArray({ dataType: "xs:string", itemName: "Item" })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0].dataType).toBe("xs:string");
 		});
@@ -209,13 +209,13 @@ describe("XmlArrayItem decorator", () => {
 			class TypeB {}
 
 			class TestClass {
-				@XmlArrayItem({ type: TypeA, itemName: "A" })
-				@XmlArrayItem({ type: TypeB, itemName: "B" })
+				@XmlArray({ type: TypeA, itemName: "A" })
+				@XmlArray({ type: TypeB, itemName: "B" })
 				items: Array<TypeA | TypeB> = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items).toHaveLength(2);
 			expect(metadata.items[0].type).toBe(TypeA);
@@ -226,14 +226,14 @@ describe("XmlArrayItem decorator", () => {
 
 		it("should avoid duplicate metadata entries", () => {
 			class TestClass {
-				@XmlArrayItem({ itemName: "Item", type: String })
+				@XmlArray({ itemName: "Item", type: String })
 				items: string[] = [];
 			}
 
 			void new TestClass();
 			void new TestClass();
 
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			// Should not have duplicates
 			expect(metadata.items).toHaveLength(1);
@@ -245,7 +245,7 @@ describe("XmlArrayItem decorator", () => {
 			class ItemType {}
 
 			class TestClass {
-				@XmlArrayItem({
+				@XmlArray({
 					containerName: "Items",
 					itemName: "Item",
 					type: ItemType,
@@ -259,7 +259,7 @@ describe("XmlArrayItem decorator", () => {
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items[0]).toMatchObject({
 				containerName: "Items",
@@ -277,12 +277,12 @@ describe("XmlArrayItem decorator", () => {
 	describe("Storage mechanisms", () => {
 		it("should allow retrieval via getter function", () => {
 			class TestClass {
-				@XmlArrayItem({ containerName: "Items", itemName: "Item" })
+				@XmlArray({ containerName: "Items", itemName: "Item" })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items).toBeDefined();
 			expect(metadata.items[0].containerName).toBe("Items");
@@ -290,15 +290,15 @@ describe("XmlArrayItem decorator", () => {
 
 		it("should handle multiple properties with array items", () => {
 			class TestClass {
-				@XmlArrayItem({ itemName: "Book" })
+				@XmlArray({ itemName: "Book" })
 				books: string[] = [];
 
-				@XmlArrayItem({ itemName: "Author" })
+				@XmlArray({ itemName: "Author" })
 				authors: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(Object.keys(metadata)).toHaveLength(2);
 			expect(metadata.books).toBeDefined();
@@ -309,12 +309,12 @@ describe("XmlArrayItem decorator", () => {
 	describe("Edge cases", () => {
 		it("should handle empty options", () => {
 			class TestClass {
-				@XmlArrayItem({})
+				@XmlArray({})
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(metadata.items).toBeDefined();
 			expect(metadata.items[0].unwrapped).toBe(true);
@@ -322,7 +322,7 @@ describe("XmlArrayItem decorator", () => {
 
 		it("should work with empty array", () => {
 			class TestClass {
-				@XmlArrayItem({ itemName: "Item" })
+				@XmlArray({ itemName: "Item" })
 				items: string[] = [];
 			}
 
@@ -332,7 +332,7 @@ describe("XmlArrayItem decorator", () => {
 
 		it("should work with undefined initial value", () => {
 			class TestClass {
-				@XmlArrayItem({ itemName: "Item" })
+				@XmlArray({ itemName: "Item" })
 				items: string[] | undefined;
 			}
 
@@ -344,12 +344,12 @@ describe("XmlArrayItem decorator", () => {
 	describe("Type safety", () => {
 		it("should maintain correct metadata structure", () => {
 			class TestClass {
-				@XmlArrayItem({ containerName: "Container", itemName: "Item", type: String, namespace: { uri: "ns1" } })
+				@XmlArray({ containerName: "Container", itemName: "Item", type: String, namespace: { uri: "ns1" } })
 				items: string[] = [];
 			}
 
 			void new TestClass();
-			const metadata = getXmlArrayItemMetadata(TestClass);
+			const metadata = getXmlArrayMetadata(TestClass);
 
 			expect(typeof metadata.items[0].containerName).toBe("string");
 		});
@@ -359,17 +359,17 @@ describe("XmlArrayItem decorator", () => {
 		it("should throw error when both unwrapped:true and containerName are specified", () => {
 			expect(() => {
 				class TestClass {
-					@XmlArrayItem({ unwrapped: true, containerName: "Container" })
+					@XmlArray({ unwrapped: true, containerName: "Container" })
 					items: string[] = [];
 				}
 				void new TestClass();
-			}).toThrow(/Invalid @XmlArrayItem configuration.*cannot specify 'containerName' when 'unwrapped' is true/);
+			}).toThrow(/Invalid @XmlArray configuration.*cannot specify 'containerName' when 'unwrapped' is true/);
 		});
 
 		it("should allow unwrapped:false with containerName", () => {
 			expect(() => {
 				class TestClass {
-					@XmlArrayItem({ unwrapped: false, containerName: "Container", itemName: "Item" })
+					@XmlArray({ unwrapped: false, containerName: "Container", itemName: "Item" })
 					items: string[] = [];
 				}
 				void new TestClass();
@@ -379,7 +379,7 @@ describe("XmlArrayItem decorator", () => {
 		it("should allow unwrapped:true without containerName", () => {
 			expect(() => {
 				class TestClass {
-					@XmlArrayItem({ unwrapped: true, itemName: "Item" })
+					@XmlArray({ unwrapped: true, itemName: "Item" })
 					items: string[] = [];
 				}
 				void new TestClass();
@@ -389,7 +389,7 @@ describe("XmlArrayItem decorator", () => {
 		it("should allow containerName without unwrapped flag", () => {
 			expect(() => {
 				class TestClass {
-					@XmlArrayItem({ containerName: "Container", itemName: "Item" })
+					@XmlArray({ containerName: "Container", itemName: "Item" })
 					items: string[] = [];
 				}
 				void new TestClass();

--- a/tests/decorators/xml-queryable-namespaces.test.ts
+++ b/tests/decorators/xml-queryable-namespaces.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import {
-	QueryableElement,
-	XmlArrayItem,
-	XmlAttribute,
-	XmlDecoratorSerializer,
-	XmlElement,
-	XmlQueryable,
-} from "../../src";
+import { QueryableElement, XmlArray, XmlAttribute, XmlDecoratorSerializer, XmlElement, XmlQueryable } from "../../src";
 
 /**
  * Helper function to extract namespace URIs from a queryable element
@@ -136,9 +129,9 @@ describe("XmlQueryable with Namespace Declarations", () => {
 		}
 		@XmlElement("xbrli:xbrl")
 		class XBRLRoot {
-			@XmlArrayItem({ itemName: "xbrli:context", type: XBRLContext })
+			@XmlArray({ itemName: "xbrli:context", type: XBRLContext })
 			contexts: XBRLContext[] = [];
-			@XmlArrayItem({ itemName: "xbrli:unit", type: XBRLUnit })
+			@XmlArray({ itemName: "xbrli:unit", type: XBRLUnit })
 			units: XBRLUnit[] = [];
 			@XmlQueryable()
 			query!: QueryableElement;
@@ -325,8 +318,8 @@ describe("XmlQueryable with Namespace Declarations", () => {
                 </edge>
             `;
 			const result = serializer.fromXml(xml, EdgeCase);
-			expect(result.query.xmlnsDeclarations).toBeDefined();
-			expect(Object.keys(result.query.xmlnsDeclarations!).length).toBe(10);
+			if (!result.query.xmlnsDeclarations) throw new Error("xmlnsDeclarations is undefined");
+			expect(Object.keys(result.query.xmlnsDeclarations).length).toBe(10);
 			expect(extractNamespaces(result.query).size).toBe(10);
 		});
 	});

--- a/tests/decorators/xml-root.test.ts
+++ b/tests/decorators/xml-root.test.ts
@@ -97,10 +97,12 @@ describe("XmlRoot decorator", () => {
 
 			const metadata = getXmlRootMetadata(ComplexRoot);
 			expect(metadata).toEqual({
-				elementName: "ComplexRoot",
+				name: "ComplexRoot",
+				elementName: "ComplexRoot", // Backward compatibility
 				namespace: { uri: "http://example.com", prefix: "ex" },
 				dataType: "xs:complexType",
 				isNullable: false,
+				xmlSpace: undefined,
 			});
 		});
 

--- a/tests/integration/edge-cases.test.ts
+++ b/tests/integration/edge-cases.test.ts
@@ -1,4 +1,4 @@
-import { XmlArrayItem } from "../../src/decorators/xml-array-item";
+import { XmlArray } from "../../src/decorators/xml-array";
 import { XmlAttribute } from "../../src/decorators/xml-attribute";
 import { XmlElement } from "../../src/decorators/xml-element";
 import { XmlRoot } from "../../src/decorators/xml-root";
@@ -39,8 +39,8 @@ describe("Integration Tests - Complex Edge Cases", () => {
 
 		@XmlRoot({ elementName: "PetStore" })
 		class PetStore {
-			@XmlArrayItem({ itemName: "Dog", type: Dog })
-			@XmlArrayItem({ itemName: "Cat", type: Cat })
+			@XmlArray({ itemName: "Dog", type: Dog })
+			@XmlArray({ itemName: "Cat", type: Cat })
 			pets: Array<Dog | Cat> = [];
 		}
 
@@ -140,13 +140,13 @@ describe("Integration Tests - Complex Edge Cases", () => {
 
 		@XmlElement("Row")
 		class Row {
-			@XmlArrayItem({ itemName: "Cell", type: Cell })
+			@XmlArray({ itemName: "Cell", type: Cell })
 			cells: Cell[] = [];
 		}
 
 		@XmlRoot({ elementName: "Table" })
 		class Table {
-			@XmlArrayItem({ itemName: "Row", type: Row })
+			@XmlArray({ itemName: "Row", type: Row })
 			rows: Row[] = [];
 		}
 
@@ -382,10 +382,10 @@ describe("Integration Tests - Complex Edge Cases", () => {
 	describe("Wrapped vs Unwrapped Arrays", () => {
 		@XmlRoot({ elementName: "Library" })
 		class Library {
-			@XmlArrayItem({ containerName: "WrappedBooks", itemName: "Book" })
+			@XmlArray({ containerName: "WrappedBooks", itemName: "Book" })
 			wrappedBooks: string[] = [];
 
-			@XmlArrayItem({ itemName: "Author" })
+			@XmlArray({ itemName: "Author" })
 			unwrappedAuthors: string[] = [];
 		}
 
@@ -520,7 +520,7 @@ describe("Integration Tests - Complex Edge Cases", () => {
 
 		@XmlRoot({ elementName: "Dataset" })
 		class Dataset {
-			@XmlArrayItem({ itemName: "Record", type: Record })
+			@XmlArray({ itemName: "Record", type: Record })
 			records: Record[] = [];
 		}
 

--- a/tests/integration/real-world-scenarios.test.ts
+++ b/tests/integration/real-world-scenarios.test.ts
@@ -1,4 +1,4 @@
-import { XmlArrayItem } from "../../src/decorators/xml-array-item";
+import { XmlArray } from "../../src/decorators/xml-array";
 import { XmlAttribute } from "../../src/decorators/xml-attribute";
 import { XmlElement } from "../../src/decorators/xml-element";
 import { XmlRoot } from "../../src/decorators/xml-root";
@@ -57,7 +57,7 @@ describe("Integration Tests - Real-world XML Scenarios", () => {
 			@XmlElement("ShippingAddress")
 			shippingAddress: Address = new Address();
 
-			@XmlArrayItem({ containerName: "Products", itemName: "Product", type: Product })
+			@XmlArray({ containerName: "Products", itemName: "Product", type: Product })
 			products: Product[] = [];
 
 			@XmlElement("TotalAmount")
@@ -193,7 +193,7 @@ describe("Integration Tests - Real-world XML Scenarios", () => {
 			@XmlElement("Link")
 			link: string = "";
 
-			@XmlArrayItem({ itemName: "Item", type: RssItem })
+			@XmlArray({ itemName: "Item", type: RssItem })
 			items: RssItem[] = [];
 		}
 
@@ -313,7 +313,7 @@ describe("Integration Tests - Real-world XML Scenarios", () => {
 			@XmlElement("ApiConfig")
 			api: ApiConfig = new ApiConfig();
 
-			@XmlArrayItem({ itemName: "Feature" })
+			@XmlArray({ itemName: "Feature" })
 			enabledFeatures: string[] = [];
 		}
 
@@ -401,7 +401,7 @@ describe("Integration Tests - Real-world XML Scenarios", () => {
 			@XmlElement("Title")
 			title: string = "";
 
-			@XmlArrayItem({ itemName: "Paragraph", type: Paragraph })
+			@XmlArray({ itemName: "Paragraph", type: Paragraph })
 			paragraphs: Paragraph[] = [];
 		}
 
@@ -416,7 +416,7 @@ describe("Integration Tests - Real-world XML Scenarios", () => {
 			@XmlElement("Author")
 			author: string = "";
 
-			@XmlArrayItem({ itemName: "Section", type: Section })
+			@XmlArray({ itemName: "Section", type: Section })
 			sections: Section[] = [];
 		}
 
@@ -722,7 +722,7 @@ describe("Integration Tests - Real-world XML Scenarios", () => {
 			@XmlElement("EmptyField")
 			emptyField: string = "";
 
-			@XmlArrayItem({ itemName: "Item" })
+			@XmlArray({ itemName: "Item" })
 			items: string[] = [];
 		}
 

--- a/tests/utils/xml-mapping-util.test.ts
+++ b/tests/utils/xml-mapping-util.test.ts
@@ -1,12 +1,4 @@
-import {
-	XmlArrayItem,
-	XmlAttribute,
-	XmlComment,
-	XmlElement,
-	XmlQueryable,
-	XmlRoot,
-	XmlText,
-} from "../../src/decorators";
+import { XmlArray, XmlAttribute, XmlComment, XmlElement, XmlQueryable, XmlRoot, XmlText } from "../../src/decorators";
 import { QueryableElement } from "../../src/query/xml-query";
 import { SerializationOptions } from "../../src/serialization-options";
 import { XmlMappingUtil } from "../../src/utils/xml-mapping-util";
@@ -223,7 +215,7 @@ describe("XmlMappingUtil", () => {
 
 				@XmlRoot({ elementName: "List" })
 				class ItemList {
-					@XmlArrayItem({ containerName: "Items", itemName: "Item", type: Item })
+					@XmlArray({ containerName: "Items", itemName: "Item", type: Item })
 					items: Item[] = [];
 				}
 
@@ -249,7 +241,7 @@ describe("XmlMappingUtil", () => {
 
 				@XmlRoot({ elementName: "List" })
 				class ItemList {
-					@XmlArrayItem({ itemName: "Item", type: Item, unwrapped: true })
+					@XmlArray({ itemName: "Item", type: Item, unwrapped: true })
 					items: Item[] = [];
 				}
 
@@ -273,7 +265,7 @@ describe("XmlMappingUtil", () => {
 
 				@XmlRoot({ elementName: "List" })
 				class ItemList {
-					@XmlArrayItem({ itemName: "Item", type: Item, unwrapped: true })
+					@XmlArray({ itemName: "Item", type: Item, unwrapped: true })
 					items: Item[] = [];
 				}
 
@@ -610,7 +602,7 @@ describe("XmlMappingUtil", () => {
 
 				@XmlRoot({ elementName: "List" })
 				class ItemList {
-					@XmlArrayItem({ containerName: "Items", itemName: "Item", type: Item })
+					@XmlArray({ containerName: "Items", itemName: "Item", type: Item })
 					items: Item[] = [new Item("Item1"), new Item("Item2")];
 				}
 
@@ -635,7 +627,7 @@ describe("XmlMappingUtil", () => {
 
 				@XmlRoot({ elementName: "List" })
 				class ItemList {
-					@XmlArrayItem({ itemName: "Item", type: Item, unwrapped: true })
+					@XmlArray({ itemName: "Item", type: Item, unwrapped: true })
 					items: Item[] = [new Item("Item1"), new Item("Item2")];
 				}
 
@@ -660,7 +652,7 @@ describe("XmlMappingUtil", () => {
 
 				@XmlRoot({ elementName: "List" })
 				class ItemList {
-					@XmlArrayItem({ itemName: "Item", type: Item })
+					@XmlArray({ itemName: "Item", type: Item })
 					items: Item[] = [new Item("Item1")];
 				}
 

--- a/tests/utils/xml-namespace-util.test.ts
+++ b/tests/utils/xml-namespace-util.test.ts
@@ -1,4 +1,4 @@
-import { XmlArrayItem } from "../../src/decorators/xml-array-item";
+import { XmlArray } from "../../src/decorators/xml-array";
 import { XmlAttribute } from "../../src/decorators/xml-attribute";
 import { XmlElement } from "../../src/decorators/xml-element";
 import { XmlRoot } from "../../src/decorators/xml-root";
@@ -159,7 +159,7 @@ describe("XmlNamespaceUtil", () => {
 		it("should collect namespaces from array items", () => {
 			@XmlRoot({ elementName: "Container" })
 			class Container {
-				@XmlArrayItem({
+				@XmlArray({
 					itemName: "Item",
 					namespace: { uri: "http://items.com", prefix: "i" },
 				})
@@ -265,7 +265,7 @@ describe("XmlNamespaceUtil", () => {
 
 			@XmlRoot({ elementName: "Container" })
 			class Container {
-				@XmlArrayItem({ itemName: "Item", type: Item, namespace: { uri: "http://item.com", prefix: "i" } })
+				@XmlArray({ itemName: "Item", type: Item, namespace: { uri: "http://item.com", prefix: "i" } })
 				items: Item[] = [new Item(), new Item()];
 			}
 

--- a/tests/xml-decorator-serializer.test.ts
+++ b/tests/xml-decorator-serializer.test.ts
@@ -1,4 +1,4 @@
-import { XmlArrayItem } from "../src/decorators/xml-array-item";
+import { XmlArray } from "../src/decorators/xml-array";
 import { XmlAttribute } from "../src/decorators/xml-attribute";
 import { XmlElement } from "../src/decorators/xml-element";
 import { XmlRoot } from "../src/decorators/xml-root";
@@ -128,10 +128,10 @@ describe("XmlSerializer", () => {
 			expect(xml).toContain("</Address>");
 		});
 
-		it("should serialize arrays with XmlArrayItem", () => {
+		it("should serialize arrays with XmlArray", () => {
 			@XmlRoot({ elementName: "Library" })
 			class Library {
-				@XmlArrayItem({ containerName: "Books", itemName: "Book" })
+				@XmlArray({ containerName: "Books", itemName: "Book" })
 				books: string[] = ["Book1", "Book2", "Book3"];
 			}
 
@@ -148,7 +148,7 @@ describe("XmlSerializer", () => {
 		it("should serialize unwrapped arrays", () => {
 			@XmlRoot({ elementName: "Container" })
 			class Container {
-				@XmlArrayItem({ itemName: "Item" })
+				@XmlArray({ itemName: "Item" })
 				items: string[] = ["A", "B", "C"];
 			}
 
@@ -178,7 +178,7 @@ describe("XmlSerializer", () => {
 
 			@XmlRoot({ elementName: "Library" })
 			class Library {
-				@XmlArrayItem({ containerName: "Books", itemName: "Book", type: Book })
+				@XmlArray({ containerName: "Books", itemName: "Book", type: Book })
 				books: Book[] = [new Book("123", "Book A"), new Book("456", "Book B")];
 			}
 
@@ -406,7 +406,7 @@ describe("XmlSerializer", () => {
 		it("should deserialize arrays", () => {
 			@XmlElement({ name: "Library" })
 			class Library {
-				@XmlArrayItem({ containerName: "Books", itemName: "Book" })
+				@XmlArray({ containerName: "Books", itemName: "Book" })
 				books: string[] = [];
 			}
 


### PR DESCRIPTION
Improves API consistency and clarity by renaming the decorator to better reflect its purpose of configuring array serialization rather than individual items.

Updates all documentation, examples, and internal references throughout the codebase to use the new naming convention. Maintains backward compatibility by keeping @XmlArrayItem as a deprecated alias and preserving legacy option interfaces.

Refactors metadata storage keys from `arrayItems` to `arrays` and updates all getter functions accordingly. Adds support for both `name` and legacy `elementName` properties in @XmlRoot options for consistent API design.