### PR TITLE
Add strict validation for required element properties after deserialization

### DIFF
--- a/.changeset/wise-carpets-grin.md
+++ b/.changeset/wise-carpets-grin.md
@@ -1,0 +1,7 @@
+---
+"@cerios/xml-poto": patch
+---
+
+Fix `strictValidation` not checking required property values after deserialization.
+
+When `strictValidation: true`, a new post-deserialization check now throws a `[Strict Validation Error]` if a required `@XmlElement` property resolves to `null` or `undefined` on the instance (e.g. when a `transform.deserialize` function returns a nullish value). Properties with a `defaultValue` are excluded from this check.

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -1073,6 +1073,27 @@ export class XmlMappingUtil {
 	}
 
 	/**
+	 * Check that required element properties have non-null/undefined values on the instance after deserialization.
+	 * This is a post-deserialization check that complements checkRequiredElements (which checks raw XML data).
+	 */
+	private validateRequiredElementValues(instance: any, fieldElementMetadata: Record<string, XmlElementMetadata>): void {
+		for (const propertyKey in fieldElementMetadata) {
+			const fieldMetadata = fieldElementMetadata[propertyKey];
+			if (!fieldMetadata.required || fieldMetadata.defaultValue !== undefined) continue;
+
+			const value = instance[propertyKey];
+			if (value === undefined || value === null) {
+				throw new Error(
+					`[Strict Validation Error] Required property '${fieldMetadata.name}' has no value after deserialization.\n\n` +
+						`The property '${propertyKey}' is marked as required but resolved to ${value === null ? "null" : "undefined"} ` +
+						`after parsing the XML.\n` +
+						`Ensure the XML contains a valid '${fieldMetadata.name}' element with a non-empty value.`,
+				);
+			}
+		}
+	}
+
+	/**
 	 * Check that required arrays deserialize to actual arrays.
 	 */
 	private validateRequiredArrayValues(instance: any, allArrayMetadata: Record<string, XmlArrayMetadata[]>): void {
@@ -1120,6 +1141,7 @@ export class XmlMappingUtil {
 			this.validateExtraFields(targetClass, data, fieldElementMetadata, allArrayMetadata, xmlToPropertyMap);
 		}
 
+		this.validateRequiredElementValues(instance, fieldElementMetadata);
 		this.validateRequiredArrayValues(instance, allArrayMetadata);
 
 		this.validatePropertyInstantiation(

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -1078,8 +1078,10 @@ export class XmlMappingUtil {
 	}
 
 	/**
-	 * Check that required element properties have non-null/undefined values on the instance after deserialization.
+	 * Check that required element properties have non-null/undefined/empty values on the instance after deserialization.
 	 * This is a post-deserialization check that complements checkRequiredElements (which checks raw XML data).
+	 * Empty string ("") is also rejected because self-closing (<tag/>) and explicitly empty (<tag></tag>) elements
+	 * both produce "" for primitive fields, which is not a meaningful value for a required property.
 	 */
 	private validateRequiredElementValues(instance: any, fieldElementMetadata: Record<string, XmlElementMetadata>): void {
 		for (const propertyKey in fieldElementMetadata) {
@@ -1087,10 +1089,12 @@ export class XmlMappingUtil {
 			if (!fieldMetadata.required || fieldMetadata.defaultValue !== undefined) continue;
 
 			const value = instance[propertyKey];
-			if (value === undefined || value === null) {
+			if (value === undefined || value === null || value === "") {
+				const reason =
+					value === null ? "null" : value === "" ? "an empty string (empty or self-closing XML element)" : "undefined";
 				throw new Error(
 					`[Strict Validation Error] Required property '${fieldMetadata.name}' has no value after deserialization.\n\n` +
-						`The property '${propertyKey}' is marked as required but resolved to ${value === null ? "null" : "undefined"} ` +
+						`The property '${propertyKey}' is marked as required but resolved to ${reason} ` +
 						`after parsing the XML.\n` +
 						`Ensure the XML contains a valid '${fieldMetadata.name}' element with a non-empty value.`,
 				);

--- a/packages/xml-poto/tests/serialization/strict-validation.test.ts
+++ b/packages/xml-poto/tests/serialization/strict-validation.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable typescript/no-explicit-any, typescript/explicit-function-return-type -- Test file with dynamic mock data */
 import { describe, expect, it } from "vitest";
 
-import { XmlDynamic, XmlElement, XmlRoot } from "../../src/decorators";
+import { XmlAttribute, XmlDynamic, XmlElement, XmlRoot } from "../../src/decorators";
 import { DynamicElement } from "../../src/query/dynamic-element";
 import { XmlDecoratorSerializer } from "../../src/xml-decorator-serializer";
 
@@ -482,6 +482,188 @@ describe("Strict Validation (strictValidation option)", () => {
 			expect(() => {
 				strictSerializer.fromXml(xml, Config);
 			}).toThrow(/Strict Validation Error.*Property 'settings' is not properly instantiated/);
+		});
+	});
+
+	describe("Required property instance-value validation (strictValidation = true)", () => {
+		it("should throw when a required @XmlElement property resolves to undefined via a transform (strict mode only)", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({
+					name: "host",
+					required: true,
+					transform: { deserialize: () => undefined as any },
+				})
+				host!: string;
+			}
+
+			// 'host' IS in the XML, but the transform returns undefined
+			const xml = `<config><host>localhost</host></config>`;
+			const strictSerializer = new XmlDecoratorSerializer({ strictValidation: true });
+
+			expect(() => {
+				strictSerializer.fromXml(xml, Config);
+			}).toThrow(/Strict Validation Error.*Required property 'host'/);
+		});
+
+		it("should throw when a required @XmlElement property resolves to null via a transform (strict mode only)", () => {
+			@XmlRoot({ name: "document" })
+			class Document {
+				@XmlElement({
+					name: "title",
+					required: true,
+					transform: { deserialize: () => null as any },
+				})
+				title!: string;
+			}
+
+			// 'title' IS in the XML, but the transform returns null
+			const xml = `<document><title>Some Title</title></document>`;
+			const strictSerializer = new XmlDecoratorSerializer({ strictValidation: true });
+
+			expect(() => {
+				strictSerializer.fromXml(xml, Document);
+			}).toThrow(/Strict Validation Error.*Required property 'title'/);
+		});
+
+		it("should NOT throw when all required @XmlElement properties have values", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host", required: true })
+				host: string = "";
+
+				@XmlElement({ name: "port", required: true })
+				port: number = 0;
+			}
+
+			const xml = `<config><host>localhost</host><port>8080</port></config>`;
+			const strictSerializer = new XmlDecoratorSerializer({ strictValidation: true });
+
+			expect(() => {
+				const result = strictSerializer.fromXml(xml, Config);
+				expect(result.host).toBe("localhost");
+				expect(result.port).toBe(8080);
+			}).not.toThrow();
+		});
+
+		it("should NOT throw when an optional @XmlElement property is absent", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host", required: true })
+				host: string = "";
+
+				@XmlElement({ name: "description" })
+				description?: string;
+			}
+
+			// description is absent but it is not required
+			const xml = `<config><host>localhost</host></config>`;
+			const strictSerializer = new XmlDecoratorSerializer({ strictValidation: true });
+
+			expect(() => {
+				const result = strictSerializer.fromXml(xml, Config);
+				expect(result.host).toBe("localhost");
+				expect(result.description).toBeUndefined();
+			}).not.toThrow();
+		});
+
+		it("should NOT throw when a required property has a defaultValue set", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host", required: true, defaultValue: "localhost" })
+				host: string = "localhost";
+			}
+
+			// host absent from XML but defaultValue is applied
+			const xml = `<config></config>`;
+			const strictSerializer = new XmlDecoratorSerializer({ strictValidation: true });
+
+			expect(() => {
+				const result = strictSerializer.fromXml(xml, Config);
+				expect(result.host).toBe("localhost");
+			}).not.toThrow();
+		});
+
+		it("should include the property name and [Strict Validation Error] prefix when transform returns null", () => {
+			@XmlRoot({ name: "user" })
+			class User {
+				@XmlElement({
+					name: "email",
+					required: true,
+					transform: { deserialize: () => null as any },
+				})
+				email!: string;
+			}
+
+			const xml = `<user><email>user@example.com</email></user>`;
+			const strictSerializer = new XmlDecoratorSerializer({ strictValidation: true });
+
+			let error: Error | undefined;
+			try {
+				strictSerializer.fromXml(xml, User);
+			} catch (e: any) {
+				error = e;
+			}
+
+			expect(error).toBeDefined();
+			expect(error?.message).toContain("[Strict Validation Error]");
+			expect(error?.message).toContain("email");
+		});
+
+		it("should NOT throw with the same null-returning transform when strictValidation is false", () => {
+			// Without strictValidation, validateRequiredElementValues is not called so null is accepted
+			@XmlRoot({ name: "user" })
+			class User {
+				@XmlElement({
+					name: "email",
+					required: true,
+					transform: { deserialize: () => null as any },
+				})
+				email!: string;
+			}
+
+			const xml = `<user><email>user@example.com</email></user>`;
+			const lenientSerializer = new XmlDecoratorSerializer();
+
+			expect(() => {
+				lenientSerializer.fromXml(xml, User);
+			}).not.toThrow();
+		});
+
+		it("should still throw 'Required element is missing' (non-strict check) when element is absent from XML", () => {
+			// This confirms checkRequiredElements still fires in both strict and non-strict mode
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host", required: true })
+				host!: string;
+			}
+
+			const xml = `<config></config>`;
+
+			for (const serializer of [new XmlDecoratorSerializer({ strictValidation: true }), new XmlDecoratorSerializer()]) {
+				expect(() => {
+					serializer.fromXml(xml, Config);
+				}).toThrow(/Required element 'host' is missing/);
+			}
+		});
+
+		it("should validate required attributes in strict mode", () => {
+			@XmlRoot({ name: "element" })
+			class Element {
+				@XmlAttribute({ name: "id", required: true })
+				id!: string;
+
+				@XmlElement({ name: "value" })
+				value: string = "";
+			}
+
+			// Attribute is missing
+			const xml = `<element><value>test</value></element>`;
+			const strictSerializer = new XmlDecoratorSerializer({ strictValidation: true });
+
+			expect(() => {
+				strictSerializer.fromXml(xml, Element);
+			}).toThrow(/Required attribute 'id' is missing/);
 		});
 	});
 });

--- a/packages/xml-poto/tests/serialization/strict-validation.test.ts
+++ b/packages/xml-poto/tests/serialization/strict-validation.test.ts
@@ -665,6 +665,70 @@ describe("Strict Validation (strictValidation option)", () => {
 				strictSerializer.fromXml(xml, Element);
 			}).toThrow(/Required attribute 'id' is missing/);
 		});
+
+		it("should throw when a required @XmlElement is a self-closing tag (strict mode only)", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host", required: true })
+				host!: string;
+			}
+
+			// Self-closing <host/> is present in the XML but has no content — resolves to ""
+			const xml = `<config><host/></config>`;
+			const strictSerializer = new XmlDecoratorSerializer({ strictValidation: true });
+
+			expect(() => {
+				strictSerializer.fromXml(xml, Config);
+			}).toThrow(/Strict Validation Error.*Required property 'host'/);
+		});
+
+		it("should throw when a required @XmlElement is an explicitly empty tag (strict mode only)", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host", required: true })
+				host!: string;
+			}
+
+			// <host></host> is present but has no content — also resolves to ""
+			const xml = `<config><host></host></config>`;
+			const strictSerializer = new XmlDecoratorSerializer({ strictValidation: true });
+
+			expect(() => {
+				strictSerializer.fromXml(xml, Config);
+			}).toThrow(/Strict Validation Error.*Required property 'host'/);
+		});
+
+		it("should NOT throw for self-closing tag on a required property when strictValidation is false", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host", required: true })
+				host!: string;
+			}
+
+			// Without strict mode, empty string is accepted (no post-deserialization value check)
+			const xml = `<config><host/></config>`;
+			const lenientSerializer = new XmlDecoratorSerializer();
+
+			expect(() => {
+				lenientSerializer.fromXml(xml, Config);
+			}).not.toThrow();
+		});
+
+		it("should NOT throw for self-closing tag when required property has a defaultValue", () => {
+			@XmlRoot({ name: "config" })
+			class Config {
+				@XmlElement({ name: "host", required: true, defaultValue: "localhost" })
+				host: string = "localhost";
+			}
+
+			// Self-closing tag — defaultValue exempts it from the empty check
+			const xml = `<config><host/></config>`;
+			const strictSerializer = new XmlDecoratorSerializer({ strictValidation: true });
+
+			expect(() => {
+				strictSerializer.fromXml(xml, Config);
+			}).not.toThrow();
+		});
 	});
 
 	describe("requireAllByDefault option", () => {


### PR DESCRIPTION
Implement a post-deserialization check that ensures required properties are not null or undefined when `strictValidation` is enabled. This enhancement throws a `[Strict Validation Error]` for any required `@XmlElement` property that fails this validation. Exempt properties with a `defaultValue` from this check. Additional tests confirm the expected behavior in various scenarios.