### PR TITLE
fix: correct path for xml-poto-codegen binary in package.json

### DIFF
--- a/packages/xml-poto-codegen/package.json
+++ b/packages/xml-poto-codegen/package.json
@@ -24,7 +24,7 @@
 		"url": "git+https://github.com/CeriosTesting/xml-poto.git"
 	},
 	"bin": {
-		"xml-poto-codegen": "./dist/cli.js"
+		"xml-poto-codegen": "dist/cli.js"
 	},
 	"files": [
 		"dist"


### PR DESCRIPTION
This pull request makes a minor update to the `xml-poto-codegen` package configuration, specifically adjusting the path to the CLI entry point in the `package.json` file to remove the leading `./`. This change helps ensure compatibility with Node.js CLI resolution.