### PR TITLE
Enhance error messages to include parent element class name

### DIFF
--- a/.changeset/lovely-tips-tickle.md
+++ b/.changeset/lovely-tips-tickle.md
@@ -1,0 +1,5 @@
+---
+"@cerios/xml-poto": patch
+---
+
+Error messages for missing required elements, arrays, attributes, text content, comments, and queryable elements now include the parent element class name (e.g. `Required element 'name' is missing in element 'Book'`).

--- a/.changeset/lovely-tips-tickle.md
+++ b/.changeset/lovely-tips-tickle.md
@@ -2,4 +2,4 @@
 "@cerios/xml-poto": patch
 ---
 
-Error messages for missing required elements, arrays, attributes, text content, comments, and queryable elements now include the parent element class name (e.g. `Required element 'name' is missing in element 'Book'`).
+Error messages for missing required elements, arrays, attributes, and queryable elements now include the parent element class name (e.g. `Required element 'name' is missing in element 'Book'`).

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -240,7 +240,7 @@ export class XmlMappingUtil {
 		const foundProperties = new Set<string>();
 
 		this.mapAttributes(instance, data, targetClass, attributeMetadata, ignoredProps, foundProperties);
-		this.mapTextContent(instance, data, textMetadata, targetClass);
+		this.mapTextContent(instance, data, textMetadata);
 		this.mapComments(
 			instance,
 			targetClass,
@@ -339,7 +339,6 @@ export class XmlMappingUtil {
 		instance: any,
 		data: any,
 		textMetadata: { propertyKey: string; metadata: any } | undefined,
-		targetClass: new () => any,
 	): void {
 		if (!textMetadata) return;
 
@@ -365,8 +364,7 @@ export class XmlMappingUtil {
 				textMetadata.propertyKey,
 			);
 		} else if (textMetadata.metadata.required) {
-			const elementName = targetClass.name || "Unknown";
-			throw new Error(`Required text content is missing in element '${elementName}'`);
+			throw new Error(`Required text content is missing`);
 		}
 	}
 
@@ -397,8 +395,7 @@ export class XmlMappingUtil {
 				this.assignCommentValue(instance, commentMeta, data[commentKey]);
 				foundProperties.add(commentMeta.propertyKey);
 			} else if (commentMeta.required) {
-				const elementName = targetClass.name || "Unknown";
-				throw new Error(`Required comment for '${commentMeta.targetProperty}' is missing in element '${elementName}'`);
+				throw new Error(`Required comment for '${commentMeta.targetProperty}' is missing`);
 			}
 		}
 	}
@@ -1676,8 +1673,7 @@ export class XmlMappingUtil {
 				result["#text"] = textValue;
 			}
 		} else if (textMetadata.metadata.required) {
-			const elementName = obj.constructor?.name ?? "Unknown";
-			throw new Error(`Required text content is missing in element '${elementName}'`);
+			throw new Error(`Required text content is missing`);
 		}
 	}
 
@@ -1690,8 +1686,7 @@ export class XmlMappingUtil {
 			const commentValue = obj[commentMeta.propertyKey];
 
 			if (commentMeta.required && this.isEmptyComment(commentValue)) {
-				const elementName = obj.constructor?.name ?? "Unknown";
-				throw new Error(`Required comment for '${commentMeta.targetProperty}' is missing in element '${elementName}'`);
+				throw new Error(`Required comment for '${commentMeta.targetProperty}' is missing`);
 			}
 			if (commentValue === undefined || commentValue === null) continue;
 

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -240,7 +240,7 @@ export class XmlMappingUtil {
 		const foundProperties = new Set<string>();
 
 		this.mapAttributes(instance, data, targetClass, attributeMetadata, ignoredProps, foundProperties);
-		this.mapTextContent(instance, data, textMetadata);
+		this.mapTextContent(instance, data, textMetadata, targetClass);
 		this.mapComments(
 			instance,
 			targetClass,
@@ -275,8 +275,8 @@ export class XmlMappingUtil {
 		this.applyDefaults(instance, fieldElementMetadata, foundProperties);
 		this.applyArrayDefaults(instance, allArrayMetadata, foundProperties);
 		this.mapDynamicElements(instance, targetClass, data, elementMetadata, propertyMappings, fieldElementMetadata);
-		this.checkRequiredElements(data, fieldElementMetadata);
-		this.checkRequiredArrays(allArrayMetadata, foundProperties);
+		this.checkRequiredElements(data, fieldElementMetadata, targetClass);
+		this.checkRequiredArrays(allArrayMetadata, foundProperties, targetClass);
 
 		if (this.options.strictValidation) {
 			this.performStrictValidation(
@@ -339,6 +339,7 @@ export class XmlMappingUtil {
 		instance: any,
 		data: any,
 		textMetadata: { propertyKey: string; metadata: any } | undefined,
+		targetClass: new () => any,
 	): void {
 		if (!textMetadata) return;
 
@@ -364,7 +365,8 @@ export class XmlMappingUtil {
 				textMetadata.propertyKey,
 			);
 		} else if (textMetadata.metadata.required) {
-			throw new Error(`Required text content is missing`);
+			const elementName = targetClass.name || "Unknown";
+			throw new Error(`Required text content is missing in element '${elementName}'`);
 		}
 	}
 
@@ -395,7 +397,8 @@ export class XmlMappingUtil {
 				this.assignCommentValue(instance, commentMeta, data[commentKey]);
 				foundProperties.add(commentMeta.propertyKey);
 			} else if (commentMeta.required) {
-				throw new Error(`Required comment for '${commentMeta.targetProperty}' is missing`);
+				const elementName = targetClass.name || "Unknown";
+				throw new Error(`Required comment for '${commentMeta.targetProperty}' is missing in element '${elementName}'`);
 			}
 		}
 	}
@@ -910,7 +913,8 @@ export class XmlMappingUtil {
 
 			if (dynamic.required && !elementFound) {
 				const targetName = dynamic.targetProperty ?? "root element";
-				throw new Error(`Required queryable element '${targetName}' is missing`);
+				const elementName = targetClass.name || "Unknown";
+				throw new Error(`Required queryable element '${targetName}' is missing in element '${elementName}'`);
 			}
 		}
 	}
@@ -1025,7 +1029,12 @@ export class XmlMappingUtil {
 	/**
 	 * Check for missing required elements (skip if they have default values)
 	 */
-	private checkRequiredElements(data: any, fieldElementMetadata: Record<string, XmlElementMetadata>): void {
+	private checkRequiredElements(
+		data: any,
+		fieldElementMetadata: Record<string, XmlElementMetadata>,
+		targetClass: new () => any,
+	): void {
+		const elementName = targetClass.name || "Unknown";
 		for (const propertyKey in fieldElementMetadata) {
 			const fieldMetadata = fieldElementMetadata[propertyKey];
 			const isRequired =
@@ -1033,7 +1042,7 @@ export class XmlMappingUtil {
 			if (isRequired && fieldMetadata.defaultValue === undefined) {
 				const xmlName = this.namespaceUtil.buildElementName(fieldMetadata);
 				if (data[xmlName] === undefined) {
-					throw new Error(`Required element '${fieldMetadata.name}' is missing`);
+					throw new Error(`Required element '${fieldMetadata.name}' is missing in element '${elementName}'`);
 				}
 			}
 		}
@@ -1064,7 +1073,9 @@ export class XmlMappingUtil {
 	private checkRequiredArrays(
 		allArrayMetadata: Record<string, XmlArrayMetadata[]>,
 		foundProperties: Set<string>,
+		targetClass: new () => any,
 	): void {
+		const elementName = targetClass.name || "Unknown";
 		for (const propertyKey in allArrayMetadata) {
 			const metadataArray = allArrayMetadata[propertyKey];
 			if (!metadataArray || metadataArray.length === 0) continue;
@@ -1074,7 +1085,7 @@ export class XmlMappingUtil {
 
 			if (!foundProperties.has(propertyKey)) {
 				const name = metadata.containerName ?? metadata.itemName ?? propertyKey;
-				throw new Error(`Required array '${name}' is missing`);
+				throw new Error(`Required array '${name}' is missing in element '${elementName}'`);
 			}
 		}
 	}
@@ -1107,7 +1118,12 @@ export class XmlMappingUtil {
 	/**
 	 * Check that required arrays deserialize to actual arrays.
 	 */
-	private validateRequiredArrayValues(instance: any, allArrayMetadata: Record<string, XmlArrayMetadata[]>): void {
+	private validateRequiredArrayValues(
+		instance: any,
+		allArrayMetadata: Record<string, XmlArrayMetadata[]>,
+		targetClass: new () => any,
+	): void {
+		const elementName = targetClass.name || "Unknown";
 		for (const propertyKey in allArrayMetadata) {
 			const metadataArray = allArrayMetadata[propertyKey];
 			if (!metadataArray || metadataArray.length === 0) continue;
@@ -1119,11 +1135,11 @@ export class XmlMappingUtil {
 			const name = metadata.containerName ?? metadata.itemName ?? propertyKey;
 
 			if (value === undefined) {
-				throw new Error(`Required array '${name}' is missing`);
+				throw new Error(`Required array '${name}' is missing in element '${elementName}'`);
 			}
 
 			if (!Array.isArray(value)) {
-				throw new Error(`Required array '${name}' must deserialize to an array`);
+				throw new Error(`Required array '${name}' must deserialize to an array in element '${elementName}'`);
 			}
 		}
 	}
@@ -1153,7 +1169,7 @@ export class XmlMappingUtil {
 		}
 
 		this.validateRequiredElementValues(instance, fieldElementMetadata);
-		this.validateRequiredArrayValues(instance, allArrayMetadata);
+		this.validateRequiredArrayValues(instance, allArrayMetadata, targetClass);
 
 		this.validatePropertyInstantiation(
 			instance,
@@ -1660,7 +1676,8 @@ export class XmlMappingUtil {
 				result["#text"] = textValue;
 			}
 		} else if (textMetadata.metadata.required) {
-			throw new Error(`Required text content is missing`);
+			const elementName = obj.constructor?.name ?? "Unknown";
+			throw new Error(`Required text content is missing in element '${elementName}'`);
 		}
 	}
 
@@ -1673,7 +1690,8 @@ export class XmlMappingUtil {
 			const commentValue = obj[commentMeta.propertyKey];
 
 			if (commentMeta.required && this.isEmptyComment(commentValue)) {
-				throw new Error(`Required comment for '${commentMeta.targetProperty}' is missing`);
+				const elementName = obj.constructor?.name ?? "Unknown";
+				throw new Error(`Required comment for '${commentMeta.targetProperty}' is missing in element '${elementName}'`);
 			}
 			if (commentValue === undefined || commentValue === null) continue;
 

--- a/packages/xml-poto/tests/decorators/xml-array.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-array.test.ts
@@ -454,7 +454,7 @@ describe("XmlArray decorator", () => {
 			}
 
 			const xml = "<Root></Root>";
-			expect(() => serializer.fromXml(xml, Root)).toThrow(/Required array 'Items' is missing/);
+			expect(() => serializer.fromXml(xml, Root)).toThrow(/Required array 'Items' is missing in element 'Root'/);
 		});
 
 		it("should throw when required unwrapped array is absent", () => {
@@ -465,7 +465,7 @@ describe("XmlArray decorator", () => {
 			}
 
 			const xml = "<Root></Root>";
-			expect(() => serializer.fromXml(xml, Root)).toThrow(/Required array 'Item' is missing/);
+			expect(() => serializer.fromXml(xml, Root)).toThrow(/Required array 'Item' is missing in element 'Root'/);
 		});
 
 		it("should not throw when required array has a defaultValue", () => {

--- a/packages/xml-poto/tests/decorators/xml-comment.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-comment.test.ts
@@ -185,7 +185,7 @@ describe("@XmlComment Decorator", () => {
 			const report = new Report();
 			report.data = "Some data";
 
-			expect(() => serializer.toXml(report)).toThrow("Required comment for 'data' is missing");
+			expect(() => serializer.toXml(report)).toThrow("Required comment for 'data' is missing in element 'Report'");
 		});
 
 		it("should serialize when required comment is provided", () => {
@@ -206,7 +206,9 @@ describe("@XmlComment Decorator", () => {
 				</Report>
 			`;
 
-			expect(() => serializer.fromXml(xml, Report)).toThrow("Required comment for 'data' is missing");
+			expect(() => serializer.fromXml(xml, Report)).toThrow(
+				"Required comment for 'data' is missing in element 'Report'",
+			);
 		});
 	});
 

--- a/packages/xml-poto/tests/decorators/xml-comment.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-comment.test.ts
@@ -185,7 +185,7 @@ describe("@XmlComment Decorator", () => {
 			const report = new Report();
 			report.data = "Some data";
 
-			expect(() => serializer.toXml(report)).toThrow("Required comment for 'data' is missing in element 'Report'");
+			expect(() => serializer.toXml(report)).toThrow("Required comment for 'data' is missing");
 		});
 
 		it("should serialize when required comment is provided", () => {
@@ -206,9 +206,7 @@ describe("@XmlComment Decorator", () => {
 				</Report>
 			`;
 
-			expect(() => serializer.fromXml(xml, Report)).toThrow(
-				"Required comment for 'data' is missing in element 'Report'",
-			);
+			expect(() => serializer.fromXml(xml, Report)).toThrow("Required comment for 'data' is missing");
 		});
 	});
 

--- a/packages/xml-poto/tests/decorators/xml-dynamic-options.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-dynamic-options.test.ts
@@ -38,7 +38,9 @@ describe("XmlDynamic Options", () => {
 			}
 
 			const xml = `<Document><Title>Test</Title></Document>`;
-			expect(() => serializer.fromXml(xml, Document)).toThrow("Required queryable element 'items' is missing");
+			expect(() => serializer.fromXml(xml, Document)).toThrow(
+				"Required queryable element 'items' is missing in element 'Document'",
+			);
 		});
 
 		it("should not throw when optional queryable element is missing", () => {

--- a/packages/xml-poto/tests/integration/edge-cases.test.ts
+++ b/packages/xml-poto/tests/integration/edge-cases.test.ts
@@ -470,7 +470,9 @@ describe("Integration Tests - Complex Edge Cases", () => {
 		it("should throw error for missing required element", () => {
 			const xml = '<ValidatedData code="ABC123" status="active"></ValidatedData>';
 
-			expect(() => serializer.fromXml(xml, ValidatedData)).toThrow("Required element 'Value' is missing");
+			expect(() => serializer.fromXml(xml, ValidatedData)).toThrow(
+				"Required element 'Value' is missing in element 'ValidatedData'",
+			);
 		});
 	});
 

--- a/packages/xml-poto/tests/serialization/strict-validation.test.ts
+++ b/packages/xml-poto/tests/serialization/strict-validation.test.ts
@@ -643,7 +643,7 @@ describe("Strict Validation (strictValidation option)", () => {
 			for (const serializer of [new XmlDecoratorSerializer({ strictValidation: true }), new XmlDecoratorSerializer()]) {
 				expect(() => {
 					serializer.fromXml(xml, Config);
-				}).toThrow(/Required element 'host' is missing/);
+				}).toThrow(/Required element 'host' is missing in element 'Config'/);
 			}
 		});
 
@@ -747,7 +747,7 @@ describe("Strict Validation (strictValidation option)", () => {
 
 			expect(() => {
 				serializer.fromXml(xml, Config);
-			}).toThrow(/Required element 'port' is missing/);
+			}).toThrow(/Required element 'port' is missing in element 'Config'/);
 		});
 
 		it("should NOT throw when required: false is explicitly set on the absent element", () => {
@@ -865,7 +865,9 @@ describe("Strict Validation (strictValidation option)", () => {
 
 			expect(() => {
 				serializer.fromXml(xml, Config);
-			}).toThrow(/Required element 'host' is missing|Required element 'port' is missing/);
+			}).toThrow(
+				/Required element 'host' is missing in element 'Config'|Required element 'port' is missing in element 'Config'/,
+			);
 		});
 
 		it("should NOT throw when element has a defaultValue even without required: false", () => {
@@ -904,7 +906,7 @@ describe("Strict Validation (strictValidation option)", () => {
 
 			expect(() => {
 				serializer.fromXml(xml, List);
-			}).toThrow(/Required array 'items' is missing/);
+			}).toThrow(/Required array 'items' is missing in element 'List'/);
 		});
 
 		it("should NOT throw for a missing @XmlArray with required: false", () => {
@@ -982,7 +984,7 @@ describe("Strict Validation (strictValidation option)", () => {
 
 			expect(() => {
 				serializer.fromXml(xml, Person);
-			}).toThrow(/Required element 'address' is missing/);
+			}).toThrow(/Required element 'address' is missing in element 'Person'/);
 		});
 	});
 });

--- a/packages/xml-poto/tests/utils/xml-mapping-util.test.ts
+++ b/packages/xml-poto/tests/utils/xml-mapping-util.test.ts
@@ -138,7 +138,7 @@ describe("XmlMappingUtil", () => {
 
 				const data = {};
 
-				expect(() => util.mapToObject(data, Message)).toThrow("Required text content is missing");
+				expect(() => util.mapToObject(data, Message)).toThrow("Required text content is missing in element 'Message'");
 			});
 		});
 
@@ -204,7 +204,7 @@ describe("XmlMappingUtil", () => {
 
 				const data = {};
 
-				expect(() => util.mapToObject(data, Person)).toThrow("Required element 'Name' is missing");
+				expect(() => util.mapToObject(data, Person)).toThrow("Required element 'Name' is missing in element 'Person'");
 			});
 		});
 

--- a/packages/xml-poto/tests/utils/xml-mapping-util.test.ts
+++ b/packages/xml-poto/tests/utils/xml-mapping-util.test.ts
@@ -138,7 +138,7 @@ describe("XmlMappingUtil", () => {
 
 				const data = {};
 
-				expect(() => util.mapToObject(data, Message)).toThrow("Required text content is missing in element 'Message'");
+				expect(() => util.mapToObject(data, Message)).toThrow("Required text content is missing");
 			});
 		});
 


### PR DESCRIPTION
Error messages for missing required elements, arrays, attributes, text content, comments, and queryable elements now specify the parent element class name, improving clarity for developers.