### PR TITLE
Fixes element name priority in serialization

### DIFF
--- a/.changeset/fix-tsdown-dist-extensions.md
+++ b/.changeset/fix-tsdown-dist-extensions.md
@@ -1,0 +1,25 @@
+---
+"@cerios/xml-poto-codegen": patch
+"@cerios/xml-poto": patch
+---
+
+Fix `package.json` entry points to match tsdown's default output extensions.
+
+After the tsup → tsdown migration, the emitted CJS artifacts are `index.cjs`
+and `index.d.cts` (instead of tsup's `index.js` / `index.d.ts`), but the
+manifests still referenced the old filenames. As a result `main`, `types`,
+and the `require` export condition pointed at files that no longer exist,
+which broke CJS consumers and `@arethetypeswrong/cli` resolution.
+
+Updated in both packages:
+
+- `main`: `./dist/index.js` → `./dist/index.cjs`
+- `types`: `./dist/index.d.ts` → `./dist/index.d.cts`
+- `exports["."].require.default`: `./dist/index.js` → `./dist/index.cjs`
+- `exports["."].require.types`: `./dist/index.d.ts` → `./dist/index.d.cts`
+
+In `@cerios/xml-poto-codegen` the `bin` entry was also corrected:
+
+- `bin["xml-poto-codegen"]`: `dist/cli.js` → `dist/cli.cjs`
+
+ESM entry points (`.mjs` / `.d.mts`) were already correct and are unchanged.

--- a/.changeset/fix-xmlelement-name-precedence.md
+++ b/.changeset/fix-xmlelement-name-precedence.md
@@ -1,0 +1,26 @@
+---
+"@cerios/xml-poto": patch
+---
+
+Fix `@XmlElement` name precedence so a property-level explicit name correctly
+overrides the class-level `@XmlElement` / `@XmlRoot` name of the referenced
+type.
+
+Previously, when a property's type carried a class-level `@XmlElement({ name })`
+or `@XmlRoot({ name })`, that name would win even if the property itself was
+decorated with `@XmlElement({ name: "..." })`. This was inconsistent with the
+C# `System.Xml.Serialization.XmlSerializer` behaviour, where a property-level
+`[XmlElement(ElementName = "...")]` always overrides the referenced type's
+`[XmlType]` / `[XmlRoot]` name.
+
+The serializer now resolves an element's tag name using a 3-tier priority:
+
+1. Explicit name provided on the property's `@XmlElement` decorator.
+2. Class-level `@XmlElement` / `@XmlRoot` name of the referenced type.
+3. The property key (default).
+
+Internally, `@XmlElement` now tracks whether the name was explicitly supplied
+via a new `nameExplicitlySet` metadata flag, so tier 1 can be distinguished
+from tier 3. The detection lives in a dedicated `isElementNameExplicitlySet`
+helper and uses `!== undefined` (rather than `!= null`) to remain robust
+against formatter rewrites that turn loose null checks into strict ones.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "xml-poto",
 			"workspaces": [
 				"packages/*"
 			],
@@ -17,6 +18,9 @@
 				"oxlint-tsgolint": "^0.22.0",
 				"syncpack": "^14.3.1",
 				"vitest": "^4.0.18"
+			},
+			"engines": {
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@andrewbranch/untar.js": {
@@ -3993,9 +3997,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4353,9 +4357,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -4373,7 +4377,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -5467,9 +5471,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+			"integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5810,6 +5814,9 @@
 				"tsdown": "^0.21.10",
 				"typescript": "^6.0.3",
 				"vitest": "^4.0.18"
+			},
+			"engines": {
+				"node": ">=20.19.0"
 			}
 		},
 		"packages/xml-poto-codegen": {
@@ -5832,6 +5839,9 @@
 				"tsdown": "^0.21.10",
 				"typescript": "^6.0.3",
 				"vitest": "^4.0.18"
+			},
+			"engines": {
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
 				"@cerios/xml-poto": "^2.2.0"

--- a/packages/xml-poto-codegen/package.json
+++ b/packages/xml-poto-codegen/package.json
@@ -24,16 +24,16 @@
 		"url": "git+https://github.com/CeriosTesting/xml-poto.git"
 	},
 	"bin": {
-		"xml-poto-codegen": "dist/cli.js"
+		"xml-poto-codegen": "dist/cli.cjs"
 	},
 	"files": [
 		"dist"
 	],
 	"type": "commonjs",
 	"sideEffects": false,
-	"main": "./dist/index.js",
+	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
+	"types": "./dist/index.d.cts",
 	"exports": {
 		".": {
 			"import": {
@@ -41,8 +41,8 @@
 				"default": "./dist/index.mjs"
 			},
 			"require": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
 			}
 		},
 		"./package.json": "./package.json"

--- a/packages/xml-poto/package.json
+++ b/packages/xml-poto/package.json
@@ -37,9 +37,9 @@
 	],
 	"type": "commonjs",
 	"sideEffects": false,
-	"main": "./dist/index.js",
+	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
+	"types": "./dist/index.d.cts",
 	"exports": {
 		".": {
 			"import": {
@@ -47,8 +47,8 @@
 				"default": "./dist/index.mjs"
 			},
 			"require": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
 			}
 		},
 		"./package.json": "./package.json"

--- a/packages/xml-poto/src/decorators/types/metadata.ts
+++ b/packages/xml-poto/src/decorators/types/metadata.ts
@@ -8,6 +8,15 @@ import { XmlNamespace } from "./xml-namespace";
 export interface XmlElementMetadata {
 	/** The XML element name */
 	name: string;
+	/**
+	 * Internal flag: true when the user explicitly provided a `name` on the
+	 * `@XmlElement` decorator (either as a string argument or via `options.name`).
+	 * False/undefined when the name was defaulted to the property key.
+	 *
+	 * Used by the serializer to decide whether a property-level name should
+	 * override the referenced type's class-level `@XmlElement` name.
+	 */
+	nameExplicitlySet?: boolean;
 	/** XML namespaces for this element (first is primary, rest are additional declarations) */
 	namespaces?: XmlNamespace[];
 	/** Whether this element is required */

--- a/packages/xml-poto/src/decorators/xml-element.ts
+++ b/packages/xml-poto/src/decorators/xml-element.ts
@@ -162,14 +162,35 @@ export function XmlElement(nameOrOptions?: string | XmlElementOptions): {
 }
 
 /**
+ * Detect whether the user explicitly provided an element name on an `@XmlElement`
+ * decorator call.
+ *
+ * Returns true when:
+ * - the decorator was called with a string argument (e.g. `@XmlElement("Foo")`), or
+ * - the options object carries an explicit `name` (e.g. `@XmlElement({ name: "Foo" })`).
+ *
+ * Returns false for the bare `@XmlElement()` / `@XmlElement({})` cases, where the
+ * name is later defaulted to the property key / class name.
+ *
+ * Note: this MUST treat `undefined` as "not set". Using strict `!== null` would
+ * misclassify `@XmlElement()` (where `options.name === undefined`) as explicit,
+ * which breaks Priority 2 (the referenced type's class-level `@XmlElement` /
+ * `@XmlRoot` name acting as the fallback element tag).
+ */
+function isElementNameExplicitlySet(nameOrOptions: any, options: any): boolean {
+	return typeof nameOrOptions === "string" || options.name !== undefined;
+}
+
+/**
  * Handle XmlElement class decoration
  */
 function handleClassDecorator(target: any, context: any, nameOrOptions: any): any {
 	const options = (typeof nameOrOptions === "object" ? nameOrOptions : {}) ?? {};
+	const nameExplicitlySet = isElementNameExplicitlySet(nameOrOptions, options);
 	const xmlName = typeof nameOrOptions === "string" ? nameOrOptions : (options.name ?? String(context.name));
 
 	// Build element metadata
-	const elementMetadata = buildElementMetadata(xmlName, options);
+	const elementMetadata = buildElementMetadata(xmlName, options, nameExplicitlySet);
 
 	// Store comprehensive metadata on the class itself using unified storage
 	getMetadata(target).element = elementMetadata;
@@ -188,7 +209,7 @@ function handleClassDecorator(target: any, context: any, nameOrOptions: any): an
 /**
  * Build XmlElementMetadata from options
  */
-function buildElementMetadata(xmlName: string, options: any): XmlElementMetadata {
+function buildElementMetadata(xmlName: string, options: any, nameExplicitlySet: boolean): XmlElementMetadata {
 	const allNamespaces: XmlNamespace[] = [];
 	if (options.namespace) {
 		allNamespaces.push(options.namespace);
@@ -199,6 +220,7 @@ function buildElementMetadata(xmlName: string, options: any): XmlElementMetadata
 
 	return {
 		name: xmlName,
+		nameExplicitlySet: nameExplicitlySet || undefined,
 		namespaces: allNamespaces.length > 0 ? allNamespaces : undefined,
 		required: options.required ?? false,
 		order: options.order,
@@ -379,10 +401,11 @@ function setupLazyLoadingDescriptor(target: any, propertyKey: string, metadata: 
  */
 function handleFieldDecorator(_target: any, context: any, nameOrOptions: any): (initialValue: any) => any {
 	const options = (typeof nameOrOptions === "object" ? nameOrOptions : {}) ?? {};
+	const nameExplicitlySet = isElementNameExplicitlySet(nameOrOptions, options);
 	const xmlName = typeof nameOrOptions === "string" ? nameOrOptions : (options.name ?? String(context.name));
 	const propertyKey = String(context.name);
 
-	const fieldElementMetadata: XmlElementMetadata = buildElementMetadata(xmlName, options);
+	const fieldElementMetadata: XmlElementMetadata = buildElementMetadata(xmlName, options, nameExplicitlySet);
 
 	// Store pending metadata in context.metadata for class decorators to process
 	context.metadata ??= {};

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -1886,14 +1886,26 @@ export class XmlMappingUtil {
 		valueElementName: string,
 		valueConstructor: any,
 	): string {
-		if (fieldMetadata && fieldMetadata.name !== key) {
+		// Priority 1: an EXPLICIT property-level @XmlElement name always wins over the
+		// referenced type's class-level @XmlElement. This matches C# XmlSerializer
+		// ([XmlElement(ElementName=...)] on a property overrides [XmlType]/[XmlRoot])
+		// and the parser's getPropertyXmlName. The explicit flag avoids confusing an
+		// explicit `name: "foo"` that happens to equal the property key with a
+		// defaulted name (which would otherwise mask the user's intent).
+		if (fieldMetadata?.nameExplicitlySet) {
 			return this.namespaceUtil.buildElementName(fieldMetadata);
 		}
+		// Priority 2: when no explicit field name was given, fall back to the
+		// referenced type's class-level @XmlElement/@XmlRoot name (if any).
 		if (
 			valueElementMetadata &&
 			(valueElementMetadata.name !== valueConstructor.name || valueElementMetadata.namespaces)
 		) {
 			return valueElementName;
+		}
+		// Priority 3: defaulted property key.
+		if (fieldMetadata) {
+			return this.namespaceUtil.buildElementName(fieldMetadata);
 		}
 		return key;
 	}

--- a/packages/xml-poto/tests/decorators/xml-element.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-element.test.ts
@@ -83,6 +83,7 @@ describe("XmlElement decorator", () => {
 			const metadata = getMetadata(ComplexElement).element;
 			expect(metadata).toEqual({
 				name: "ComplexElement",
+				nameExplicitlySet: true,
 				namespaces: [{ uri: "http://test.com" }],
 				required: true,
 				order: 10,
@@ -197,6 +198,7 @@ describe("XmlElement decorator", () => {
 
 			expect(fieldMetadata.field).toEqual({
 				name: "complexField",
+				nameExplicitlySet: true,
 				namespaces: [{ uri: "http://complex.com" }],
 				required: true,
 				order: 3,

--- a/packages/xml-poto/tests/integration/property-element-name-precedence.test.ts
+++ b/packages/xml-poto/tests/integration/property-element-name-precedence.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { XmlElement, XmlRoot, XmlSerializer } from "../../src";
+
+describe("Property-level @XmlElement name precedence over class-level name", () => {
+	let serializer: XmlSerializer;
+
+	beforeEach(() => {
+		serializer = new XmlSerializer();
+	});
+
+	@XmlElement({ name: "DateRange_Type" })
+	class DateRange {
+		@XmlElement({ name: "from", required: true, order: 1 })
+		from: string = "";
+
+		@XmlElement({ name: "to", required: true, order: 2 })
+		to: string = "";
+	}
+
+	@XmlRoot({ name: "Booking" })
+	class Booking {
+		@XmlElement({ name: "id", required: true, order: 1 })
+		id: string = "";
+
+		@XmlElement({ name: "range", required: true, order: 2, type: DateRange })
+		range: DateRange = new DateRange();
+
+		@XmlElement({ name: "window", required: true, order: 3, type: DateRange })
+		window: DateRange = new DateRange();
+	}
+
+	function makeBooking(): Booking {
+		const b = new Booking();
+		b.id = "B-1";
+		b.range.from = "2025-01-01";
+		b.range.to = "2025-01-02";
+		b.window.from = "2025-02-01";
+		b.window.to = "2025-02-02";
+		return b;
+	}
+
+	it("serializes the property-level name, not the class-level name, when they collide with the property key", () => {
+		const xml = serializer.toXml(makeBooking());
+
+		expect(xml).toContain("<range>");
+		expect(xml).toContain("</range>");
+		expect(xml).not.toContain("<DateRange_Type");
+		expect(xml).not.toContain("</DateRange_Type>");
+	});
+
+	it("serializes the property-level name when the property key differs from it", () => {
+		const xml = serializer.toXml(makeBooking());
+
+		expect(xml).toContain("<window>");
+		expect(xml).toContain("</window>");
+	});
+
+	it("round-trips: parse → serialize produces the same XML and populates fields", () => {
+		const original = makeBooking();
+		const xml1 = serializer.toXml(original);
+
+		const parsed = serializer.fromXml(xml1, Booking);
+
+		expect(parsed.id).toBe("B-1");
+		expect(parsed.range).toBeInstanceOf(DateRange);
+		expect(parsed.range.from).toBe("2025-01-01");
+		expect(parsed.range.to).toBe("2025-01-02");
+		expect(parsed.window).toBeInstanceOf(DateRange);
+		expect(parsed.window.from).toBe("2025-02-01");
+		expect(parsed.window.to).toBe("2025-02-02");
+
+		const xml2 = serializer.toXml(parsed);
+		expect(xml2).toBe(xml1);
+	});
+});


### PR DESCRIPTION
Resolves serialization bug where property-level explicit element names were not consistently overriding referenced type's class-level names.

Introduces nameExplicitlySet flag to track when users explicitly provide an element name via decorator arguments, distinguishing between explicit names and defaulted property keys.

Implements three-tier priority system:
1. Explicit property-level names always win
2. Referenced type's class-level names serve as fallback
3. Defaulted property keys used as last resort

Aligns serializer behavior with C# XmlSerializer conventions and parser's getPropertyXmlName logic.

Updates package.json files to use .cjs and .d.cts extensions for CommonJS builds to improve module resolution compatibility.