### PR TITLE
Generate fix

### DIFF
--- a/.changeset/fix-codegen-backslash-paths-and-ts-config-loading.md
+++ b/.changeset/fix-codegen-backslash-paths-and-ts-config-loading.md
@@ -1,0 +1,13 @@
+---
+"@cerios/xml-poto-codegen": patch
+---
+
+Fixed two issues affecting Windows users using a TypeScript config file.
+
+**Paths with backslashes no longer appear in generated config files**
+
+When running `xml-poto-codegen init` on Windows, entering paths with backslashes (e.g. `.\schemas\file.xsd`) would write those backslashes directly into the generated config file. The config would look broken in your editor and could cause problems on other operating systems. You no longer need to type forward slashes manually — any path you enter is automatically normalized before being written.
+
+**`generate` no longer fails with `Unknown file extension ".ts"`**
+
+After running `init` with a TypeScript config, running `xml-poto-codegen generate` would immediately fail with `TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"`, making the TypeScript config format unusable. This is now fixed — `generate` correctly loads `xml-poto-codegen.config.ts` files.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Upgrade npm
-        run: npm install -g npm@latest
+      - name: Show Node and npm versions
+        run: |
+          node -v
+          npm -v
 
       - name: Install dependencies
         run: npm ci

--- a/packages/xml-poto-codegen/src/commands/init.ts
+++ b/packages/xml-poto-codegen/src/commands/init.ts
@@ -68,15 +68,29 @@ async function runInit(): Promise<void> {
 	console.log(`${getRandomCeriosMessage()}\n`);
 }
 
-function writeJsonConfig(configPath: string, config: XmlPotoCodegenConfig): void {
-	fs.writeFileSync(configPath, JSON.stringify(config, null, "\t") + "\n", "utf-8");
+function toPosixPath(p: string): string {
+	return p.replace(/\\/g, "/");
 }
 
-function writeTsConfig(configPath: string, config: XmlPotoCodegenConfig): void {
+export function writeJsonConfig(configPath: string, config: XmlPotoCodegenConfig): void {
+	const normalized = {
+		...config,
+		sources: config.sources.map((s) => ({
+			...s,
+			xsdPath: toPosixPath(s.xsdPath),
+			outputPath: toPosixPath(s.outputPath),
+		})),
+	};
+	fs.writeFileSync(configPath, JSON.stringify(normalized, null, "\t") + "\n", "utf-8");
+}
+
+export function writeTsConfig(configPath: string, config: XmlPotoCodegenConfig): void {
 	const sourcesStr = config.sources
 		.map((s) => {
+			const xsdPath = toPosixPath(s.xsdPath);
+			const outputPath = toPosixPath(s.outputPath);
 			const styleLine = s.outputStyle ? `,\n\t\t\toutputStyle: "${s.outputStyle}"` : "";
-			return `\t\t{\n\t\t\txsdPath: "${s.xsdPath}",\n\t\t\toutputPath: "${s.outputPath}"${styleLine}\n\t\t}`;
+			return `\t\t{\n\t\t\txsdPath: "${xsdPath}",\n\t\t\toutputPath: "${outputPath}"${styleLine}\n\t\t}`;
 		})
 		.join(",\n");
 

--- a/packages/xml-poto-codegen/src/config/config-loader.ts
+++ b/packages/xml-poto-codegen/src/config/config-loader.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 
 import { createJiti } from "jiti";
 
@@ -91,8 +90,8 @@ export async function loadConfig(configPath?: string): Promise<{ config: XmlPoto
 		const content = fs.readFileSync(resolvedPath, "utf-8");
 		raw = JSON.parse(content);
 	} else if (resolvedPath.endsWith(".ts")) {
-		const jiti = createJiti(pathToFileURL(configDir).href);
-		const mod = await jiti.import(pathToFileURL(resolvedPath).href, { default: true });
+		const jiti = createJiti(__filename);
+		const mod = await jiti.import(resolvedPath, { default: true });
 		if (mod && typeof mod === "object" && "default" in mod) {
 			raw = (mod as { default: unknown }).default;
 		} else {

--- a/packages/xml-poto-codegen/tests/commands/init.test.ts
+++ b/packages/xml-poto-codegen/tests/commands/init.test.ts
@@ -1,0 +1,166 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { writeJsonConfig, writeTsConfig } from "../../src/commands/init";
+import type { XmlPotoCodegenConfig } from "../../src/config/config-types";
+
+const TMP = join(__dirname, "..", "tmp-init-test");
+
+describe("init – path normalization", () => {
+	beforeEach(async () => {
+		await mkdir(TMP, { recursive: true });
+	});
+
+	afterEach(async () => {
+		if (existsSync(TMP)) {
+			await rm(TMP, { recursive: true, force: true });
+		}
+	});
+
+	describe("writeTsConfig", () => {
+		it("writes forward slashes when xsdPath and outputPath use backslashes", async () => {
+			const configPath = join(TMP, "xml-poto-codegen.config.ts");
+			const config: XmlPotoCodegenConfig = {
+				sources: [
+					{
+						xsdPath: ".\\schemas\\myschema.xsd",
+						outputPath: ".\\src\\generated",
+					},
+				],
+			};
+
+			writeTsConfig(configPath, config);
+
+			const content = await readFile(configPath, "utf-8");
+			expect(content).toContain(`xsdPath: "./schemas/myschema.xsd"`);
+			expect(content).toContain(`outputPath: "./src/generated"`);
+			expect(content).not.toContain("\\");
+		});
+
+		it("writes forward slashes for mixed-slash paths", async () => {
+			const configPath = join(TMP, "xml-poto-codegen.config.ts");
+			const config: XmlPotoCodegenConfig = {
+				sources: [
+					{
+						xsdPath: "./schemas\\nested\\schema.xsd",
+						outputPath: "src\\generated",
+					},
+				],
+			};
+
+			writeTsConfig(configPath, config);
+
+			const content = await readFile(configPath, "utf-8");
+			expect(content).toContain(`xsdPath: "./schemas/nested/schema.xsd"`);
+			expect(content).toContain(`outputPath: "src/generated"`);
+			expect(content).not.toContain("\\");
+		});
+
+		it("preserves forward-slash paths unchanged", async () => {
+			const configPath = join(TMP, "xml-poto-codegen.config.ts");
+			const config: XmlPotoCodegenConfig = {
+				sources: [
+					{
+						xsdPath: "./schemas/myschema.xsd",
+						outputPath: "./src/generated",
+					},
+				],
+			};
+
+			writeTsConfig(configPath, config);
+
+			const content = await readFile(configPath, "utf-8");
+			expect(content).toContain(`xsdPath: "./schemas/myschema.xsd"`);
+			expect(content).toContain(`outputPath: "./src/generated"`);
+		});
+
+		it("writes valid importable TypeScript with backslash paths normalized", async () => {
+			const configPath = join(TMP, "xml-poto-codegen.config.ts");
+			const config: XmlPotoCodegenConfig = {
+				sources: [
+					{
+						xsdPath: ".\\schemas\\schema.xsd",
+						outputPath: ".\\src\\generated\\schema.ts",
+						outputStyle: "per-xsd",
+					},
+				],
+				defaultOutputStyle: "per-xsd",
+			};
+
+			writeTsConfig(configPath, config);
+
+			const content = await readFile(configPath, "utf-8");
+			expect(content).toContain(`outputStyle: "per-xsd"`);
+			expect(content).toContain(`xsdPath: "./schemas/schema.xsd"`);
+			expect(content).toContain(`outputPath: "./src/generated/schema.ts"`);
+		});
+
+		it("normalizes multiple sources independently", async () => {
+			const configPath = join(TMP, "xml-poto-codegen.config.ts");
+			const config: XmlPotoCodegenConfig = {
+				sources: [
+					{
+						xsdPath: ".\\schemas\\first.xsd",
+						outputPath: ".\\src\\first",
+					},
+					{
+						xsdPath: ".\\schemas\\second.xsd",
+						outputPath: ".\\src\\second",
+					},
+				],
+			};
+
+			writeTsConfig(configPath, config);
+
+			const content = await readFile(configPath, "utf-8");
+			expect(content).toContain(`xsdPath: "./schemas/first.xsd"`);
+			expect(content).toContain(`outputPath: "./src/first"`);
+			expect(content).toContain(`xsdPath: "./schemas/second.xsd"`);
+			expect(content).toContain(`outputPath: "./src/second"`);
+			expect(content).not.toContain("\\");
+		});
+	});
+
+	describe("writeJsonConfig", () => {
+		it("writes forward slashes when xsdPath and outputPath use backslashes", async () => {
+			const configPath = join(TMP, "xml-poto-codegen.config.json");
+			const config: XmlPotoCodegenConfig = {
+				sources: [
+					{
+						xsdPath: ".\\schemas\\myschema.xsd",
+						outputPath: ".\\src\\generated",
+					},
+				],
+			};
+
+			writeJsonConfig(configPath, config);
+
+			const content = await readFile(configPath, "utf-8");
+			const parsed = JSON.parse(content) as XmlPotoCodegenConfig;
+			expect(parsed.sources[0].xsdPath).toBe("./schemas/myschema.xsd");
+			expect(parsed.sources[0].outputPath).toBe("./src/generated");
+		});
+
+		it("preserves forward-slash paths unchanged", async () => {
+			const configPath = join(TMP, "xml-poto-codegen.config.json");
+			const config: XmlPotoCodegenConfig = {
+				sources: [
+					{
+						xsdPath: "./schemas/myschema.xsd",
+						outputPath: "./src/generated",
+					},
+				],
+			};
+
+			writeJsonConfig(configPath, config);
+
+			const content = await readFile(configPath, "utf-8");
+			const parsed = JSON.parse(content) as XmlPotoCodegenConfig;
+			expect(parsed.sources[0].xsdPath).toBe("./schemas/myschema.xsd");
+			expect(parsed.sources[0].outputPath).toBe("./src/generated");
+		});
+	});
+});

--- a/packages/xml-poto-codegen/tests/config/config-loader.test.ts
+++ b/packages/xml-poto-codegen/tests/config/config-loader.test.ts
@@ -83,6 +83,59 @@ describe("ConfigLoader", () => {
 			expect(loaded.config.sources[0].outputPath).toBe("./generated");
 		});
 
+		it("should load TS config with export default and typed config object", async () => {
+			const dir = join(TMP, "ts-typed");
+			await mkdir(dir, { recursive: true });
+			const configPath = join(dir, "xml-poto-codegen.config.ts");
+			await writeFile(
+				configPath,
+				[
+					`import type { XmlPotoCodegenConfig } from "@cerios/xml-poto-codegen";`,
+					`const config: XmlPotoCodegenConfig = {`,
+					`  sources: [{ xsdPath: "./typed.xsd", outputPath: "./typed-out" }],`,
+					`  defaultOutputStyle: "per-type",`,
+					`};`,
+					`export default config;`,
+				].join("\n"),
+			);
+
+			const loaded = await loadConfig(configPath);
+			expect(loaded.config.sources[0].xsdPath).toBe("./typed.xsd");
+			expect(loaded.config.sources[0].outputPath).toBe("./typed-out");
+		});
+
+		it("should load TS config with multiple sources", async () => {
+			const dir = join(TMP, "ts-multi");
+			await mkdir(dir, { recursive: true });
+			const configPath = join(dir, "xml-poto-codegen.config.ts");
+			await writeFile(
+				configPath,
+				[
+					`export default {`,
+					`  sources: [`,
+					`    { xsdPath: "./schemas/first.xsd", outputPath: "./generated/first" },`,
+					`    { xsdPath: "./schemas/second.xsd", outputPath: "./generated/second.ts", outputStyle: "per-xsd" },`,
+					`  ],`,
+					`};`,
+				].join("\n"),
+			);
+
+			const loaded = await loadConfig(configPath);
+			expect(loaded.config.sources).toHaveLength(2);
+			expect(loaded.config.sources[0].xsdPath).toBe("./schemas/first.xsd");
+			expect(loaded.config.sources[1].outputStyle).toBe("per-xsd");
+		});
+
+		it("should return configDir as the directory of the TS config file", async () => {
+			const dir = join(TMP, "ts-configdir");
+			await mkdir(dir, { recursive: true });
+			const configPath = join(dir, "xml-poto-codegen.config.ts");
+			await writeFile(configPath, `export default { sources: [{ xsdPath: "./a.xsd", outputPath: "./out" }] };`);
+
+			const loaded = await loadConfig(configPath);
+			expect(loaded.configDir).toBe(dir);
+		});
+
 		it("should throw when config file does not exist", async () => {
 			await expect(loadConfig(join(TMP, "nonexistent.json"))).rejects.toThrow("Config file not found");
 		});


### PR DESCRIPTION
This pull request addresses two main issues for Windows users of `@cerios/xml-poto-codegen`: it normalizes backslash paths in generated config files and fixes TypeScript config loading. It also updates the Node.js version used in CI, improves test coverage, and refines the config loader implementation.

**Windows path normalization and config generation:**
- Paths with backslashes entered during `init` are now automatically converted to forward slashes in both JSON and TypeScript config files, ensuring cross-platform compatibility and cleaner configs. (`writeJsonConfig`, `writeTsConfig`, and related tests) [[1]](diffhunk://#diff-69b2d0676e42c1d0a6bb74c9d50b909da446fe2c3ef1afa35bf60008b589a624L71-R93) [[2]](diffhunk://#diff-01e8747fd4e4ae31b3984e7cfe6b57d51897be2ef422769681a23da60075ebcbR1-R166)
- Added comprehensive tests to verify path normalization for various input scenarios in config file generation.

**TypeScript config file support:**
- Fixed an issue where running `generate` with a TypeScript config file failed due to incorrect file extension handling, by updating how the config loader imports `.ts` files using `jiti`.
- Added tests to ensure TypeScript config files (including typed configs and multiple sources) are loaded correctly, and that the config directory is determined accurately.

**Continuous integration and maintenance:**
- Updated the CI workflow to use Node.js 24, removed the explicit npm upgrade step, and added a version display for Node and npm during CI runs.

**Documentation:**
- Added a changeset describing the bugfixes for Windows path normalization and TypeScript config loading.