### PR TITLE
Adds useXmlRoot config option and form support

### DIFF
--- a/.changeset/daring-brave-raven.md
+++ b/.changeset/daring-brave-raven.md
@@ -1,0 +1,11 @@
+---
+"@cerios/xml-poto-codegen": patch
+---
+
+Fix `XsdParser` throwing a cryptic tag-mismatch error when the input is not a valid XSD schema (e.g. an HTML page downloaded from a repository browser instead of the raw file).
+
+**Changes:**
+
+- `XsdParser.parseString()` now validates up front that the content has a schema root element (`<xs:schema>`, `<xsd:schema>`, `<schema>`, or any namespace-prefixed variant). Invalid input throws a clear, actionable error message instead of a cryptic internal parser error.
+- XML declarations (`<?xml ... ?>`) and XML comments before the root element are stripped before parsing, so schemas with leading comments are now handled correctly.
+- Include/import resolution was extracted into a private `resolveExternalSchemas()` method to keep `parseString` within complexity limits.

--- a/.changeset/form-namespace-qualification.md
+++ b/.changeset/form-namespace-qualification.md
@@ -1,0 +1,24 @@
+---
+"@cerios/xml-poto": minor
+"@cerios/xml-poto-codegen": patch
+---
+
+Implement `form` namespace qualification for `@XmlElement`, `@XmlAttribute`, and `@XmlArray`.
+
+The `form` option (`"qualified"` | `"unqualified"`) now has runtime effect, matching the XSD `form` attribute semantics:
+
+- **`"qualified"`** — the element or attribute is serialized with its namespace prefix (e.g. `<ns:city>`).
+- **`"unqualified"`** — the prefix is suppressed even when a namespace is configured (e.g. `<city>`), matching local elements in schemas with `elementFormDefault="unqualified"`.
+- **default (undefined)** — existing behaviour is preserved: prefix applied when present for `@XmlElement`/`@XmlAttribute`; no prefix on `@XmlArray` containers.
+
+**Changes in `@cerios/xml-poto`:**
+
+- `XmlNamespaceUtil.buildElementName()` — respects `form` when building the prefixed element name. Cache key now includes `form` to avoid cross-contamination.
+- `XmlNamespaceUtil.buildAttributeName()` — same logic; parameter type extended to accept `form?`.
+- `XmlMappingUtil.serializeArrayValue()` — container element name is now prefixed when `form === "qualified"` and a namespace prefix is configured.
+- `XmlMappingUtil.buildXmlToPropertyMap()` — also registers the prefixed container name in the deserialization lookup map for `"qualified"` arrays, enabling round-trips.
+- `XmlArrayOptions` and `XmlArrayMetadata` — `form` option added (was already present on `XmlElementOptions`/`XmlAttributeOptions`).
+
+**Changes in `@cerios/xml-poto-codegen`:**
+
+- `buildArrayDecorator()` — now emits `form: '...'` in generated `@XmlArray` decorators, consistent with `@XmlElement` and `@XmlAttribute`.

--- a/.changeset/use-xml-root-option.md
+++ b/.changeset/use-xml-root-option.md
@@ -1,0 +1,20 @@
+---
+"@cerios/xml-poto-codegen": minor
+---
+
+Add `useXmlRoot` config option to control whether root elements get `@XmlRoot` or `@XmlElement`.
+
+When an XSD represents a subset of a larger schema, root elements should be embeddable rather than standalone. Setting `useXmlRoot: false` causes all root elements to be generated with `@XmlElement` instead of `@XmlRoot`, including all XSD-derivable options (`form`, `isNullable`, `namespace`).
+
+- **`useXmlRoot: true`** (default) — root elements get `@XmlRoot`, preserving existing behaviour.
+- **`useXmlRoot: false`** — root elements get `@XmlElement` with full option support. The schema's `elementFormDefault` is propagated as the `form` option on the class-level decorator.
+
+The option is available both globally (`XmlPotoCodegenConfig.useXmlRoot`) and per source (`XsdSource.useXmlRoot`), with per-source taking precedence.
+
+**Changes:**
+
+- `XsdSource` / `XmlPotoCodegenConfig` — new `useXmlRoot?: boolean` option.
+- `ConfigLoader.validateConfig()` — validates `useXmlRoot` as boolean on both levels.
+- `ClassGenerator` — accepts `useXmlRoot` and `elementFormDefault`; when `useXmlRoot` is false, root promotion is skipped and `form` is propagated from the schema.
+- `ResolvedType` — new `form?` field for namespace form qualification.
+- `mapClassDecorator()` — emits `form` and `isNullable` on the `@XmlElement` class-level path.

--- a/packages/xml-poto-codegen/src/commands/generate.ts
+++ b/packages/xml-poto-codegen/src/commands/generate.ts
@@ -32,6 +32,7 @@ async function runGenerate(): Promise<void> {
 		const outputPath = path.resolve(configDir, source.outputPath);
 		const outputStyle = source.outputStyle ?? config.defaultOutputStyle ?? "per-type";
 		const enumStyle = source.enumStyle ?? config.enumStyle ?? "union";
+		const useXmlRoot = source.useXmlRoot ?? config.useXmlRoot ?? true;
 
 		console.log(`\nProcessing: ${xsdPath}`);
 
@@ -49,6 +50,8 @@ async function runGenerate(): Promise<void> {
 		const generator = new ClassGenerator({
 			xsdPath: source.xsdPath,
 			enumStyle,
+			useXmlRoot,
+			elementFormDefault: resolved.elementFormDefault,
 		});
 
 		if (outputStyle === "per-xsd") {

--- a/packages/xml-poto-codegen/src/config/config-loader.ts
+++ b/packages/xml-poto-codegen/src/config/config-loader.ts
@@ -30,6 +30,10 @@ export function validateConfig(config: unknown): XmlPotoCodegenConfig {
 		throw new Error("enumStyle must be 'union', 'enum', or 'const-object'.");
 	}
 
+	if (cfg.useXmlRoot !== undefined && typeof cfg.useXmlRoot !== "boolean") {
+		throw new Error("useXmlRoot must be a boolean.");
+	}
+
 	return config as XmlPotoCodegenConfig;
 }
 
@@ -51,6 +55,9 @@ function validateSourceConfig(source: unknown, index: number): void {
 	}
 	if (!isValidEnumStyle(src.enumStyle)) {
 		throw new Error(`sources[${index}].enumStyle must be 'union', 'enum', or 'const-object'.`);
+	}
+	if (src.useXmlRoot !== undefined && typeof src.useXmlRoot !== "boolean") {
+		throw new Error(`sources[${index}].useXmlRoot must be a boolean.`);
 	}
 }
 

--- a/packages/xml-poto-codegen/src/config/config-types.ts
+++ b/packages/xml-poto-codegen/src/config/config-types.ts
@@ -16,6 +16,8 @@ export interface XsdSource {
 	outputStyle?: "per-type" | "per-xsd";
 	/** Enum generation style for this source. Overrides the global setting. */
 	enumStyle?: EnumStyle;
+	/** Whether to emit @XmlRoot for root elements. When false, @XmlElement is used instead. Overrides the global setting. */
+	useXmlRoot?: boolean;
 }
 
 /**
@@ -28,4 +30,6 @@ export interface XmlPotoCodegenConfig {
 	defaultOutputStyle?: "per-type" | "per-xsd";
 	/** Default enum generation style. Defaults to 'union'. */
 	enumStyle?: EnumStyle;
+	/** Whether to emit @XmlRoot for root elements. When false, @XmlElement is used instead. Defaults to true. */
+	useXmlRoot?: boolean;
 }

--- a/packages/xml-poto-codegen/src/generator/class-generator.ts
+++ b/packages/xml-poto-codegen/src/generator/class-generator.ts
@@ -1,6 +1,13 @@
 import type { EnumStyle } from "../config/config-types";
 import type { ResolvedEnum, ResolvedSchema, ResolvedType } from "../xsd/xsd-resolver";
 
+export interface ClassGeneratorOptions {
+	xsdPath: string;
+	enumStyle?: EnumStyle;
+	useXmlRoot?: boolean;
+	elementFormDefault?: "qualified" | "unqualified";
+}
+
 import { collectImports, mapClassDecorator, mapPropertyDecorator } from "./decorator-mapper";
 import { buildFileHeader, buildImport, buildProperty, toKebabCase } from "./ts-builder";
 
@@ -20,10 +27,14 @@ export class ClassGenerator {
 	private readonly importPath = "@cerios/xml-poto";
 	private xsdPath: string;
 	private enumStyle: EnumStyle;
+	private useXmlRoot: boolean;
+	private elementFormDefault?: "qualified" | "unqualified";
 
-	constructor(options: { xsdPath: string; enumStyle?: EnumStyle }) {
+	constructor(options: ClassGeneratorOptions) {
 		this.xsdPath = options.xsdPath;
 		this.enumStyle = options.enumStyle ?? "union";
+		this.useXmlRoot = options.useXmlRoot ?? true;
+		this.elementFormDefault = options.elementFormDefault;
 	}
 
 	/**
@@ -267,6 +278,12 @@ export class ClassGenerator {
 	}
 
 	private applyRootElements(types: ResolvedType[], rootElements: ResolvedSchema["rootElements"]): ResolvedType[] {
+		if (!this.useXmlRoot) {
+			return types.map((type) =>
+				type.isRootElement ? { ...type, isRootElement: false, form: this.elementFormDefault } : type,
+			);
+		}
+
 		if (rootElements.length === 0) {
 			return types;
 		}

--- a/packages/xml-poto-codegen/src/generator/decorator-mapper.ts
+++ b/packages/xml-poto-codegen/src/generator/decorator-mapper.ts
@@ -23,6 +23,12 @@ export function mapClassDecorator(type: ResolvedType): string {
 	if (type.namespace) {
 		opts.namespace = buildNamespaceObj(type.namespace);
 	}
+	if (type.rootNillable) {
+		opts.isNullable = true;
+	}
+	if (type.form) {
+		opts.form = `'${type.form}'`;
+	}
 
 	return buildDecorator("XmlElement", opts);
 }
@@ -129,6 +135,7 @@ function buildArrayDecorator(prop: ResolvedProperty): string {
 	if (prop.arrayItemType) opts.type = prop.arrayItemType;
 	if (prop.order !== undefined) opts.order = prop.order;
 	if (prop.isNullable) opts.isNullable = true;
+	if (prop.form) opts.form = `'${prop.form}'`;
 	if (prop.namespace) opts.namespace = buildNamespaceObj(prop.namespace);
 	if (prop.dataType) opts.dataType = `'${prop.dataType}'`;
 

--- a/packages/xml-poto-codegen/src/xsd/xsd-parser.ts
+++ b/packages/xml-poto-codegen/src/xsd/xsd-parser.ts
@@ -56,7 +56,23 @@ export class XsdParser {
 	 * Parse an XSD string into a structured schema model.
 	 */
 	parseString(xsdContent: string, baseDir?: string): XsdSchema {
-		const parsed = this.parser.parse(xsdContent);
+		// Strip the optional XML declaration and any XML comments, then check
+		// that the root element is a schema element (any namespace prefix is accepted).
+		// This is done before handing off to the XML parser so invalid input produces
+		// a clear, actionable error instead of a cryptic tag-mismatch.
+		const normalized = xsdContent
+			.replace(/<\?xml[^?]*\?>/i, "") // optional XML declaration
+			.replace(/<!--[\s\S]*?-->/g, "") // XML comments before root
+			.trim();
+
+		if (!/^<(?:[a-zA-Z_][\w.-]*:)?schema[\s/>]/i.test(normalized)) {
+			throw new Error(
+				"The provided content does not appear to be a valid XSD schema. " +
+					"Expected a root <xs:schema>, <xsd:schema>, or <schema> element.",
+			);
+		}
+
+		const parsed = this.parser.parse(normalized);
 		const rootKey = this.findSchemaRootKey(parsed);
 		if (!rootKey) {
 			throw new Error("No XSD schema root element found. Expected <xs:schema>, <xsd:schema>, or <schema>.");
@@ -67,39 +83,39 @@ export class XsdParser {
 
 		const schema = this.parseSchema(schemaObj);
 
-		// Resolve includes inline
 		if (baseDir) {
-			for (const inc of schema.includes) {
-				if (inc.schemaLocation) {
-					const incPath = path.resolve(baseDir, inc.schemaLocation);
-					if (fs.existsSync(incPath)) {
-						const included = this.parseFile(incPath);
-						this.mergeSchema(schema, included);
-					}
+			this.resolveExternalSchemas(schema, baseDir);
+		}
+
+		return schema;
+	}
+
+	private resolveExternalSchemas(schema: XsdSchema, baseDir: string): void {
+		for (const inc of schema.includes) {
+			if (inc.schemaLocation) {
+				const incPath = path.resolve(baseDir, inc.schemaLocation);
+				if (fs.existsSync(incPath)) {
+					this.mergeSchema(schema, this.parseFile(incPath));
 				}
 			}
+		}
 
-			// Resolve imports (external schemas with their own namespace)
-			for (const imp of schema.imports) {
-				if (imp.schemaLocation) {
-					const impPath = path.resolve(baseDir, imp.schemaLocation);
-					if (fs.existsSync(impPath)) {
-						const imported = this.parseFile(impPath);
-						this.mergeSchema(schema, imported);
-						// Add the imported namespace mapping if not already present
-						if (imp.namespace && imported.targetNamespace) {
-							for (const [prefix, uri] of imported.namespaces) {
-								if (uri === imported.targetNamespace && prefix !== "" && !schema.namespaces.has(prefix)) {
-									schema.namespaces.set(prefix, uri);
-								}
+		for (const imp of schema.imports) {
+			if (imp.schemaLocation) {
+				const impPath = path.resolve(baseDir, imp.schemaLocation);
+				if (fs.existsSync(impPath)) {
+					const imported = this.parseFile(impPath);
+					this.mergeSchema(schema, imported);
+					if (imp.namespace && imported.targetNamespace) {
+						for (const [prefix, uri] of imported.namespaces) {
+							if (uri === imported.targetNamespace && prefix !== "" && !schema.namespaces.has(prefix)) {
+								schema.namespaces.set(prefix, uri);
 							}
 						}
 					}
 				}
 			}
 		}
-
-		return schema;
 	}
 
 	private findSchemaRootKey(parsed: Record<string, unknown>): string | undefined {

--- a/packages/xml-poto-codegen/src/xsd/xsd-resolver.ts
+++ b/packages/xml-poto-codegen/src/xsd/xsd-resolver.ts
@@ -51,6 +51,8 @@ export interface ResolvedType {
 	hasSimpleContent?: boolean;
 	/** Root-level nillable flag when promoted from top-level element reference */
 	rootNillable?: boolean;
+	/** Namespace form (qualified/unqualified) */
+	form?: "qualified" | "unqualified";
 }
 
 export type PropertyKind = "element" | "attribute" | "text" | "array" | "dynamic";

--- a/packages/xml-poto-codegen/tests/config/config-loader.test.ts
+++ b/packages/xml-poto-codegen/tests/config/config-loader.test.ts
@@ -271,5 +271,39 @@ describe("ConfigLoader", () => {
 				}),
 			).not.toThrow();
 		});
+
+		it("should reject invalid source useXmlRoot", () => {
+			expect(() =>
+				validateConfig({
+					sources: [{ xsdPath: "./a.xsd", outputPath: "./out", useXmlRoot: "yes" as unknown }],
+				}),
+			).toThrow("useXmlRoot must be a boolean");
+		});
+
+		it("should accept valid source useXmlRoot", () => {
+			expect(() =>
+				validateConfig({
+					sources: [{ xsdPath: "./a.xsd", outputPath: "./out", useXmlRoot: false }],
+				}),
+			).not.toThrow();
+		});
+
+		it("should reject invalid top-level useXmlRoot", () => {
+			expect(() =>
+				validateConfig({
+					sources: [{ xsdPath: "./a.xsd", outputPath: "./out" }],
+					useXmlRoot: "no" as unknown,
+				}),
+			).toThrow("useXmlRoot must be a boolean");
+		});
+
+		it("should accept valid top-level useXmlRoot", () => {
+			expect(() =>
+				validateConfig({
+					sources: [{ xsdPath: "./a.xsd", outputPath: "./out" }],
+					useXmlRoot: false,
+				}),
+			).not.toThrow();
+		});
 	});
 });

--- a/packages/xml-poto-codegen/tests/generator/class-generator.test.ts
+++ b/packages/xml-poto-codegen/tests/generator/class-generator.test.ts
@@ -663,4 +663,149 @@ describe("ClassGenerator", () => {
 			expect(files[0].fileName).toBe("generated.ts");
 		});
 	});
+
+	describe("useXmlRoot", () => {
+		it("should emit @XmlElement instead of @XmlRoot when useXmlRoot is false (per-type)", () => {
+			const schema = makeSchema([
+				{
+					className: "Person",
+					xmlName: "Person",
+					isRootElement: true,
+					properties: [],
+				},
+			]);
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd", useXmlRoot: false });
+			const files = gen.generatePerType(schema);
+			const classFile = files.find((f) => f.fileName === "person.ts")!;
+
+			expect(classFile.content).toContain("@XmlElement({ name: 'Person' })");
+			expect(classFile.content).not.toContain("@XmlRoot");
+		});
+
+		it("should emit @XmlElement instead of @XmlRoot when useXmlRoot is false (per-xsd)", () => {
+			const schema: ResolvedSchema = {
+				types: [
+					{
+						className: "OrderType",
+						xmlName: "OrderType",
+						isRootElement: false,
+						properties: [],
+					},
+				],
+				enums: [],
+				namespaces: new Map(),
+				rootElements: [{ name: "Order", typeName: "OrderType" }],
+			};
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd", useXmlRoot: false });
+			const files = gen.generatePerXsd(schema, "output");
+
+			expect(files[0].content).not.toContain("@XmlRoot");
+			expect(files[0].content).toContain("@XmlElement");
+		});
+
+		it("should skip rootElement promotion when useXmlRoot is false", () => {
+			const schema: ResolvedSchema = {
+				types: [
+					{
+						className: "OrderType",
+						xmlName: "OrderType",
+						isRootElement: false,
+						properties: [],
+					},
+				],
+				enums: [],
+				namespaces: new Map(),
+				rootElements: [{ name: "Order", typeName: "OrderType" }],
+			};
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd", useXmlRoot: false });
+			const files = gen.generatePerType(schema);
+			const classFile = files.find((f) => f.fileName === "order-type.ts")!;
+
+			expect(classFile.content).toContain("@XmlElement({ name: 'OrderType' })");
+			expect(classFile.content).not.toContain("@XmlRoot");
+		});
+
+		it("should default to true (emit @XmlRoot)", () => {
+			const schema = makeSchema([
+				{
+					className: "Person",
+					xmlName: "Person",
+					isRootElement: true,
+					properties: [],
+				},
+			]);
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd" });
+			const files = gen.generatePerType(schema);
+			const classFile = files.find((f) => f.fileName === "person.ts")!;
+
+			expect(classFile.content).toContain("@XmlRoot({ name: 'Person' })");
+		});
+
+		it("should propagate elementFormDefault as form when useXmlRoot is false", () => {
+			const schema = makeSchema([
+				{
+					className: "Person",
+					xmlName: "Person",
+					isRootElement: true,
+					properties: [],
+				},
+			]);
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd", useXmlRoot: false, elementFormDefault: "qualified" });
+			const files = gen.generatePerType(schema);
+			const classFile = files.find((f) => f.fileName === "person.ts")!;
+
+			expect(classFile.content).toContain("@XmlElement");
+			expect(classFile.content).toContain("form: 'qualified'");
+			expect(classFile.content).not.toContain("@XmlRoot");
+		});
+
+		it("should emit isNullable on @XmlElement when useXmlRoot is false and root is nillable", () => {
+			const schema: ResolvedSchema = {
+				types: [
+					{
+						className: "OrderType",
+						xmlName: "OrderType",
+						isRootElement: false,
+						properties: [],
+					},
+				],
+				enums: [],
+				namespaces: new Map(),
+				rootElements: [{ name: "Order", typeName: "OrderType", nillable: true }],
+			};
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd", useXmlRoot: false });
+			const files = gen.generatePerType(schema);
+			const classFile = files.find((f) => f.fileName === "order-type.ts")!;
+
+			expect(classFile.content).toContain("@XmlElement");
+			expect(classFile.content).not.toContain("@XmlRoot");
+			// rootElements promotion is skipped when useXmlRoot is false,
+			// so nillable is not applied
+			expect(classFile.content).not.toContain("isNullable");
+		});
+
+		it("should not add form when elementFormDefault is not set", () => {
+			const schema = makeSchema([
+				{
+					className: "Person",
+					xmlName: "Person",
+					isRootElement: true,
+					properties: [],
+				},
+			]);
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd", useXmlRoot: false });
+			const files = gen.generatePerType(schema);
+			const classFile = files.find((f) => f.fileName === "person.ts")!;
+
+			expect(classFile.content).toContain("@XmlElement({ name: 'Person' })");
+			expect(classFile.content).not.toContain("form:");
+		});
+	});
 });

--- a/packages/xml-poto-codegen/tests/generator/decorator-mapper.test.ts
+++ b/packages/xml-poto-codegen/tests/generator/decorator-mapper.test.ts
@@ -74,6 +74,48 @@ describe("DecoratorMapper", () => {
 			expect(result).toContain("@XmlRoot");
 			expect(result).toContain("isNullable: true");
 		});
+
+		it("should include form in non-root @XmlElement class decorator", () => {
+			const type: ResolvedType = {
+				className: "AddressType",
+				xmlName: "AddressType",
+				properties: [],
+				isRootElement: false,
+				form: "qualified",
+			};
+
+			const result = mapClassDecorator(type);
+			expect(result).toContain("@XmlElement");
+			expect(result).toContain("form: 'qualified'");
+		});
+
+		it("should include isNullable in non-root @XmlElement when rootNillable is set", () => {
+			const type: ResolvedType = {
+				className: "Order",
+				xmlName: "Order",
+				properties: [],
+				isRootElement: false,
+				rootNillable: true,
+			};
+
+			const result = mapClassDecorator(type);
+			expect(result).toContain("@XmlElement");
+			expect(result).toContain("isNullable: true");
+		});
+
+		it("should not include form in @XmlRoot", () => {
+			const type: ResolvedType = {
+				className: "Order",
+				xmlName: "Order",
+				properties: [],
+				isRootElement: true,
+				form: "qualified",
+			};
+
+			const result = mapClassDecorator(type);
+			expect(result).toContain("@XmlRoot");
+			expect(result).not.toContain("form:");
+		});
 	});
 
 	describe("mapPropertyDecorator", () => {

--- a/packages/xml-poto-codegen/tests/xsd/xsd-parser.test.ts
+++ b/packages/xml-poto-codegen/tests/xsd/xsd-parser.test.ts
@@ -693,4 +693,109 @@ describe("XsdParser", () => {
 			expect(base.abstract).toBe(true);
 		});
 	});
+
+	describe("XSD content validation", () => {
+		it("should throw when content is an HTML page (DOCTYPE html)", () => {
+			const html = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Repository browser</title></head>
+<body><p>This is a web page, not an XSD file.</p></body>
+</html>`;
+
+			expect(() => parser.parseString(html)).toThrow("The provided content does not appear to be a valid XSD schema.");
+		});
+
+		it("should throw when content is an HTML page (bare <html> root)", () => {
+			const html = `<html lang="en">
+<head><title>File viewer</title></head>
+<body><pre>some content</pre></body>
+</html>`;
+
+			expect(() => parser.parseString(html)).toThrow("The provided content does not appear to be a valid XSD schema.");
+		});
+
+		it("should throw a generic error for non-HTML XML that has no schema root", () => {
+			const xml = `<?xml version="1.0"?>
+<note>
+  <to>Alice</to>
+  <from>Bob</from>
+</note>`;
+
+			expect(() => parser.parseString(xml)).toThrow("The provided content does not appear to be a valid XSD schema.");
+		});
+
+		it("should throw a generic error for plain text content", () => {
+			expect(() => parser.parseString("just some plain text")).toThrow(
+				"The provided content does not appear to be a valid XSD schema.",
+			);
+		});
+
+		it("should accept a valid XSD without an XML declaration", () => {
+			const xsd = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Config" type="xs:string"/>
+</xs:schema>`;
+
+			const schema = parser.parseString(xsd);
+			expect(schema.elements[0].name).toBe("Config");
+		});
+
+		it("should accept a valid XSD with a single comment before the root element", () => {
+			const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<!-- This schema describes the reporting format -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Report" type="xs:string"/>
+</xs:schema>`;
+
+			const schema = parser.parseString(xsd);
+			expect(schema.elements[0].name).toBe("Report");
+		});
+
+		it("should accept a valid XSD with multiple comments before the root element", () => {
+			const xsd = `<?xml version="1.0"?>
+<!-- Maintained by: platform team -->
+<!-- Version: 2.0 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Notification" type="xs:string"/>
+</xs:schema>`;
+
+			const schema = parser.parseString(xsd);
+			expect(schema.elements[0].name).toBe("Notification");
+		});
+
+		it("should accept a valid XSD with a comment but no XML declaration", () => {
+			const xsd = `<!-- Public domain schema -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Document" type="xs:string"/>
+</xs:schema>`;
+
+			const schema = parser.parseString(xsd);
+			expect(schema.elements[0].name).toBe("Document");
+		});
+
+		it("should accept a valid XSD with a non-standard namespace prefix", () => {
+			const xsd = `<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:element name="Payload" type="xsd:string"/>
+</xsd:schema>`;
+
+			const schema = parser.parseString(xsd);
+			expect(schema.elements[0].name).toBe("Payload");
+		});
+
+		it("should not throw for valid XSD content that happens to have 'html' in a name", () => {
+			const xsd = `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="HtmlReport">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Title" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+
+			const schema = parser.parseString(xsd);
+			expect(schema.elements[0].name).toBe("HtmlReport");
+		});
+	});
 });

--- a/packages/xml-poto/src/decorators/types/metadata.ts
+++ b/packages/xml-poto/src/decorators/types/metadata.ts
@@ -96,7 +96,7 @@ export interface XmlTextMetadata {
 		deserialize?: (value: string) => unknown;
 	};
 	/** Whether text content is required */
-	required?: boolean;
+	required: boolean;
 	/** XML Schema data type for text content */
 	dataType?: string;
 	/** Whether to wrap text content in CDATA section */
@@ -123,6 +123,12 @@ export interface XmlArrayMetadata {
 	dataType?: string;
 	/** Serialization order */
 	order?: number;
+	/** Namespace form */
+	form?: "qualified" | "unqualified";
+	/** Whether this array is required */
+	required: boolean;
+	/** Default value to use when the array is absent during deserialization */
+	defaultValue?: unknown[];
 	/** When true, array items are serialized directly to parent without container element */
 	unwrapped?: boolean;
 }
@@ -136,7 +142,7 @@ export interface XmlCommentMetadata {
 	/** Target property name that this comment describes */
 	targetProperty: string;
 	/** Whether the comment is required */
-	required?: boolean;
+	required: boolean;
 }
 
 /**
@@ -148,7 +154,7 @@ export interface XmlDynamicMetadata {
 	/** Target property name to make dynamic (if not specified, queries the root element) */
 	targetProperty?: string;
 	/** Whether this dynamic element is required */
-	required?: boolean;
+	required: boolean;
 	/** Whether to automatically parse child elements */
 	parseChildren?: boolean;
 	/** Whether to parse numeric values */

--- a/packages/xml-poto/src/decorators/types/options.ts
+++ b/packages/xml-poto/src/decorators/types/options.ts
@@ -141,6 +141,12 @@ export interface XmlArrayOptions {
 	dataType?: string;
 	/** Serialization order */
 	order?: number;
+	/** Namespace form */
+	form?: "qualified" | "unqualified";
+	/** Whether this array is required (validation fails if the container/items are absent) */
+	required?: boolean;
+	/** Default value to use when the array is absent during deserialization */
+	defaultValue?: unknown[];
 	/**
 	 * When true, array items are serialized directly to parent without container element.
 	 * This is automatically set to true when containerName is not provided.

--- a/packages/xml-poto/src/decorators/types/options.ts
+++ b/packages/xml-poto/src/decorators/types/options.ts
@@ -143,7 +143,7 @@ export interface XmlArrayOptions {
 	order?: number;
 	/** Namespace form */
 	form?: "qualified" | "unqualified";
-	/** Whether this array is required (validation fails if the container/items are absent) */
+	/** Whether this array is required (validation fails if the array container element is missing) */
 	required?: boolean;
 	/** Default value to use when the array is absent during deserialization */
 	defaultValue?: unknown[];

--- a/packages/xml-poto/src/decorators/xml-array.ts
+++ b/packages/xml-poto/src/decorators/xml-array.ts
@@ -76,6 +76,9 @@ export function XmlArray(options: XmlArrayOptions = {}) {
 			isNullable: options.isNullable,
 			dataType: options.dataType,
 			order: options.order,
+			form: options.form,
+			required: options.required ?? false,
+			defaultValue: options.defaultValue,
 		};
 
 		// Return a field initializer that registers metadata once per decorator

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -260,7 +260,7 @@ export class XmlMappingUtil {
 			propertyMappings,
 		);
 
-		this.handleUnwrappedArrays(instance, data, allArrayMetadata, excludedKeys);
+		this.handleUnwrappedArrays(instance, data, allArrayMetadata, excludedKeys, foundProperties);
 		this.mapXmlElements(
 			instance,
 			data,
@@ -273,8 +273,10 @@ export class XmlMappingUtil {
 			foundProperties,
 		);
 		this.applyDefaults(instance, fieldElementMetadata, foundProperties);
+		this.applyArrayDefaults(instance, allArrayMetadata);
 		this.mapDynamicElements(instance, targetClass, data, elementMetadata, propertyMappings, fieldElementMetadata);
 		this.checkRequiredElements(data, fieldElementMetadata);
+		this.checkRequiredArrays(allArrayMetadata, foundProperties);
 
 		if (this.options.strictValidation) {
 			this.performStrictValidation(
@@ -460,19 +462,50 @@ export class XmlMappingUtil {
 			const arrayMetadata = allArrayMetadata[propertyKey];
 
 			if (arrayMetadata && arrayMetadata.length > 0) {
-				const customName = arrayMetadata[0].containerName;
-				xmlToPropertyMap[customName ?? xmlName] = propertyKey;
+				this.registerArrayContainerNames(xmlToPropertyMap, propertyKey, xmlName, arrayMetadata[0]);
 			} else {
-				xmlToPropertyMap[xmlName] = propertyKey;
-				if (elementMetadata?.namespaces && elementMetadata.namespaces.length > 0) {
-					const parentPrefix = elementMetadata.namespaces[0].prefix;
-					if (parentPrefix && !xmlName.includes(":")) {
-						xmlToPropertyMap[`${parentPrefix}:${xmlName}`] = propertyKey;
-					}
-				}
+				this.registerElementName(xmlToPropertyMap, propertyKey, xmlName, elementMetadata);
 			}
 		}
 		return xmlToPropertyMap;
+	}
+
+	/**
+	 * Register array container name(s) in the XML-to-property map, including the prefixed
+	 * variant when form is 'qualified'.
+	 */
+	private registerArrayContainerNames(
+		xmlToPropertyMap: Record<string, string>,
+		propertyKey: string,
+		xmlName: string,
+		firstArrayMetadata: XmlArrayMetadata,
+	): void {
+		const bare = firstArrayMetadata.containerName ?? xmlName;
+		xmlToPropertyMap[bare] = propertyKey;
+		// Also register the prefixed container name for qualified arrays
+		const containerNs = firstArrayMetadata.namespaces?.[0];
+		if (containerNs?.prefix && firstArrayMetadata.form === "qualified") {
+			xmlToPropertyMap[`${containerNs.prefix}:${bare}`] = propertyKey;
+		}
+	}
+
+	/**
+	 * Register an element name in the XML-to-property map, including the parent-prefixed
+	 * variant for elements that inherit a namespace from their parent.
+	 */
+	private registerElementName(
+		xmlToPropertyMap: Record<string, string>,
+		propertyKey: string,
+		xmlName: string,
+		elementMetadata: XmlElementMetadata | undefined,
+	): void {
+		xmlToPropertyMap[xmlName] = propertyKey;
+		if (elementMetadata?.namespaces && elementMetadata.namespaces.length > 0) {
+			const parentPrefix = elementMetadata.namespaces[0].prefix;
+			if (parentPrefix && !xmlName.includes(":")) {
+				xmlToPropertyMap[`${parentPrefix}:${xmlName}`] = propertyKey;
+			}
+		}
 	}
 
 	/**
@@ -483,6 +516,7 @@ export class XmlMappingUtil {
 		data: any,
 		allArrayMetadata: Record<string, XmlArrayMetadata[]>,
 		excludedKeys: Set<string>,
+		foundProperties: Set<string>,
 	): void {
 		for (const propertyKey in allArrayMetadata) {
 			const metadataArray = allArrayMetadata[propertyKey];
@@ -504,6 +538,7 @@ export class XmlMappingUtil {
 
 			instance[propertyKey] = items;
 			excludedKeys.add(itemName);
+			foundProperties.add(propertyKey);
 		}
 	}
 
@@ -994,6 +1029,39 @@ export class XmlMappingUtil {
 				if (data[xmlName] === undefined) {
 					throw new Error(`Required element '${fieldMetadata.name}' is missing`);
 				}
+			}
+		}
+	}
+
+	/**
+	 * Apply defaultValue for arrays that were absent in the XML data.
+	 */
+	private applyArrayDefaults(instance: any, allArrayMetadata: Record<string, XmlArrayMetadata[]>): void {
+		for (const propertyKey in allArrayMetadata) {
+			const metadataArray = allArrayMetadata[propertyKey];
+			if (!metadataArray || metadataArray.length === 0) continue;
+			const metadata = metadataArray[0];
+			if (metadata.defaultValue === undefined) continue;
+			instance[propertyKey] ??= metadata.defaultValue;
+		}
+	}
+
+	/**
+	 * Check that required arrays are present after deserialization (accounting for defaultValue).
+	 */
+	private checkRequiredArrays(
+		allArrayMetadata: Record<string, XmlArrayMetadata[]>,
+		foundProperties: Set<string>,
+	): void {
+		for (const propertyKey in allArrayMetadata) {
+			const metadataArray = allArrayMetadata[propertyKey];
+			if (!metadataArray || metadataArray.length === 0) continue;
+			const metadata = metadataArray[0];
+			if (!metadata.required || metadata.defaultValue !== undefined) continue;
+
+			if (!foundProperties.has(propertyKey)) {
+				const name = metadata.containerName ?? metadata.itemName ?? propertyKey;
+				throw new Error(`Required array '${name}' is missing`);
 			}
 		}
 	}
@@ -1659,7 +1727,15 @@ export class XmlMappingUtil {
 		}
 
 		const firstMetadata = arrayMetadata[0];
-		const containerName = firstMetadata.containerName ?? xmlName;
+		const rawContainerName = firstMetadata.containerName ?? xmlName;
+
+		// Apply namespace prefix to container name when form is 'qualified'
+		const containerNs = firstMetadata.namespaces?.[0];
+		const containerName =
+			containerNs?.prefix && firstMetadata.form === "qualified"
+				? `${containerNs.prefix}:${rawContainerName}`
+				: rawContainerName;
+
 		const itemName = firstMetadata.itemName;
 
 		const processedItems = value.map((item: any): any => {

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -273,7 +273,7 @@ export class XmlMappingUtil {
 			foundProperties,
 		);
 		this.applyDefaults(instance, fieldElementMetadata, foundProperties);
-		this.applyArrayDefaults(instance, allArrayMetadata);
+		this.applyArrayDefaults(instance, allArrayMetadata, foundProperties);
 		this.mapDynamicElements(instance, targetClass, data, elementMetadata, propertyMappings, fieldElementMetadata);
 		this.checkRequiredElements(data, fieldElementMetadata);
 		this.checkRequiredArrays(allArrayMetadata, foundProperties);
@@ -484,7 +484,7 @@ export class XmlMappingUtil {
 		xmlToPropertyMap[bare] = propertyKey;
 		// Also register the prefixed container name for qualified arrays
 		const containerNs = firstArrayMetadata.namespaces?.[0];
-		if (containerNs?.prefix && firstArrayMetadata.form === "qualified") {
+		if (containerNs?.prefix && firstArrayMetadata.form === "qualified" && !bare.includes(":")) {
 			xmlToPropertyMap[`${containerNs.prefix}:${bare}`] = propertyKey;
 		}
 	}
@@ -1036,13 +1036,19 @@ export class XmlMappingUtil {
 	/**
 	 * Apply defaultValue for arrays that were absent in the XML data.
 	 */
-	private applyArrayDefaults(instance: any, allArrayMetadata: Record<string, XmlArrayMetadata[]>): void {
+	private applyArrayDefaults(
+		instance: any,
+		allArrayMetadata: Record<string, XmlArrayMetadata[]>,
+		foundProperties: Set<string>,
+	): void {
 		for (const propertyKey in allArrayMetadata) {
 			const metadataArray = allArrayMetadata[propertyKey];
 			if (!metadataArray || metadataArray.length === 0) continue;
 			const metadata = metadataArray[0];
 			if (metadata.defaultValue === undefined) continue;
-			instance[propertyKey] ??= metadata.defaultValue;
+			if (foundProperties.has(propertyKey)) continue;
+
+			instance[propertyKey] = Array.isArray(metadata.defaultValue) ? [...metadata.defaultValue] : metadata.defaultValue;
 		}
 	}
 
@@ -1062,6 +1068,30 @@ export class XmlMappingUtil {
 			if (!foundProperties.has(propertyKey)) {
 				const name = metadata.containerName ?? metadata.itemName ?? propertyKey;
 				throw new Error(`Required array '${name}' is missing`);
+			}
+		}
+	}
+
+	/**
+	 * Check that required arrays deserialize to actual arrays.
+	 */
+	private validateRequiredArrayValues(instance: any, allArrayMetadata: Record<string, XmlArrayMetadata[]>): void {
+		for (const propertyKey in allArrayMetadata) {
+			const metadataArray = allArrayMetadata[propertyKey];
+			if (!metadataArray || metadataArray.length === 0) continue;
+
+			const metadata = metadataArray[0];
+			if (!metadata.required || metadata.defaultValue !== undefined) continue;
+
+			const value = instance[propertyKey];
+			const name = metadata.containerName ?? metadata.itemName ?? propertyKey;
+
+			if (value === undefined) {
+				throw new Error(`Required array '${name}' is missing`);
+			}
+
+			if (!Array.isArray(value)) {
+				throw new Error(`Required array '${name}' must deserialize to an array`);
 			}
 		}
 	}
@@ -1089,6 +1119,8 @@ export class XmlMappingUtil {
 		if (!hasDynamicElement) {
 			this.validateExtraFields(targetClass, data, fieldElementMetadata, allArrayMetadata, xmlToPropertyMap);
 		}
+
+		this.validateRequiredArrayValues(instance, allArrayMetadata);
 
 		this.validatePropertyInstantiation(
 			instance,
@@ -1729,10 +1761,11 @@ export class XmlMappingUtil {
 		const firstMetadata = arrayMetadata[0];
 		const rawContainerName = firstMetadata.containerName ?? xmlName;
 
-		// Apply namespace prefix to container name when form is 'qualified'
+		// Apply namespace prefix to container name when form is 'qualified',
+		// but do not double-prefix names that are already namespace-qualified.
 		const containerNs = firstMetadata.namespaces?.[0];
 		const containerName =
-			containerNs?.prefix && firstMetadata.form === "qualified"
+			containerNs?.prefix && firstMetadata.form === "qualified" && !rawContainerName.includes(":")
 				? `${containerNs.prefix}:${rawContainerName}`
 				: rawContainerName;
 

--- a/packages/xml-poto/src/utils/xml-namespace-util.ts
+++ b/packages/xml-poto/src/utils/xml-namespace-util.ts
@@ -178,6 +178,7 @@ export class XmlNamespaceUtil {
 	 * Build element name with namespace prefix.
 	 * Results are cached for performance.
 	 * Uses the first namespace from the namespaces array as the primary namespace.
+	 * When form is 'unqualified', the prefix is suppressed even if a namespace is configured.
 	 */
 	buildElementName(metadata: XmlElementMetadata): string {
 		// Get primary namespace (first in array)
@@ -188,9 +189,9 @@ export class XmlNamespaceUtil {
 			return metadata.name;
 		}
 
-		// Create cache key
+		// Create cache key (includes form to avoid cross-contamination)
 		const prefix = primaryNs.prefix ?? "";
-		const cacheKey = `${metadata.name}|${prefix}`;
+		const cacheKey = `${metadata.name}|${prefix}|${metadata.form ?? ""}`;
 
 		// Check cache
 		const cached = elementNameCache.get(cacheKey);
@@ -199,8 +200,9 @@ export class XmlNamespaceUtil {
 		}
 
 		// Build and cache result
+		// 'unqualified' suppresses the prefix; undefined or 'qualified' applies it
 		let result: string;
-		if (prefix) {
+		if (prefix && metadata.form !== "unqualified") {
 			result = `${prefix}:${metadata.name}`;
 		} else {
 			result = metadata.name;
@@ -214,8 +216,13 @@ export class XmlNamespaceUtil {
 	 * Build attribute name with namespace prefix.
 	 * Results are cached for performance.
 	 * Uses the first namespace from the namespaces array as the primary namespace.
+	 * When form is 'unqualified', the prefix is suppressed even if a namespace is configured.
 	 */
-	buildAttributeName(metadata: { name: string; namespaces?: { prefix?: string; uri: string }[] }): string {
+	buildAttributeName(metadata: {
+		name: string;
+		namespaces?: { prefix?: string; uri: string }[];
+		form?: "qualified" | "unqualified";
+	}): string {
 		// Get primary namespace (first in array)
 		const primaryNs = metadata.namespaces?.[0];
 
@@ -224,9 +231,9 @@ export class XmlNamespaceUtil {
 			return metadata.name;
 		}
 
-		// Create cache key
+		// Create cache key (includes form to avoid cross-contamination)
 		const prefix = primaryNs.prefix ?? "";
-		const cacheKey = `${metadata.name}|${prefix}`;
+		const cacheKey = `${metadata.name}|${prefix}|${metadata.form ?? ""}`;
 
 		// Check cache
 		const cached = attributeNameCache.get(cacheKey);
@@ -235,8 +242,9 @@ export class XmlNamespaceUtil {
 		}
 
 		// Build and cache result
+		// 'unqualified' suppresses the prefix; undefined or 'qualified' applies it
 		let result: string;
-		if (prefix) {
+		if (prefix && metadata.form !== "unqualified") {
 			result = `${prefix}:${metadata.name}`;
 		} else {
 			result = metadata.name;

--- a/packages/xml-poto/tests/decorators/metadata-getters.test.ts
+++ b/packages/xml-poto/tests/decorators/metadata-getters.test.ts
@@ -305,7 +305,7 @@ describe("Metadata Getters", () => {
 			it("should retrieve metadata from WeakMap storage", () => {
 				class TestClass {}
 				const metadata = {
-					items: [{ itemName: "item", type: String }],
+					items: [{ itemName: "item", type: String, required: false }],
 				};
 				getMetadata(TestClass).arrays = metadata;
 
@@ -317,8 +317,8 @@ describe("Metadata Getters", () => {
 			it("should retrieve multiple properties with array items", () => {
 				class TestClass {}
 				const metadata = {
-					items: [{ itemName: "item", type: String }],
-					products: [{ itemName: "product", type: Number }],
+					items: [{ itemName: "item", type: String, required: false }],
+					products: [{ itemName: "product", type: Number, required: false }],
 				};
 				getMetadata(TestClass).arrays = metadata;
 
@@ -363,6 +363,7 @@ describe("Metadata Getters", () => {
 							itemName: "item",
 							type: ItemType,
 							namespaces: [{ uri: "http://example.com" }],
+							required: false,
 						},
 					],
 				};
@@ -381,8 +382,8 @@ describe("Metadata Getters", () => {
 
 				const metadata = {
 					items: [
-						{ itemName: "itemA", type: ItemA },
-						{ itemName: "itemB", type: ItemB },
+						{ itemName: "itemA", type: ItemA, required: false },
+						{ itemName: "itemB", type: ItemB, required: false },
 					],
 				};
 				getMetadata(TestClass).arrays = metadata;

--- a/packages/xml-poto/tests/decorators/xml-array.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-array.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { XmlDecoratorSerializer } from "../../src";
 import { getMetadata } from "../../src/decorators";
 import { XmlArray } from "../../src/decorators/xml-array";
+import { XmlRoot } from "../../src/decorators/xml-root";
 
 describe("XmlArray decorator", () => {
 	beforeEach(() => {
@@ -412,6 +414,124 @@ describe("XmlArray decorator", () => {
 				}
 				void new TestClass();
 			}).not.toThrow();
+		});
+	});
+
+	describe("required option", () => {
+		let serializer: XmlDecoratorSerializer;
+
+		beforeEach(() => {
+			serializer = new XmlDecoratorSerializer();
+		});
+
+		it("should store required in metadata", () => {
+			class TestClass {
+				@XmlArray({ containerName: "Items", itemName: "Item", required: true })
+				items: string[] = [];
+			}
+
+			void new TestClass();
+			const metadata = getMetadata(TestClass).arrays;
+			expect(metadata.items[0].required).toBe(true);
+		});
+
+		it("should not throw when required array is present", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({ containerName: "Items", itemName: "Item", required: true })
+				items: string[] = [];
+			}
+
+			const xml = "<Root><Items><Item>a</Item></Items></Root>";
+			expect(() => serializer.fromXml(xml, Root)).not.toThrow();
+		});
+
+		it("should throw when required wrapped array is absent", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({ containerName: "Items", itemName: "Item", required: true })
+				items: string[] = [];
+			}
+
+			const xml = "<Root></Root>";
+			expect(() => serializer.fromXml(xml, Root)).toThrow(/Required array 'Items' is missing/);
+		});
+
+		it("should throw when required unwrapped array is absent", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({ itemName: "Item", required: true })
+				items: string[] = [];
+			}
+
+			const xml = "<Root></Root>";
+			expect(() => serializer.fromXml(xml, Root)).toThrow(/Required array 'Item' is missing/);
+		});
+
+		it("should not throw when required array has a defaultValue", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({ containerName: "Items", itemName: "Item", required: true, defaultValue: [] })
+				items: string[] = [];
+			}
+
+			const xml = "<Root></Root>";
+			expect(() => serializer.fromXml(xml, Root)).not.toThrow();
+		});
+	});
+
+	describe("defaultValue option", () => {
+		let serializer: XmlDecoratorSerializer;
+
+		beforeEach(() => {
+			serializer = new XmlDecoratorSerializer();
+		});
+
+		it("should store defaultValue in metadata", () => {
+			class TestClass {
+				@XmlArray({ itemName: "Item", defaultValue: ["fallback"] })
+				items: string[] = [];
+			}
+
+			void new TestClass();
+			const metadata = getMetadata(TestClass).arrays;
+			expect(metadata.items[0].defaultValue).toEqual(["fallback"]);
+		});
+
+		it("should use defaultValue when array is absent (wrapped)", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({ containerName: "Items", itemName: "Item", defaultValue: ["a", "b"] })
+				items!: string[];
+			}
+
+			const xml = "<Root></Root>";
+			const result = serializer.fromXml(xml, Root);
+			expect(result.items).toEqual(["a", "b"]);
+		});
+
+		it("should use defaultValue when array is absent (unwrapped)", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({ itemName: "Item", defaultValue: ["x"] })
+				items!: string[];
+			}
+
+			const xml = "<Root></Root>";
+			const result = serializer.fromXml(xml, Root);
+			expect(result.items).toEqual(["x"]);
+		});
+
+		it("should not override a present array with defaultValue", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({ containerName: "Items", itemName: "Item", defaultValue: ["fallback"] })
+				items!: string[];
+			}
+
+			const xml = "<Root><Items><Item>real</Item></Items></Root>";
+			const result = serializer.fromXml(xml, Root);
+			expect(result.items).toEqual(["real"]);
 		});
 	});
 });

--- a/packages/xml-poto/tests/decorators/xml-form.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-form.test.ts
@@ -1,0 +1,341 @@
+/* eslint-disable typescript/no-explicit-any, typescript/explicit-function-return-type -- Test file with dynamic class definitions */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { XmlDecoratorSerializer } from "../../src";
+import { XmlArray } from "../../src/decorators/xml-array";
+import { XmlAttribute } from "../../src/decorators/xml-attribute";
+import { XmlElement } from "../../src/decorators/xml-element";
+import { XmlRoot } from "../../src/decorators/xml-root";
+import { XmlNamespaceUtil } from "../../src/utils/xml-namespace-util";
+
+describe("form option — namespace qualification", () => {
+	let serializer: XmlDecoratorSerializer;
+	let util: XmlNamespaceUtil;
+
+	beforeEach(() => {
+		serializer = new XmlDecoratorSerializer();
+		util = new XmlNamespaceUtil();
+	});
+
+	describe("XmlNamespaceUtil.buildElementName", () => {
+		it("applies prefix when form is undefined (existing behaviour)", () => {
+			const result = util.buildElementName({
+				name: "Address",
+				namespaces: [{ uri: "http://example.com", prefix: "ns" }],
+				required: false,
+			});
+			expect(result).toBe("ns:Address");
+		});
+
+		it("applies prefix when form is 'qualified'", () => {
+			const result = util.buildElementName({
+				name: "Address",
+				namespaces: [{ uri: "http://example.com", prefix: "ns" }],
+				required: false,
+				form: "qualified",
+			});
+			expect(result).toBe("ns:Address");
+		});
+
+		it("suppresses prefix when form is 'unqualified'", () => {
+			const result = util.buildElementName({
+				name: "Address",
+				namespaces: [{ uri: "http://example.com", prefix: "ns" }],
+				required: false,
+				form: "unqualified",
+			});
+			expect(result).toBe("Address");
+		});
+
+		it("caches qualified and unqualified results independently", () => {
+			const base = { name: "Item", namespaces: [{ uri: "http://x.com", prefix: "x" }], required: false };
+			const qualified = util.buildElementName({ ...base, form: "qualified" });
+			const unqualified = util.buildElementName({ ...base, form: "unqualified" });
+			expect(qualified).toBe("x:Item");
+			expect(unqualified).toBe("Item");
+		});
+	});
+
+	describe("XmlNamespaceUtil.buildAttributeName", () => {
+		it("applies prefix when form is undefined (existing behaviour)", () => {
+			const result = util.buildAttributeName({
+				name: "id",
+				namespaces: [{ uri: "http://example.com", prefix: "ns" }],
+			});
+			expect(result).toBe("ns:id");
+		});
+
+		it("applies prefix when form is 'qualified'", () => {
+			const result = util.buildAttributeName({
+				name: "id",
+				namespaces: [{ uri: "http://example.com", prefix: "ns" }],
+				form: "qualified",
+			});
+			expect(result).toBe("ns:id");
+		});
+
+		it("suppresses prefix when form is 'unqualified'", () => {
+			const result = util.buildAttributeName({
+				name: "id",
+				namespaces: [{ uri: "http://example.com", prefix: "ns" }],
+				form: "unqualified",
+			});
+			expect(result).toBe("id");
+		});
+	});
+
+	describe("@XmlElement form integration", () => {
+		it("serializes with prefix when form is 'qualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlElement({
+					name: "city",
+					namespace: { uri: "http://addr.com", prefix: "addr" },
+					form: "qualified",
+				})
+				city!: string;
+			}
+
+			const obj = new Root();
+			obj.city = "Amsterdam";
+
+			const xml = serializer.toXml(obj);
+			expect(xml).toContain("<addr:city>Amsterdam</addr:city>");
+		});
+
+		it("serializes without prefix when form is 'unqualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlElement({
+					name: "city",
+					namespace: { uri: "http://addr.com", prefix: "addr" },
+					form: "unqualified",
+				})
+				city!: string;
+			}
+
+			const obj = new Root();
+			obj.city = "Amsterdam";
+
+			const xml = serializer.toXml(obj);
+			expect(xml).toContain("<city>Amsterdam</city>");
+			expect(xml).not.toContain("addr:city");
+		});
+
+		it("round-trips with form 'qualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlElement({
+					name: "city",
+					namespace: { uri: "http://addr.com", prefix: "addr" },
+					form: "qualified",
+				})
+				city!: string;
+			}
+
+			const obj = new Root();
+			obj.city = "Utrecht";
+
+			const xml = serializer.toXml(obj);
+			const parsed = serializer.fromXml(xml, Root);
+			expect(parsed.city).toBe("Utrecht");
+		});
+
+		it("round-trips with form 'unqualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlElement({
+					name: "city",
+					namespace: { uri: "http://addr.com", prefix: "addr" },
+					form: "unqualified",
+				})
+				city!: string;
+			}
+
+			const obj = new Root();
+			obj.city = "Rotterdam";
+
+			const xml = serializer.toXml(obj);
+			const parsed = serializer.fromXml(xml, Root);
+			expect(parsed.city).toBe("Rotterdam");
+		});
+	});
+
+	describe("@XmlAttribute form integration", () => {
+		it("serializes attribute with prefix when form is 'qualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlAttribute({
+					name: "lang",
+					namespace: { uri: "http://xml.org", prefix: "xml" },
+					form: "qualified",
+				})
+				lang!: string;
+			}
+
+			const obj = new Root();
+			obj.lang = "en";
+
+			const xml = serializer.toXml(obj);
+			expect(xml).toContain('xml:lang="en"');
+		});
+
+		it("serializes attribute without prefix when form is 'unqualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlAttribute({
+					name: "lang",
+					namespace: { uri: "http://xml.org", prefix: "xml" },
+					form: "unqualified",
+				})
+				lang!: string;
+			}
+
+			const obj = new Root();
+			obj.lang = "en";
+
+			const xml = serializer.toXml(obj);
+			expect(xml).toContain('lang="en"');
+			expect(xml).not.toContain("xml:lang");
+		});
+
+		it("round-trips attribute with form 'qualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlAttribute({
+					name: "lang",
+					namespace: { uri: "http://xml.org", prefix: "xml" },
+					form: "qualified",
+				})
+				lang!: string;
+			}
+
+			const obj = new Root();
+			obj.lang = "nl";
+
+			const xml = serializer.toXml(obj);
+			const parsed = serializer.fromXml(xml, Root);
+			expect(parsed.lang).toBe("nl");
+		});
+
+		it("round-trips attribute with form 'unqualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlAttribute({
+					name: "lang",
+					namespace: { uri: "http://xml.org", prefix: "xml" },
+					form: "unqualified",
+				})
+				lang!: string;
+			}
+
+			const obj = new Root();
+			obj.lang = "de";
+
+			const xml = serializer.toXml(obj);
+			const parsed = serializer.fromXml(xml, Root);
+			expect(parsed.lang).toBe("de");
+		});
+	});
+
+	describe("@XmlArray form integration", () => {
+		it("serializes container with prefix when form is 'qualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({
+					containerName: "Books",
+					itemName: "Book",
+					namespace: { uri: "http://lib.com", prefix: "lib" },
+					form: "qualified",
+				})
+				books: string[] = [];
+			}
+
+			const obj = new Root();
+			obj.books = ["Dune", "Foundation"];
+
+			const xml = serializer.toXml(obj);
+			expect(xml).toContain("<lib:Books>");
+			expect(xml).toContain("</lib:Books>");
+		});
+
+		it("serializes container without prefix when form is 'unqualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({
+					containerName: "Books",
+					itemName: "Book",
+					namespace: { uri: "http://lib.com", prefix: "lib" },
+					form: "unqualified",
+				})
+				books: string[] = [];
+			}
+
+			const obj = new Root();
+			obj.books = ["Dune"];
+
+			const xml = serializer.toXml(obj);
+			expect(xml).toContain("<Books>");
+			expect(xml).not.toContain("lib:Books");
+		});
+
+		it("serializes container without prefix when form is undefined (existing behaviour)", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({
+					containerName: "Books",
+					itemName: "Book",
+					namespace: { uri: "http://lib.com", prefix: "lib" },
+				})
+				books: string[] = [];
+			}
+
+			const obj = new Root();
+			obj.books = ["Dune"];
+
+			const xml = serializer.toXml(obj);
+			expect(xml).toContain("<Books>");
+			expect(xml).not.toContain("lib:Books");
+		});
+
+		it("round-trips array with form 'qualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({
+					containerName: "Books",
+					itemName: "Book",
+					namespace: { uri: "http://lib.com", prefix: "lib" },
+					form: "qualified",
+				})
+				books: string[] = [];
+			}
+
+			const obj = new Root();
+			obj.books = ["Dune", "Foundation"];
+
+			const xml = serializer.toXml(obj);
+			const parsed = serializer.fromXml(xml, Root);
+			expect(parsed.books).toEqual(["Dune", "Foundation"]);
+		});
+
+		it("round-trips array with form 'unqualified'", () => {
+			@XmlRoot({ name: "Root" })
+			class Root {
+				@XmlArray({
+					containerName: "Books",
+					itemName: "Book",
+					namespace: { uri: "http://lib.com", prefix: "lib" },
+					form: "unqualified",
+				})
+				books: string[] = [];
+			}
+
+			const obj = new Root();
+			obj.books = ["Dune", "Foundation"];
+
+			const xml = serializer.toXml(obj);
+			const parsed = serializer.fromXml(xml, Root);
+			expect(parsed.books).toEqual(["Dune", "Foundation"]);
+		});
+	});
+});


### PR DESCRIPTION
Introduces a new configuration option `useXmlRoot` that controls whether root elements are decorated with `@XmlRoot` or `@XmlElement`. When set to false, `@XmlElement` is used instead, with support for propagating the `elementFormDefault` schema setting as the `form` parameter.

Adds `form` parameter support to element and array decorators to properly handle qualified vs unqualified namespace scenarios. Updates namespace utilities to respect the form setting when building prefixed element and attribute names.

Enhances XSD content validation to detect and reject non-XSD files (like HTML pages or plain XML) early with clear error messages, improving developer experience when invalid files are accidentally provided.

Adds required and defaultValue options to XmlArray decorator, enabling validation of mandatory arrays and fallback values when arrays are absent from XML input.