### PR TITLE
Introduce `requireAllByDefault` option for strict XML validation

### DIFF
--- a/.changeset/curvy-plants-divide.md
+++ b/.changeset/curvy-plants-divide.md
@@ -1,0 +1,14 @@
+---
+"@cerios/xml-poto": minor
+---
+
+Add `requireAllByDefault` serialization option.
+
+When set to `true`, all `@XmlElement`, `@XmlAttribute`, `@XmlArray`, and `@XmlText` decorated fields are treated as required during deserialization unless the decorator explicitly sets `required: false`. This complements the existing per-field `required` option by providing a class-wide default, removing the need to mark every field individually.
+
+Key behaviours:
+
+- Fields with `required: false` are always optional regardless of this option.
+- Fields with a `defaultValue` in the decorator are exempt from the required check (the default is used instead).
+- TypeScript field initializers (e.g. `= ""`) have no effect on the required check; only `defaultValue` in the decorator suppresses the error.
+- Can be combined with `strictValidation`.

--- a/packages/xml-poto/docs/features/validation.md
+++ b/packages/xml-poto/docs/features/validation.md
@@ -12,6 +12,7 @@ Learn how to validate XML data and convert values using patterns, enums, and cus
 - [Required Fields](#required-fields)
 - [Combining Validation Rules](#combining-validation-rules)
 - [Strict Validation Mode](#strict-validation-mode)
+- [Require All By Default](#require-all-by-default)
 - [Best Practices](#best-practices)
 
 ## Overview
@@ -1104,6 +1105,130 @@ const serializer = new XmlSerializer({
 // Both validations apply:
 // 1. Field-level: email must match pattern
 // 2. Strict: profile must be properly typed
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Require All By Default
+
+The `requireAllByDefault` serializer option makes every decorated property (`@XmlElement`, `@XmlAttribute`, `@XmlArray`, `@XmlText`) required during deserialization unless `required: false` is **explicitly** set on that decorator.
+
+This is useful when you want strict presence checking globally without having to write `required: true` on every individual field.
+
+> **Opt-in, non-breaking**: the default value is `false`, preserving existing behaviour.
+
+### Enabling `requireAllByDefault`
+
+```typescript
+const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+```
+
+### Basic Example
+
+```typescript
+@XmlRoot({ name: "config" })
+class Config {
+	@XmlElement({ name: "host" })
+	host!: string; // required by requireAllByDefault
+
+	@XmlElement({ name: "port", required: false })
+	port?: number; // explicitly optional — never throws
+}
+
+const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+
+// ✅ Both present
+serializer.fromXml("<config><host>localhost</host><port>8080</port></config>", Config);
+
+// ✅ Only host — port is explicitly optional
+serializer.fromXml("<config><host>localhost</host></config>", Config);
+
+// ❌ host is absent — throws "Required element 'host' is missing"
+serializer.fromXml("<config><port>8080</port></config>", Config);
+```
+
+### Opting Individual Fields Out
+
+Set `required: false` on a decorator to opt that field out of the global requirement:
+
+```typescript
+@XmlRoot({ name: "Server" })
+class Server {
+	@XmlAttribute({ name: "id" })
+	id!: string; // required (throws if absent)
+
+	@XmlAttribute({ name: "region", required: false })
+	region?: string; // optional — skipped by requireAllByDefault
+
+	@XmlElement({ name: "host" })
+	host!: string; // required
+
+	@XmlElement({ name: "port", required: false })
+	port?: number; // optional
+
+	@XmlArray({ containerName: "tags", itemName: "tag" })
+	tags!: string[]; // required
+
+	@XmlArray({ containerName: "aliases", itemName: "alias", required: false })
+	aliases?: string[]; // optional
+}
+
+const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+```
+
+### `defaultValue` Suppresses the Error
+
+A field with `defaultValue` set is never considered missing, even under `requireAllByDefault`:
+
+```typescript
+@XmlRoot({ name: "config" })
+class Config {
+	@XmlElement({ name: "host" })
+	host!: string;
+
+	@XmlElement({ name: "port", defaultValue: 3000 })
+	port: number = 3000; // absent → uses defaultValue, no error
+}
+
+const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+const config = serializer.fromXml("<config><host>localhost</host></config>", Config);
+console.log(config.port); // 3000
+```
+
+### Combining with `strictValidation`
+
+Both options can be enabled simultaneously:
+
+```typescript
+const serializer = new XmlDecoratorSerializer({
+	requireAllByDefault: true, // all decorated properties must be present
+	strictValidation: true, // nested objects must be properly instantiated
+});
+```
+
+- `requireAllByDefault` validates **presence** of XML elements, attributes, and arrays.
+- `strictValidation` validates **type instantiation** of nested class instances.
+
+### Comparison with Per-Field `required: true`
+
+| Approach                          | Description                                                                                  |
+| --------------------------------- | -------------------------------------------------------------------------------------------- |
+| `@XmlElement({ required: true })` | Marks one specific field as required; default behaviour per field is optional                |
+| `requireAllByDefault: true`       | All decorated fields are required globally; opt individual fields out with `required: false` |
+
+Use `requireAllByDefault: true` when most fields should be required and only a few are optional. Use per-field `required: true` when only a handful of fields need enforcement.
+
+### Environment-Specific Configuration
+
+```typescript
+export function createSerializer() {
+	return new XmlDecoratorSerializer({
+		requireAllByDefault: process.env.NODE_ENV !== "production", // strict in dev
+		strictValidation: process.env.NODE_ENV !== "production",
+	});
+}
 ```
 
 [↑ Back to top](#table-of-contents)

--- a/packages/xml-poto/src/decorators/types/metadata.ts
+++ b/packages/xml-poto/src/decorators/types/metadata.ts
@@ -21,6 +21,8 @@ export interface XmlElementMetadata {
 	namespaces?: XmlNamespace[];
 	/** Whether this element is required */
 	required: boolean;
+	/** True when the user explicitly set required: false on the decorator (used by requireAllByDefault) */
+	requiredExplicitlyFalse?: boolean;
 	/** Serialization order */
 	order?: number;
 	/** XML Schema data type */
@@ -60,6 +62,8 @@ export interface XmlAttributeMetadata {
 	namespaces?: XmlNamespace[];
 	/** Whether this attribute is required */
 	required: boolean;
+	/** True when the user explicitly set required: false on the decorator (used by requireAllByDefault) */
+	requiredExplicitlyFalse?: boolean;
 	/** Custom type conversion functions */
 	converter?: {
 		serialize?: (value: unknown) => string;
@@ -106,6 +110,8 @@ export interface XmlTextMetadata {
 	};
 	/** Whether text content is required */
 	required: boolean;
+	/** True when the user explicitly set required: false on the decorator (used by requireAllByDefault) */
+	requiredExplicitlyFalse?: boolean;
 	/** XML Schema data type for text content */
 	dataType?: string;
 	/** Whether to wrap text content in CDATA section */
@@ -136,6 +142,8 @@ export interface XmlArrayMetadata {
 	form?: "qualified" | "unqualified";
 	/** Whether this array is required */
 	required: boolean;
+	/** True when the user explicitly set required: false on the decorator (used by requireAllByDefault) */
+	requiredExplicitlyFalse?: boolean;
 	/** Default value to use when the array is absent during deserialization */
 	defaultValue?: unknown[];
 	/** When true, array items are serialized directly to parent without container element */

--- a/packages/xml-poto/src/decorators/xml-array.ts
+++ b/packages/xml-poto/src/decorators/xml-array.ts
@@ -78,6 +78,7 @@ export function XmlArray(options: XmlArrayOptions = {}) {
 			order: options.order,
 			form: options.form,
 			required: options.required ?? false,
+			requiredExplicitlyFalse: options.required === false || undefined,
 			defaultValue: options.defaultValue,
 		};
 

--- a/packages/xml-poto/src/decorators/xml-attribute.ts
+++ b/packages/xml-poto/src/decorators/xml-attribute.ts
@@ -132,6 +132,7 @@ export function XmlAttribute(
 			name: options.name ?? propertyKey,
 			namespaces: allNamespaces.length > 0 ? allNamespaces : undefined,
 			required: options.required ?? false,
+			requiredExplicitlyFalse: options.required === false || undefined,
 			converter: options.converter,
 			pattern: options.pattern,
 			enumValues: options.enumValues,

--- a/packages/xml-poto/src/decorators/xml-element.ts
+++ b/packages/xml-poto/src/decorators/xml-element.ts
@@ -223,6 +223,7 @@ function buildElementMetadata(xmlName: string, options: any, nameExplicitlySet: 
 		nameExplicitlySet: nameExplicitlySet || undefined,
 		namespaces: allNamespaces.length > 0 ? allNamespaces : undefined,
 		required: options.required ?? false,
+		requiredExplicitlyFalse: options.required === false || undefined,
 		order: options.order,
 		dataType: options.dataType,
 		isNullable: options.isNullable,

--- a/packages/xml-poto/src/decorators/xml-text.ts
+++ b/packages/xml-poto/src/decorators/xml-text.ts
@@ -102,6 +102,7 @@ export function XmlText(
 		const textMetadata: XmlTextMetadata = {
 			converter: options.converter,
 			required: options.required ?? false,
+			requiredExplicitlyFalse: options.required === false || undefined,
 			dataType: options.dataType,
 			useCDATA: options.useCDATA,
 		};

--- a/packages/xml-poto/src/serialization-options.ts
+++ b/packages/xml-poto/src/serialization-options.ts
@@ -52,6 +52,8 @@ export interface SerializationOptions {
 	emptyElementStyle?: "self-closing" | "explicit";
 	/** Throw error if nested objects with are not properly instantiated via type option - default: false */
 	strictValidation?: boolean;
+	/** Treat all @XmlElement, @XmlAttribute, @XmlArray and @XmlText properties as required unless required: false is explicitly set - default: false */
+	requireAllByDefault?: boolean;
 }
 
 /**
@@ -70,4 +72,5 @@ export const DEFAULT_SERIALIZATION_OPTIONS: Required<
 	useXsiType: false,
 	emptyElementStyle: "self-closing",
 	strictValidation: false,
+	requireAllByDefault: false,
 };

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -314,7 +314,9 @@ export class XmlMappingUtil {
 			if (value === undefined && attrMetadata.defaultValue !== undefined) {
 				value = attrMetadata.defaultValue;
 			}
-			if (value === undefined && attrMetadata.required) {
+			const isAttrRequired =
+				attrMetadata.required || (this.options.requireAllByDefault && !attrMetadata.requiredExplicitlyFalse);
+			if (value === undefined && isAttrRequired) {
 				throw new Error(`Required attribute '${attributeName}' is missing`);
 			}
 			if (value !== undefined) {
@@ -1024,7 +1026,9 @@ export class XmlMappingUtil {
 	private checkRequiredElements(data: any, fieldElementMetadata: Record<string, XmlElementMetadata>): void {
 		for (const propertyKey in fieldElementMetadata) {
 			const fieldMetadata = fieldElementMetadata[propertyKey];
-			if (fieldMetadata.required && fieldMetadata.defaultValue === undefined) {
+			const isRequired =
+				fieldMetadata.required || (this.options.requireAllByDefault && !fieldMetadata.requiredExplicitlyFalse);
+			if (isRequired && fieldMetadata.defaultValue === undefined) {
 				const xmlName = this.namespaceUtil.buildElementName(fieldMetadata);
 				if (data[xmlName] === undefined) {
 					throw new Error(`Required element '${fieldMetadata.name}' is missing`);
@@ -1063,7 +1067,8 @@ export class XmlMappingUtil {
 			const metadataArray = allArrayMetadata[propertyKey];
 			if (!metadataArray || metadataArray.length === 0) continue;
 			const metadata = metadataArray[0];
-			if (!metadata.required || metadata.defaultValue !== undefined) continue;
+			const isRequired = metadata.required || (this.options.requireAllByDefault && !metadata.requiredExplicitlyFalse);
+			if (!isRequired || metadata.defaultValue !== undefined) continue;
 
 			if (!foundProperties.has(propertyKey)) {
 				const name = metadata.containerName ?? metadata.itemName ?? propertyKey;

--- a/packages/xml-poto/src/xml-decorator-serializer.ts
+++ b/packages/xml-poto/src/xml-decorator-serializer.ts
@@ -19,34 +19,37 @@ export class XmlDecoratorSerializer {
 	 * Creates a new XmlDecoratorSerializer to convert between TypeScript objects and XML strings.
 	 *
 	 * The serializer uses decorator metadata from your classes to handle serialization and
-	 * deserialization. Configure XML generation options like formatting, namespaces, DOCTYPE,
-	 * processing instructions, and empty element syntax.
+	 * deserialization. Configure XML generation options like DOCTYPE, processing instructions,
+	 * empty element syntax, and validation behaviour.
 	 *
 	 * @param options Configuration options for XML serialization
-	 * @param options.indent - Indentation string for formatted output (default: no indentation)
-	 * @param options.newLine - Line break character(s) for formatted output (default: no line breaks)
-	 * @param options.xmlDeclaration - Whether to include XML declaration (default: true)
-	 * @param options.encoding - Character encoding for XML declaration (default: 'UTF-8')
-	 * @param options.standalone - Standalone attribute for XML declaration
-	 * @param options.processingInstructions - Array of processing instructions to include
-	 * @param options.docType - DOCTYPE declaration configuration
-	 * @param options.emptyElementStyle - How to serialize empty elements: 'self-closing' (default) or 'explicit'
-	 * @param options.defaultNamespace - Default XML namespace URI
-	 * @param options.namespacePrefixes - Map of namespace URIs to prefixes
+	 * @param options.omitXmlDeclaration - Suppress the `<?xml?>` declaration entirely (default: false)
+	 * @param options.xmlVersion - XML version written in the declaration (default: `"1.0"`)
+	 * @param options.encoding - Character encoding written in the declaration (default: `"UTF-8"`)
+	 * @param options.standalone - Standalone attribute for the XML declaration (`true` → `"yes"`, `false` → `"no"`)
+	 * @param options.processingInstructions - Processing instructions to insert after the XML declaration
+	 * @param options.docType - DOCTYPE declaration to insert before the root element
+	 * @param options.emptyElementStyle - How to render empty elements: `'self-closing'` (default) or `'explicit'`
+	 * @param options.ignoreAttributes - Skip all XML attributes during parsing/serialization (default: false)
+	 * @param options.attributeNamePrefix - Prefix added to attribute keys in the intermediate object (default: `"@_"`)
+	 * @param options.textNodeName - Key used for text content in mixed-content elements (default: `"#text"`)
+	 * @param options.omitNullValues - Skip `null`/`undefined` values instead of writing empty elements (default: false)
+	 * @param options.useXsiType - Emit `xsi:type` attributes for polymorphic types (default: false)
+	 * @param options.strictValidation - Throw when a nested object is not properly instantiated (i.e. missing a `type` option or `@XmlDynamic`) (default: false)
+	 * @param options.requireAllByDefault - Treat every `@XmlElement`, `@XmlAttribute`, `@XmlArray` and `@XmlText` property as required during deserialization unless `required: false` is explicitly set on the decorator (default: false)
 	 *
 	 * @example
 	 * ```
-	 * // Basic serializer with no formatting
+	 * // Basic serializer
 	 * const serializer = new XmlDecoratorSerializer();
 	 * ```
 	 *
 	 * @example
 	 * ```
-	 * // Formatted output with indentation
-	 * const prettySerializer = new XmlDecoratorSerializer({
-	 *   indent: '  ',
-	 *   newLine: '\n',
-	 *   xmlDeclaration: true
+	 * // Suppress XML declaration, use explicit empty-element syntax
+	 * const serializer = new XmlDecoratorSerializer({
+	 *   omitXmlDeclaration: true,
+	 *   emptyElementStyle: 'explicit'
 	 * });
 	 * ```
 	 *
@@ -54,30 +57,33 @@ export class XmlDecoratorSerializer {
 	 * ```
 	 * // With DOCTYPE and processing instructions
 	 * const advancedSerializer = new XmlDecoratorSerializer({
-	 *   indent: '\t',
-	 *   newLine: '\n',
 	 *   processingInstructions: [
-	 *     { target: 'xml-stylesheet', content: 'type="text/xsl" href="style.xsl"' }
+	 *     { target: 'xml-stylesheet', data: 'type="text/xsl" href="style.xsl"' }
 	 *   ],
 	 *   docType: {
-	 *     name: 'document',
+	 *     rootElement: 'document',
 	 *     publicId: '-//W3C//DTD XHTML 1.0 Strict//EN',
 	 *     systemId: 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'
-	 *   },
-	 *   emptyElementStyle: 'explicit'
+	 *   }
 	 * });
 	 * ```
 	 *
 	 * @example
 	 * ```
-	 * // With namespaces
-	 * const nsSerializer = new XmlDecoratorSerializer({
-	 *   defaultNamespace: 'http://example.com/schema',
-	 *   namespacePrefixes: {
-	 *     'http://www.w3.org/2001/XMLSchema': 'xs',
-	 *     'http://example.com/custom': 'custom'
-	 *   }
-	 * });
+	 * // Require all decorated properties to be present in XML input
+	 * const strictSerializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+	 *
+	 * @XmlRoot({ name: 'config' })
+	 * class Config {
+	 *   @XmlElement({ name: 'host' })            // required (throws if absent)
+	 *   host?: string;
+	 *
+	 *   @XmlElement({ name: 'port', required: false })  // explicitly optional
+	 *   port?: number;
+	 * }
+	 *
+	 * strictSerializer.fromXml('<config><host>localhost</host></config>', Config);
+	 * // → Config { host: 'localhost', port: undefined }
 	 * ```
 	 */
 	constructor(options: SerializationOptions = {}) {
@@ -271,10 +277,10 @@ export class XmlDecoratorSerializer {
 	 * // With DOCTYPE and processing instructions
 	 * const advancedSerializer = new XmlDecoratorSerializer({
 	 *   processingInstructions: [
-	 *     { target: 'xml-stylesheet', content: 'type="text/xsl" href="style.xsl"' }
+	 *     { target: 'xml-stylesheet', data: 'type="text/xsl" href="style.xsl"' }
 	 *   ],
 	 *   docType: {
-	 *     name: 'document',
+	 *     rootElement: 'document',
 	 *     systemId: 'http://example.com/dtd/document.dtd'
 	 *   }
 	 * });

--- a/packages/xml-poto/tests/serialization/strict-validation.test.ts
+++ b/packages/xml-poto/tests/serialization/strict-validation.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable typescript/no-explicit-any, typescript/explicit-function-return-type -- Test file with dynamic mock data */
 import { describe, expect, it } from "vitest";
 
-import { XmlDynamic, XmlElement, XmlRoot } from "../../src/decorators";
+import { XmlArray, XmlAttribute, XmlDynamic, XmlElement, XmlRoot } from "../../src/decorators";
 import { DynamicElement } from "../../src/query/dynamic-element";
 import { XmlDecoratorSerializer } from "../../src/xml-decorator-serializer";
 
@@ -482,6 +482,262 @@ describe("Strict Validation (strictValidation option)", () => {
 			expect(() => {
 				strictSerializer.fromXml(xml, Config);
 			}).toThrow(/Strict Validation Error.*Property 'settings' is not properly instantiated/);
+		});
+	});
+
+	describe("requireAllByDefault option", () => {
+		it("should throw when an @XmlElement is absent and required: false is not set", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host" })
+				host!: string;
+
+				@XmlElement({ name: "port" })
+				port!: number;
+			}
+
+			const xml = `<config><host>localhost</host></config>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+
+			expect(() => {
+				serializer.fromXml(xml, Config);
+			}).toThrow(/Required element 'port' is missing/);
+		});
+
+		it("should NOT throw when required: false is explicitly set on the absent element", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host" })
+				host!: string;
+
+				@XmlElement({ name: "port", required: false })
+				port?: number;
+			}
+
+			const xml = `<config><host>localhost</host></config>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+
+			expect(() => {
+				const result = serializer.fromXml(xml, Config);
+				expect(result.host).toBe("localhost");
+				expect(result.port).toBeUndefined();
+			}).not.toThrow();
+		});
+
+		it("should NOT throw when all elements are present", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host" })
+				host!: string;
+
+				@XmlElement({ name: "port" })
+				port!: number;
+			}
+
+			const xml = `<config><host>localhost</host><port>8080</port></config>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+
+			expect(() => {
+				const result = serializer.fromXml(xml, Config);
+				expect(result.host).toBe("localhost");
+				expect(result.port).toBe(8080);
+			}).not.toThrow();
+		});
+
+		it("should throw for a missing @XmlAttribute when requireAllByDefault is true", () => {
+			@XmlRoot({ name: "element" })
+			class Element {
+				@XmlAttribute({ name: "id" })
+				id!: string;
+
+				@XmlElement({ name: "value", required: false })
+				value?: string;
+			}
+
+			const xml = `<element><value>test</value></element>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+
+			expect(() => {
+				serializer.fromXml(xml, Element);
+			}).toThrow(/Required attribute 'id' is missing/);
+		});
+
+		it("should NOT throw for an absent @XmlAttribute with required: false", () => {
+			@XmlRoot({ name: "element" })
+			class Element {
+				@XmlAttribute({ name: "id", required: false })
+				id?: string;
+
+				@XmlElement({ name: "value", required: false })
+				value?: string;
+			}
+
+			const xml = `<element><value>test</value></element>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+
+			expect(() => {
+				const result = serializer.fromXml(xml, Element);
+				expect(result.id).toBeUndefined();
+				expect(result.value).toBe("test");
+			}).not.toThrow();
+		});
+
+		it("should NOT change behavior when requireAllByDefault is false (default)", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host" })
+				host?: string;
+
+				@XmlElement({ name: "port" })
+				port?: number;
+			}
+
+			// Both elements absent - default mode never throws for non-required elements
+			const xml = `<config></config>`;
+			const serializer = new XmlDecoratorSerializer();
+
+			expect(() => {
+				const result = serializer.fromXml(xml, Config);
+				expect(result.host).toBeUndefined();
+				expect(result.port).toBeUndefined();
+			}).not.toThrow();
+		});
+
+		it("should still throw when field has a TypeScript initializer (= '') but no defaultValue in decorator", () => {
+			// A field initializer like `= ""` is a TypeScript-only construct.
+			// The decorator has no knowledge of it, so the required check still fires.
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host" })
+				host: string = ""; // initializer does NOT suppress the required check
+
+				@XmlElement({ name: "port" })
+				port: number = 0; // same — initializer is invisible to the decorator
+			}
+
+			const xml = `<config></config>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+
+			expect(() => {
+				serializer.fromXml(xml, Config);
+			}).toThrow(/Required element 'host' is missing|Required element 'port' is missing/);
+		});
+
+		it("should NOT throw when element has a defaultValue even without required: false", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host" })
+				host!: string;
+
+				@XmlElement({ name: "port", defaultValue: 3000 })
+				port: number = 3000;
+			}
+
+			// port is absent but has defaultValue - should not throw
+			const xml = `<config><host>localhost</host></config>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+
+			expect(() => {
+				const result = serializer.fromXml(xml, Config);
+				expect(result.host).toBe("localhost");
+				expect(result.port).toBe(3000);
+			}).not.toThrow();
+		});
+
+		it("should throw for a missing @XmlArray when requireAllByDefault is true", () => {
+			@XmlRoot({ name: "list" })
+			class List {
+				@XmlArray({ containerName: "items", itemName: "item" })
+				items!: string[];
+
+				@XmlElement({ name: "title", required: false })
+				title?: string;
+			}
+
+			const xml = `<list><title>My List</title></list>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+
+			expect(() => {
+				serializer.fromXml(xml, List);
+			}).toThrow(/Required array 'items' is missing/);
+		});
+
+		it("should NOT throw for a missing @XmlArray with required: false", () => {
+			@XmlRoot({ name: "list" })
+			class List {
+				@XmlArray({ containerName: "items", itemName: "item", required: false })
+				items?: string[];
+
+				@XmlElement({ name: "title", required: false })
+				title?: string;
+			}
+
+			const xml = `<list><title>My List</title></list>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true });
+
+			expect(() => {
+				const result = serializer.fromXml(xml, List);
+				expect(result.title).toBe("My List");
+				expect(result.items).toBeUndefined();
+			}).not.toThrow();
+		});
+
+		it("should work combined with strictValidation", () => {
+			@XmlElement({ name: "address" })
+			class Address {
+				@XmlElement({ name: "street" })
+				street!: string;
+
+				@XmlElement({ name: "city", required: false })
+				city?: string;
+			}
+
+			@XmlRoot({ name: "person" })
+			class Person {
+				@XmlElement({ name: "name" })
+				name!: string;
+
+				@XmlElement({ name: "address", type: Address })
+				address!: Address;
+			}
+
+			const xml = `<person><name>Alice</name><address><street>Main St</street></address></person>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true, strictValidation: true });
+
+			expect(() => {
+				const result = serializer.fromXml(xml, Person);
+				expect(result.name).toBe("Alice");
+				expect(result.address.street).toBe("Main St");
+				expect(result.address.city).toBeUndefined();
+			}).not.toThrow();
+		});
+
+		it("should throw when a nested required element is missing even with strictValidation", () => {
+			@XmlElement({ name: "address" })
+			class Address {
+				@XmlElement({ name: "street" })
+				street!: string;
+
+				@XmlElement({ name: "city", required: false })
+				city?: string;
+			}
+
+			@XmlRoot({ name: "person" })
+			class Person {
+				@XmlElement({ name: "name" })
+				name!: string;
+
+				@XmlElement({ name: "address", type: Address })
+				address!: Address;
+			}
+
+			// address is absent — required by default
+			const xml = `<person><name>Alice</name></person>`;
+			const serializer = new XmlDecoratorSerializer({ requireAllByDefault: true, strictValidation: true });
+
+			expect(() => {
+				serializer.fromXml(xml, Person);
+			}).toThrow(/Required element 'address' is missing/);
 		});
 	});
 });


### PR DESCRIPTION
Add a new `requireAllByDefault` option to the XML serialization process. When enabled, this option treats all decorated fields as required unless explicitly marked as optional. This change simplifies the requirement management for XML elements, attributes, and arrays, allowing for a more streamlined validation approach. Key behaviors include the ability to opt-out individual fields and the interaction with existing `defaultValue` settings. This enhancement supports stricter validation without altering existing functionality by default.