### PR TITLE
Enhance error messages for missing required attributes

### DIFF
--- a/.changeset/red-views-report.md
+++ b/.changeset/red-views-report.md
@@ -1,0 +1,5 @@
+---
+"@cerios/xml-poto": patch
+---
+
+Improved error message for missing required attributes to include the parent element class name (e.g. `Required attribute 'id' is missing in element 'MyClass'`).

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -239,7 +239,7 @@ export class XmlMappingUtil {
 
 		const foundProperties = new Set<string>();
 
-		this.mapAttributes(instance, data, attributeMetadata, ignoredProps, foundProperties);
+		this.mapAttributes(instance, data, targetClass, attributeMetadata, ignoredProps, foundProperties);
 		this.mapTextContent(instance, data, textMetadata);
 		this.mapComments(
 			instance,
@@ -299,6 +299,7 @@ export class XmlMappingUtil {
 	private mapAttributes(
 		instance: any,
 		data: any,
+		targetClass: new () => any,
 		attributeMetadata: Record<string, XmlAttributeMetadata>,
 		ignoredProps: Set<string>,
 		foundProperties: Set<string>,
@@ -317,7 +318,8 @@ export class XmlMappingUtil {
 			const isAttrRequired =
 				attrMetadata.required || (this.options.requireAllByDefault && !attrMetadata.requiredExplicitlyFalse);
 			if (value === undefined && isAttrRequired) {
-				throw new Error(`Required attribute '${attributeName}' is missing`);
+				const className = targetClass.name || "Unknown";
+				throw new Error(`Required attribute '${attributeName}' is missing in element '${className}'`);
 			}
 			if (value !== undefined) {
 				value = XmlValidationUtil.applyConverter(value, attrMetadata.converter, "deserialize");

--- a/packages/xml-poto/tests/serialization/strict-validation.test.ts
+++ b/packages/xml-poto/tests/serialization/strict-validation.test.ts
@@ -663,7 +663,7 @@ describe("Strict Validation (strictValidation option)", () => {
 
 			expect(() => {
 				strictSerializer.fromXml(xml, Element);
-			}).toThrow(/Required attribute 'id' is missing/);
+			}).toThrow(/Required attribute 'id' is missing in element 'Element'/);
 		});
 
 		it("should throw when a required @XmlElement is a self-closing tag (strict mode only)", () => {
@@ -805,9 +805,8 @@ describe("Strict Validation (strictValidation option)", () => {
 
 			expect(() => {
 				serializer.fromXml(xml, Element);
-			}).toThrow(/Required attribute 'id' is missing/);
+			}).toThrow(/Required attribute 'id' is missing in element 'Element'/);
 		});
-
 		it("should NOT throw for an absent @XmlAttribute with required: false", () => {
 			@XmlRoot({ name: "element" })
 			class Element {

--- a/packages/xml-poto/tests/utils/xml-mapping-util.test.ts
+++ b/packages/xml-poto/tests/utils/xml-mapping-util.test.ts
@@ -57,7 +57,7 @@ describe("XmlMappingUtil", () => {
 
 				const data = {};
 
-				expect(() => util.mapToObject(data, Person)).toThrow("Required attribute 'id' is missing");
+				expect(() => util.mapToObject(data, Person)).toThrow("Required attribute 'id' is missing in element 'Person'");
 			});
 
 			it("should validate attribute patterns", () => {


### PR DESCRIPTION
Improve error messages to include the parent element class name when required attributes are missing, providing clearer context for developers.