### PR TITLE
Wsdl support and extra xsd validations

### DIFF
--- a/.changeset/great-hats-refuse.md
+++ b/.changeset/great-hats-refuse.md
@@ -1,0 +1,15 @@
+---
+"@cerios/xml-poto": minor
+---
+
+Add XSD validation support to the decorators and serializer:
+
+- **XSD facets on `@XmlElement`, `@XmlAttribute`, `@XmlText`, and `@XmlArray`**: `pattern`, `enumValues`, `length`, `minLength`, `maxLength`, `minInclusive`, `maxInclusive`, `minExclusive`, `maxExclusive`, `totalDigits`, `fractionDigits`, `whiteSpace`, and `fixedValue`. Facets are validated during both serialization and deserialization.
+- **Unified `validationMode` serializer option** (`"strict"` | `"warn"` | `"off"`, default `"strict"`): governs all facet validation including the pre-existing `pattern`/`enumValues` checks on `@XmlAttribute` (whose default throw behavior is unchanged but can now be relaxed). Individual rules can be tuned per rule via **`validationModeOverrides`** (e.g. `{ pattern: "warn", fixedValue: "off", choiceGroup: "warn" }`); unlisted rules follow `validationMode`. When a value violates several rules, each violation is handled by its own rule's mode.
+- **`xs:list` support**: the new `list` option on `@XmlElement`, `@XmlAttribute`, and `@XmlText` round-trips arrays as space-separated text (e.g. `<sizes>1 2 3</sizes>` ↔ `number[]`), with optional typed items via `list: { itemType: "number" }`.
+- **Choice groups (`xs:choice`)**: `choiceGroup` and `choiceRequired` options on `@XmlElement`/`@XmlArray` enforce that at most one (and, when required, at least one) member of a group is set.
+- **`minOccurs`/`maxOccurs` on `@XmlArray`**: item-count validation.
+- **`xsi:nil` round-trip**: `isNullable` elements now deserialize `xsi:nil="true"` back to `null` (previously serialize-only). Applies only when `isNullable: true` is set.
+- **`dataType` activated**: the previously inert `dataType` option now coerces values (numeric/boolean XSD types) during deserialization when the property type cannot be inferred from its runtime value (i.e. optional properties that were previously left as raw strings).
+- **`fixedValue`**: acts as a default when the value is absent and as a constraint (value must equal it) when present.
+- `@XmlText` now also deserializes text-only elements that parse to a plain primitive.

--- a/.changeset/lazy-type-refs.md
+++ b/.changeset/lazy-type-refs.md
@@ -1,0 +1,17 @@
+---
+"@cerios/xml-poto": minor
+---
+
+Add lazy type references: the `type` option on `@XmlElement`, `@XmlAttribute`, and `@XmlArray` now accepts a `() => Constructor` thunk (new `TypeRef` type, exported along with `resolveTypeRef`/`isTypeThunk`) in addition to a plain constructor.
+
+Thunks make forward, circular, and self references safe. With standard TC39 decorators, an option object like `{ type: Section }` is evaluated while the referenced class may still be in its temporal dead zone (self-recursive types, mutually referencing types, or classes declared later in the same module) and throws a `ReferenceError`. A thunk (`{ type: () => Section }`) defers the lookup until (de)serialization:
+
+```ts
+@XmlElement({ name: "Section" })
+class Section {
+	@XmlArray({ itemName: "Section", type: () => Section })
+	children?: Section[];
+}
+```
+
+Resolution is lazy with write-back caching, and registry registration (auto-discovery) for thunk-referenced classes is deferred to the first registry lookup. Plain constructor usage is unchanged. `unionTypes` intentionally still takes plain constructors (it is only used for primitive wrapper types).

--- a/.changeset/ordered-codegen-output.md
+++ b/.changeset/ordered-codegen-output.md
@@ -1,0 +1,15 @@
+---
+"@cerios/xml-poto-codegen": minor
+---
+
+Generate classes in dependency order so the output always compiles (fixes broken `per-xsd` output for XSDs that declare types before their dependencies, e.g. alphabetically ordered schemas):
+
+- **Topological sorting**: classes are now emitted dependency-first (based on `extends` bases and decorator `type:` references), with a stable order — schemas already in a valid order produce unchanged output, and independent types keep their XSD document order. Previously classes were emitted in raw document order, producing `class X used before its declaration` compile errors and runtime TDZ crashes.
+- **Circular and self references** (which no ordering can satisfy) are emitted as lazy `() => Foo` thunks in both output styles. This requires `@cerios/xml-poto` >= the release adding `TypeRef` support (published together with this change).
+- **`per-type` mode**: classes linked by an `extends` edge inside a reference cycle are now merged into one file (named after the base class), because a cyclic `extends` split across ES modules always leaves an import order that fails. All other classes keep one file each; the barrel re-exports everything as before.
+- **`xs:redefine`**: a type deriving from itself (the redefine pattern; redefines are merged like includes) no longer generates `class X extends X` — the extends clause is dropped with a coverage note.
+
+Also fixes two further compile errors surfaced by the same schemas:
+
+- Required properties typed by a named enum no longer get a mis-typed base-type initializer (`status: StatusType = ''`); they are emitted with a definite-assignment assertion (`status!: StatusType`).
+- The same element appearing in multiple `xs:choice` branches no longer generates duplicate class properties; occurrences are merged into one property that is optional unless required in every branch.

--- a/.changeset/shiny-pots-search.md
+++ b/.changeset/shiny-pots-search.md
@@ -1,0 +1,15 @@
+---
+"@cerios/xml-poto-codegen": minor
+---
+
+WSDL support and complete XSD rule coverage in generated classes:
+
+- **WSDL input**: files with a `<definitions>` root (SOAP/WSDL) are now detected automatically; all XSD schemas embedded in the WSDL `<types>` section are extracted and merged, inheriting `xmlns` declarations from the `<definitions>` root. This fixes "No XSD schema root element found" for `.xsd`/`.wsdl` files that are actually WSDL documents.
+- **Facets are now emitted and enforced**: `length`, `minLength`, `maxLength`, `minInclusive`, `maxInclusive`, `minExclusive`, `maxExclusive`, `totalDigits`, `fractionDigits`, `whiteSpace`, `pattern` (now also on elements and simpleContent, with multiple `xs:pattern` facets ORed together), and `fixed` values — all mapped to the corresponding `@cerios/xml-poto` decorator options instead of a "not enforced" warning.
+- **`xs:list`**: generated as `list` options (with typed items), including facets from the list's `itemType`.
+- **`xs:choice`**: direct choice members now share a generated `choiceGroup` (with `choiceRequired` per the choice's `minOccurs`), enforced at runtime by xml-poto.
+- **Bounded `maxOccurs`**: finite occurs bounds are emitted as `minOccurs`/`maxOccurs` on `@XmlArray`.
+- **`xs:annotation`/`xs:documentation`** becomes JSDoc on generated classes, properties, and enums.
+- **More XSD constructs**: `complexContent` restriction with `choice`/`all`/group refs, `xs:all` with `minOccurs`/nested choices, `use="prohibited"` attributes omitted, `xs:redefine` merged (with warning), `xs:notation` and identity constraints (`xs:key`/`xs:keyref`/`xs:unique`) parsed and reported as coverage notes, and explicit warnings for remote or missing `schemaLocation` references.
+
+Requires `@cerios/xml-poto` ≥ the release containing the new validation options.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     name: Lint, Type & Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: 24
           cache: "npm"
 
       - name: Install dependencies
@@ -38,11 +38,11 @@ jobs:
     name: Build Packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: 24
           cache: "npm"
 
       - name: Install dependencies
@@ -59,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: 24
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,7 +1,7 @@
 {
 	"**/*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx}": [
-		"oxlint -c .oxlintrc.json --fix --type-aware",
-		"oxfmt --config .oxfmtrc.json"
+		"oxlint -c .oxlintrc.json --fix --type-aware --no-error-on-unmatched-pattern",
+		"oxfmt --config .oxfmtrc.json --no-error-on-unmatched-pattern"
 	],
-	"**/*.{json,jsonc}": ["oxfmt --config .oxfmtrc.json"]
+	"**/*.{json,jsonc}": ["oxfmt --config .oxfmtrc.json --no-error-on-unmatched-pattern"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 			],
 			"devDependencies": {
 				"@changesets/cli": "^2.31.1",
+				"esbuild": "^0.28.1",
 				"husky": "^9.1.7",
 				"lint-staged": "^17.0.8",
 				"npm-check-updates": "^22.2.9",
@@ -444,6 +445,448 @@
 			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/external-editor": {
@@ -3114,6 +3557,48 @@
 			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
+			}
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
@@ -6303,6 +6788,7 @@
 			"devDependencies": {
 				"@arethetypeswrong/cli": "^0.18.5",
 				"@types/node": "^26.1.1",
+				"esbuild": "^0.28.1",
 				"tsdown": "^0.22.9",
 				"typescript": "^7.0.2",
 				"vitest": "4.1.10"
@@ -6325,6 +6811,7 @@
 			"devDependencies": {
 				"@cerios/xml-poto": "2.3.3",
 				"@types/node": "^26.1.1",
+				"esbuild": "^0.28.1",
 				"tsdown": "^0.22.9",
 				"typescript": "^7.0.2",
 				"vitest": "4.1.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,15 @@
 				"packages/*"
 			],
 			"devDependencies": {
-				"@changesets/cli": "^2.31.0",
+				"@changesets/cli": "^2.31.1",
 				"husky": "^9.1.7",
 				"lint-staged": "^17.0.8",
 				"npm-check-updates": "^22.2.9",
-				"oxfmt": "^0.58.0",
-				"oxlint": "^1.73.0",
+				"oxfmt": "^0.59.0",
+				"oxlint": "^1.74.0",
 				"oxlint-tsgolint": "^0.24.0",
 				"syncpack": "^15.3.2",
-				"vitest": "4.0.18"
+				"vitest": "4.1.10"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -83,58 +83,37 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/@babel/generator": {
-			"version": "8.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.3.tgz",
-			"integrity": "sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==",
+		"node_modules/@astrojs/compiler": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+			"integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@astrojs/ts-plugin": {
+			"version": "1.10.10",
+			"resolved": "https://registry.npmjs.org/@astrojs/ts-plugin/-/ts-plugin-1.10.10.tgz",
+			"integrity": "sha512-US1czRBD43THzzwSyWJwPRX9VDBYbHmJKnpJAsmqT7Uun5UYvcMNNOfDyZxp5bKTNiApvA8HrjwUhYso8CE2Iw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^8.0.0-rc.3",
-				"@babel/types": "^8.0.0-rc.3",
-				"@jridgewell/gen-mapping": "^0.3.12",
-				"@jridgewell/trace-mapping": "^0.3.28",
-				"@types/jsesc": "^2.5.0",
-				"jsesc": "^3.0.2"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
+				"@astrojs/compiler": "^2.13.1",
+				"@astrojs/yaml2ts": "^0.2.4",
+				"@jridgewell/sourcemap-codec": "^1.5.5",
+				"@volar/language-core": "~2.4.28",
+				"@volar/typescript": "~2.4.28",
+				"semver": "^7.7.4",
+				"vscode-languageserver-textdocument": "^1.0.12"
 			}
 		},
-		"node_modules/@babel/helper-string-parser": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^22.18.0 || >=24.11.0"
-			}
-		},
-		"node_modules/@babel/helper-validator-identifier": {
-			"version": "8.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.3.tgz",
-			"integrity": "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@babel/parser": {
-			"version": "8.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.3.tgz",
-			"integrity": "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==",
+		"node_modules/@astrojs/yaml2ts": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+			"integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^8.0.0-rc.3"
-			},
-			"bin": {
-				"parser": "bin/babel-parser.js"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
+				"yaml": "^2.8.3"
 			}
 		},
 		"node_modules/@babel/runtime": {
@@ -145,20 +124,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/types": {
-			"version": "8.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.3.tgz",
-			"integrity": "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-string-parser": "^8.0.0-rc.3",
-				"@babel/helper-validator-identifier": "^8.0.0-rc.3"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@braidai/lang": {
@@ -224,9 +189,9 @@
 			}
 		},
 		"node_modules/@changesets/cli": {
-			"version": "2.31.0",
-			"resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.0.tgz",
-			"integrity": "sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==",
+			"version": "2.31.1",
+			"resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.1.tgz",
+			"integrity": "sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -436,6 +401,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@emnapi/wasi-threads": "1.2.1",
 				"tslib": "^2.4.0"
@@ -448,6 +414,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -459,450 +426,9 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-arm": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-arm": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/external-editor": {
@@ -927,44 +453,12 @@
 				}
 			}
 		},
-		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			}
-		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.31",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.1.0",
-				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
 		},
 		"node_modules/@loaderkit/resolve": {
 			"version": "1.0.6",
@@ -988,6 +482,13 @@
 				"find-up": "^4.1.0",
 				"fs-extra": "^8.1.0"
 			}
+		},
+		"node_modules/@manypkg/find-root/node_modules/@types/node": {
+			"version": "12.20.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@manypkg/find-root/node_modules/fs-extra": {
 			"version": "8.1.0",
@@ -1099,9 +600,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-			"integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+			"version": "0.140.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.140.0.tgz",
+			"integrity": "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1109,9 +610,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-android-arm-eabi": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.58.0.tgz",
-			"integrity": "sha512-Uz62sHduGGPftXtILGyxdSW4PX82rUg+rfdNqhsgxe881g4rIoXlIqmZQ6HVKcF4f+F8qMhdD03Bx5u7gmeTdg==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.59.0.tgz",
+			"integrity": "sha512-bNTnfbuG7sAwb2PakMNaDukx5kXeW9duXOBeWtTOiLz3fXz3q2DlWguufPZ+c2IHEVrRXHD+M4aUgEWm841LDA==",
 			"cpu": [
 				"arm"
 			],
@@ -1126,9 +627,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-android-arm64": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.58.0.tgz",
-			"integrity": "sha512-rD0lRaJp1b+9vw6X4A2dJWKukd6X8yxiicN4JxXcXayolmUypRZxk+lKR+fVOu5q/iYc0fh5fR4bgmfOfVlbaA==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.59.0.tgz",
+			"integrity": "sha512-R/Sn7z52QtdAKNqQLLY0EK7hVMjXiz3XUlvoCFCm/60jgIzAnQtiqLKBCFaBkimCQL5rs2ezPMcicpjCsrl54Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1143,9 +644,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-darwin-arm64": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.58.0.tgz",
-			"integrity": "sha512-uzbPPk7O6M+w2K65vcQ1woga3wgP8zghjL1KOG5b6qJ8dvYHZJ1VShaslg2KOK6yQIwCQtcMCXqLBM6sqXUNTg==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.59.0.tgz",
+			"integrity": "sha512-vm/ynUqE4HjC0ZIEjmXv1UJu1/GngccQ+T+TJudTMxUxm6r+GQTg1TO3E5jJfI71pBaXxSzs1+vWHIwuilGHhw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1160,9 +661,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-darwin-x64": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.58.0.tgz",
-			"integrity": "sha512-L0nKYDxU32oxeQqJj21W9SlIMnf81VZEhyah6iDvFhf5q0oynq498Fopth7blErUJVBpVtxQ98RMCfMPqpJX6w==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.59.0.tgz",
+			"integrity": "sha512-uTtYDpLN/obfKVWGpgEc8BqYlLZBQTPz2uYEvLRy3HPZxjZ34wiFzukUBU2bf64JuCYZI//GTV1EOMmWlPjf/w==",
 			"cpu": [
 				"x64"
 			],
@@ -1177,9 +678,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-freebsd-x64": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.58.0.tgz",
-			"integrity": "sha512-woNwfD58dC5PGS9LSLSD5JYfo/EFK5iG9vhDWkcCg3q78ag7KC8bpDqgvPHrMoXpx83OLXxoSOhu6z8FsVTHlg==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.59.0.tgz",
+			"integrity": "sha512-e2UnxL/ifStSPy8ffBCDbdy595SYsGy+U1pur4G65TuMmWxAMBzYGG7atZo/3mp515p8rZdsflxVD/E1FAdPLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1194,9 +695,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.58.0.tgz",
-			"integrity": "sha512-Sqs8nMLxuQpY21NKJ1u4stPDmO5hskBCNNh2E3AdCfI1QqWtf4m+Qn4mGEIUO4KGmuq3SWc/SZ80uy5IiwTCDw==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.59.0.tgz",
+			"integrity": "sha512-LtdeZ1l0urxte3VNi3g8cocZwv1xGM1NKHSgF/fJEEVhyQmlgGh7WFWKFd/pNuO7djfvPNtNO1+MS+FEWkgVSA==",
 			"cpu": [
 				"arm"
 			],
@@ -1211,9 +712,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.58.0.tgz",
-			"integrity": "sha512-Vd4exzBI5B5hB9m22JiTQzIL23WvHo/Pe+sNXPNeBLXSP9swCBPKCEBRwKpmpQzYhlgYaCgfPcGXPKAJBRIiZQ==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.59.0.tgz",
+			"integrity": "sha512-dBTciSsj9GTMl7p+h2gMSI0hoPn2ijfc/dUsbnWsP0RbwgPl2r0C/5zkMb3Pb+gGj17LH7f1o4qLo9aes/pAvA==",
 			"cpu": [
 				"arm"
 			],
@@ -1228,9 +729,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm64-gnu": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.58.0.tgz",
-			"integrity": "sha512-bUWi5mHV+4Vi56RLHE1h6q/HHfwAIT3XoB9vJAVeRzfu5NriXM8y6eeJu0vlKa0C9kq2rq1sOWRClhdLHPocrg==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.59.0.tgz",
+			"integrity": "sha512-tXVdJ/JINsNWdponPHN0OuKHtC+HdpyoS9sd6IDPNiiEYsRki8b7tefRZ1iMnRkdbyT4SEbguWsr6o+5awvbPQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1248,9 +749,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm64-musl": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.58.0.tgz",
-			"integrity": "sha512-2ZHxemzgHcjtktAuVUwSoyXmGo/t+aF5tS1ciPpPei4rhSyrz3JOqDosXXrmhN/yLUSzJjtuW7ToTWqfQpCj2w==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.59.0.tgz",
+			"integrity": "sha512-RRTq38i2zT5fnw6XGHjvT6w2mh6x/G3m6AZcAZ56OTDTT/lsOeYnG3SVjwmH40z5kPqF+lf+o35e6m6PpKy9Dw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1268,9 +769,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.58.0.tgz",
-			"integrity": "sha512-AwKkVwjVmFQ3bcO7j0McGYAqCKH2a326fswfofng/E8VewCT/raeeGQr4huVhY704deK8AWASSTlxzMj0eZc6Q==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.59.0.tgz",
+			"integrity": "sha512-lD3k7glAJSaXW0D6xzu8VOZbYbosvy+0ktOVkfLEoQF5HJlMSxTQ2KNW0JO+08ccP/1ElOKktVEMI0fqRbVB4w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1288,9 +789,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.58.0.tgz",
-			"integrity": "sha512-xsRpTxfUnJF8D3AUKko/qyWdjw4GZVHlCVFuGlzSCTeewLmykKINW8em1+wx+axsDVtJJcMtvsiaXggXxrlHgw==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.59.0.tgz",
+			"integrity": "sha512-WH5ZP1RbuHKBO/yfPRQKpNO/ijHcEDNbnmC4VPf/Bcd3+mbMAZpRiJWRa1PL5bREdIZZHo343mk3sqlc9x7Usw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1308,9 +809,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-riscv64-musl": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.58.0.tgz",
-			"integrity": "sha512-Z4AYOTcy7nYEIiXwD62PlerimyYRcfJOgUbQAEBjXz098kxKuERBlRntofGy69HHhe9E0TLVNMl1yspVNu+efw==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.59.0.tgz",
+			"integrity": "sha512-743wOiaI9RZY4QVGkWkfGRavD5ZJUJ6gscFjVrVu1dP8AZh9jM+a6v3NhlR+OIzHdS6DhLM96w+gcVskskz7rw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1328,9 +829,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-s390x-gnu": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.58.0.tgz",
-			"integrity": "sha512-A3nhhtZPC/TKVWOPj9q/H3p2znJDCcHWYlJBhWL8hGq/bFmBaNBHC8Np6E581yVq1w9Mi3rMDNzDalWvtUfJtQ==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.59.0.tgz",
+			"integrity": "sha512-xjRXQsRnrRZCcCkIEnbd2lmsQNobtwwkJxdy2bWXhZ1lIN0ouZwsBXRsoovW3yATuziAYwr9HMiQuR/Cc75NIw==",
 			"cpu": [
 				"s390x"
 			],
@@ -1348,9 +849,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-x64-gnu": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.58.0.tgz",
-			"integrity": "sha512-2g+tVkgwqphw8R4hgo+kF4oz8+P5RwVOtr9+irsC7uwEp0e9j7Crw8kDGKL20uYlLPD7g02DqA61mC/UNYx98A==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.59.0.tgz",
+			"integrity": "sha512-4hNjqq/Rbr9B+StY9zMMAfm72+mtM4v80xYL5Qkb59Qd72g2vJMI0iFlPj3kf6miMsie/yJ7rt4urJT292HBgA==",
 			"cpu": [
 				"x64"
 			],
@@ -1368,9 +869,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-x64-musl": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.58.0.tgz",
-			"integrity": "sha512-rc15P6AbyyB7426aN8AakLd02Trb3a6ML/mmfAQeVHJEfVofWLcWIrBdy6zDEY+DIaL/s8E4GGPboVw+oP3+EA==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.59.0.tgz",
+			"integrity": "sha512-NH579iN8EVQYsWowUB8B5vFchcylJtwPVJ7NmUAqEQHNLfhPbDT3K56KrECNAkUN4QpF4qiMgN2vsfZwVvjm7g==",
 			"cpu": [
 				"x64"
 			],
@@ -1388,9 +889,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-openharmony-arm64": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.58.0.tgz",
-			"integrity": "sha512-ZWoTM27/HYPOh9iq86DAbhPu9nXb8qKvvGU/h8OfliyVUFAMMNTLDkGsWDKKnDqIkqvZ9+dXlgUOsH1LYO3O7g==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.59.0.tgz",
+			"integrity": "sha512-mzZy3Z5Aj1D75Aq9FVlmoRQH5ei8Ga4o/NZmlXkKyeZ5EmPrUXRR7c6BMBteV1ZuZ/356UYDuLRLjAMxTDTiBA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1405,9 +906,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-win32-arm64-msvc": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.58.0.tgz",
-			"integrity": "sha512-LHZnqFXe2dEfkRI4XdZS/57nEOT/I4UCRX5IyM9v4GYW9XwQCjGe1IUK59SuKw3POwvcgWQ4pme2cYXmNqTNPg==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.59.0.tgz",
+			"integrity": "sha512-0CpDJ1gE3jN1Gk6xms1Ie6LPfPcOtY4FAtoOmVLHQoAf8DvO2wd0DW2dIX2f7YTp5dxrr0ND8JeUEjm3DP3k5g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1422,9 +923,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-win32-ia32-msvc": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.58.0.tgz",
-			"integrity": "sha512-mZKpg20TpheCJym1rarcZCUJeW1sSruw8zAAaCYWvuVfwIUDN1CXdrPU/JgCWReXTCTrEfCB8Wyo3hh9jSZ2EA==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.59.0.tgz",
+			"integrity": "sha512-zwdKBu3pt87uW0bRcywZb0oGMS7C6n87qogwRYFUgmk44T90ZzYlPjtlFYXs/DnBFrgNCvlHwCuWKfVWLeE7kw==",
 			"cpu": [
 				"ia32"
 			],
@@ -1439,9 +940,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-win32-x64-msvc": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.58.0.tgz",
-			"integrity": "sha512-N/wUU4N5PZ2orBtI+Ko7MnMfYLfE7K91UrGMY/c/pYyHR3lA9kwst1XugkZx+92YcRh/Eo+iv2eTESSWXfiZPA==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.59.0.tgz",
+			"integrity": "sha512-dUUbZkKgWrmAeI/puzv4bxN8lzcYaFnQVwFTFtwO2Gp8M7lZGSE2qJjC58g518+1bltJ8mizjYwD0BGHym0l/w==",
 			"cpu": [
 				"x64"
 			],
@@ -1540,9 +1041,9 @@
 			]
 		},
 		"node_modules/@oxlint/binding-android-arm-eabi": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.73.0.tgz",
-			"integrity": "sha512-HZQRN/UMBu+Ut+/9MiAChkbP4qZqrNOWBcNI45vOT40GVhbGR0JgHB87L48D4iAqFQIdVmeQYtV9RF89AjTKkg==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.74.0.tgz",
+			"integrity": "sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==",
 			"cpu": [
 				"arm"
 			],
@@ -1557,9 +1058,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-android-arm64": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.73.0.tgz",
-			"integrity": "sha512-Gp+KJRylv2aW7thRpG5p1KTxZq4ZJFbWowrKzufNq9d3ssl3r3JviYV45/+p+7CN1Nv0zDd1e8Ex0b/HUDq4TQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.74.0.tgz",
+			"integrity": "sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1574,9 +1075,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-darwin-arm64": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.73.0.tgz",
-			"integrity": "sha512-3de96NdtXhxERMjIz7wsp2HYMY6pMQycGxFWac2mFecAx6VeARF/IqFb1QIaqiCRIdfzBwzTed+pCTCoiS+CYA==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.74.0.tgz",
+			"integrity": "sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1591,9 +1092,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-darwin-x64": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.73.0.tgz",
-			"integrity": "sha512-5zx/uPW32TiaOeVY1dQ/H5iOf0K1HOdFKOJhLqGl4o63+i1fpzoqqu/mKtd7OFgFjNCdhlyTGgjVkQTZm1ELcg==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.74.0.tgz",
+			"integrity": "sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==",
 			"cpu": [
 				"x64"
 			],
@@ -1608,9 +1109,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-freebsd-x64": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.73.0.tgz",
-			"integrity": "sha512-qNe4gKHaGnLuZJ8toUg90JAa0S2vTVvDw+0bRi3q1avXZXDT4u5mMeECf3nD4HYrbdn1O7dXqWut4onY/yx/Xg==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.74.0.tgz",
+			"integrity": "sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==",
 			"cpu": [
 				"x64"
 			],
@@ -1625,9 +1126,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.73.0.tgz",
-			"integrity": "sha512-cCehYh5hTbfShm/fxTD6wwrGUWIpvX+N5OxmAMhFhDeTGXvw+BeNj889tpxsFQ9ZLatQ6wImuY8tsKLZ+FMz7w==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.74.0.tgz",
+			"integrity": "sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==",
 			"cpu": [
 				"arm"
 			],
@@ -1642,9 +1143,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm-musleabihf": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.73.0.tgz",
-			"integrity": "sha512-d5j5GDU/2dMgjVhw7TQT9ITrsIr1Y02KEXKyVGIXUkD+KiaxE9TP65FS2ZdgTBemQvoRL+gSBdbrIm3cQIeacg==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.74.0.tgz",
+			"integrity": "sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1659,9 +1160,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm64-gnu": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.73.0.tgz",
-			"integrity": "sha512-Eyf1SrP3+yR1DI3OJgOY2Pvrr9dWP9TK37xPaDYycwTtlGlI45erJAVIfH5/m/xosDt6BupJYEFi47bvbTuuyw==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.74.0.tgz",
+			"integrity": "sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1679,9 +1180,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm64-musl": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.73.0.tgz",
-			"integrity": "sha512-IlT/OJApEDKaMmCooHuncgJZbbCe7T5QIWmTZBEtYscWvzPQuuEinVcid6kwQRVQOUdb7PUCz4jQHnaYXdfJXw==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.74.0.tgz",
+			"integrity": "sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1699,9 +1200,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-ppc64-gnu": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.73.0.tgz",
-			"integrity": "sha512-L+JYcb/vdg5fmcH08V6o0YYLU28cTH1SPNulwJdvK9NK49aXSkYy6oNpKBmddArVOXYqNepriDGiZ04G54kh1Q==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.74.0.tgz",
+			"integrity": "sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1719,9 +1220,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-riscv64-gnu": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.73.0.tgz",
-			"integrity": "sha512-Qtk0g3bKV6OwWjIm7R8kQN1uOZRKQt/MODK2a8QfkwhTpXBD53ozx5XLVWLGDQAVyp2otLW4D2wB98XfAfMPGA==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.74.0.tgz",
+			"integrity": "sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1739,9 +1240,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-riscv64-musl": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.73.0.tgz",
-			"integrity": "sha512-wX0NQKZVxltkAOVmzFcpOaMpdaUvsq1Eqpx9tkAfl71UdkTlSo1R4AdAnGccR1Fm2+TzFgZ22CyyGuZ41RDr/A==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.74.0.tgz",
+			"integrity": "sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1759,9 +1260,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-s390x-gnu": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.73.0.tgz",
-			"integrity": "sha512-vPe7UGBMWyiLTtnqS4xxgMQFSFGmtQwhwCxuiw6lXygaO6bVt0D8dFVg8Xv05eaiN3ybC0HXXHUAohFMFvqoCQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.74.0.tgz",
+			"integrity": "sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==",
 			"cpu": [
 				"s390x"
 			],
@@ -1779,9 +1280,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-x64-gnu": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.73.0.tgz",
-			"integrity": "sha512-2CwIWr9cemFC/CbRBWZvuk5mffz6ObmfFkfcC/9rTQ7f+icNhYr2kOjf9Rt8lLvugvkdGDOmkoVoFFHh6ClCTw==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.74.0.tgz",
+			"integrity": "sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==",
 			"cpu": [
 				"x64"
 			],
@@ -1799,9 +1300,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-x64-musl": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.73.0.tgz",
-			"integrity": "sha512-nDadfJgg7NBBxG0N560wOe7LLX5QiYp6qBaI7viuk5EUORFBktU/NfV0MbTqU3gTqQDCh4VyxKdo5VADxk9w8Q==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.74.0.tgz",
+			"integrity": "sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==",
 			"cpu": [
 				"x64"
 			],
@@ -1819,9 +1320,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-openharmony-arm64": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.73.0.tgz",
-			"integrity": "sha512-wGjJC+NLH9xP+IKGn9RDW94ojJR/wPbg5WCnQjj/oReaOtCQthr8ws1zICe77JFmo4ouUdeTHHZL/ESGiF6Pmw==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.74.0.tgz",
+			"integrity": "sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1836,9 +1337,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-arm64-msvc": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.73.0.tgz",
-			"integrity": "sha512-I7X47GPGljw225YUQ5SbC/rb1Kkdrd0yQf0x+hYxeKS6DpfjMbo9ccQPQ6LNY6BoJQ1sHhgDUGuMn5Vg5gHT6w==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.74.0.tgz",
+			"integrity": "sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1853,9 +1354,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-ia32-msvc": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.73.0.tgz",
-			"integrity": "sha512-5lWj+3h+74Fm1jYOO9qkJA4xkAlZA099DkXppuXsk7UpnpZLttsefrZU469vChGaG6hcSqrkKXQOvMTZtbjeNg==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.74.0.tgz",
+			"integrity": "sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1870,9 +1371,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-x64-msvc": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.73.0.tgz",
-			"integrity": "sha512-WaNRvh4f6zY9CvUQk2YoA1O90ieWrIklI84+HXFr9Isjz9CSESrdqo/RtIYt4Dll/cAchqGDMehfaZd0vqEFZw==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.74.0.tgz",
+			"integrity": "sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==",
 			"cpu": [
 				"x64"
 			],
@@ -1917,9 +1418,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.0.tgz",
+			"integrity": "sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1934,9 +1435,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.0.tgz",
+			"integrity": "sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1951,9 +1452,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.0.tgz",
+			"integrity": "sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==",
 			"cpu": [
 				"x64"
 			],
@@ -1968,9 +1469,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.0.tgz",
+			"integrity": "sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1985,9 +1486,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-			"integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.0.tgz",
+			"integrity": "sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==",
 			"cpu": [
 				"arm"
 			],
@@ -2002,9 +1503,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.0.tgz",
+			"integrity": "sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==",
 			"cpu": [
 				"arm64"
 			],
@@ -2022,9 +1523,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.0.tgz",
+			"integrity": "sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2042,9 +1543,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.0.tgz",
+			"integrity": "sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -2062,9 +1563,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.0.tgz",
+			"integrity": "sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -2082,9 +1583,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.0.tgz",
+			"integrity": "sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2102,9 +1603,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.0.tgz",
+			"integrity": "sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==",
 			"cpu": [
 				"x64"
 			],
@@ -2122,9 +1623,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.0.tgz",
+			"integrity": "sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2139,9 +1640,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-			"integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.0.tgz",
+			"integrity": "sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==",
 			"cpu": [
 				"wasm32"
 			],
@@ -2149,18 +1650,52 @@
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "1.10.0",
-				"@emnapi/runtime": "1.10.0",
-				"@napi-rs/wasm-runtime": "^1.1.4"
+				"@emnapi/core": "1.11.2",
+				"@emnapi/runtime": "1.11.2",
+				"@napi-rs/wasm-runtime": "^1.1.6"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+			"integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+			"integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.0.tgz",
+			"integrity": "sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2175,9 +1710,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.0.tgz",
+			"integrity": "sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==",
 			"cpu": [
 				"x64"
 			],
@@ -2192,400 +1727,11 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-			"integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-			"integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-			"integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-			"integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-			"integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-			"integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-			"integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-			"integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-			"integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-			"integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-			"integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-			"integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-			"integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-			"integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-			"integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-			"integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-			"integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-			"integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-			"integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-			"integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-			"integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			]
-		},
-		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-			"integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-			"integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-			"integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-			"integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-			"integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/@sindresorhus/is": {
 			"version": "4.6.0",
@@ -2643,13 +1789,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/jsesc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
-			"integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/node": {
 			"version": "26.1.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
@@ -2660,32 +1799,372 @@
 				"undici-types": "~8.3.0"
 			}
 		},
+		"node_modules/@typescript/typescript-aix-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+			"integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+			"integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+			"integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+			"integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+			"integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+			"integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-loong64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+			"integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-mips64el": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+			"integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+			"integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-riscv64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+			"integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-s390x": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+			"integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+			"integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-sunos-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+			"integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+			"integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+			"integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
 		"node_modules/@vitest/expect": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-			"integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@standard-schema/spec": "^1.0.0",
+				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.0.18",
-				"@vitest/utils": "4.0.18",
-				"chai": "^6.2.1",
-				"tinyrainbow": "^3.0.3"
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-			"integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.0.18",
+				"@vitest/spy": "4.1.10",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -2694,7 +2173,7 @@
 			},
 			"peerDependencies": {
 				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0-0"
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"msw": {
@@ -2706,26 +2185,26 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-			"integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tinyrainbow": "^3.0.3"
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-			"integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.0.18",
+				"@vitest/utils": "4.1.10",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -2733,13 +2212,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-			"integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.18",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -2748,9 +2228,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-			"integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2758,18 +2238,377 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-			"integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.18",
-				"tinyrainbow": "^3.0.3"
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
+		},
+		"node_modules/@volar/language-core": {
+			"version": "2.4.28",
+			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+			"integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/source-map": "2.4.28"
+			}
+		},
+		"node_modules/@volar/source-map": {
+			"version": "2.4.28",
+			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+			"integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@volar/typescript": {
+			"version": "2.4.28",
+			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+			"integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/language-core": "2.4.28",
+				"path-browserify": "^1.0.1",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/@yuku-codegen/binding-darwin-arm64": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-darwin-arm64/-/binding-darwin-arm64-0.6.5.tgz",
+			"integrity": "sha512-uR1OCnftxC89GP6ZLPbaAXU9wdycmXt5BUQAOaDUmU/b38WJefse4RcL793rsOw1rkb8UC3UqP9F8hQ0lDB5xg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@yuku-codegen/binding-darwin-x64": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-darwin-x64/-/binding-darwin-x64-0.6.5.tgz",
+			"integrity": "sha512-b5m/NymPwAV8OYmWPK0GwVeXw/D7EMIr1GkgL9fW/JCFDvkSkBTz8cbGl5Jkoxr+bamOZy4C1ySngpU///4CFQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@yuku-codegen/binding-freebsd-x64": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-freebsd-x64/-/binding-freebsd-x64-0.6.5.tgz",
+			"integrity": "sha512-wLTe/QeBF37qb4bR++t/jLP3LQ7oS76lsZigk7J10IR2GwD4w8GJqhIm1NsAwho6OjWDNnfxkkw/Oadf/jex4Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@yuku-codegen/binding-linux-arm-gnu": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm-gnu/-/binding-linux-arm-gnu-0.6.5.tgz",
+			"integrity": "sha512-Clah7LByDMBFkHKeRsUrqoftiyocoYaAmDc7aM14S9qghvKPnbTAtvrG8QOLMkWviWS+rQ94YWFGqzk1cRxAnA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-codegen/binding-linux-arm-musl": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm-musl/-/binding-linux-arm-musl-0.6.5.tgz",
+			"integrity": "sha512-3ghZT7Dtp5tzIyfSFWcLFxtwnXjrrqLhO+MTuw3Am03K9Coo2NQICwwA9DN2HBrb8KXES1U43an1rNgzRw9xog==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-codegen/binding-linux-arm64-gnu": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.6.5.tgz",
+			"integrity": "sha512-9zT+uVEtVJkvm0Ba5BkUgBXNqw3kcolV9RAf0kSgIe44bi5Lp6MPqCRm9JrWnJTZOySzPII3oRNRl9dtBlOdLg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-codegen/binding-linux-arm64-musl": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.6.5.tgz",
+			"integrity": "sha512-Uyi/vT++0gyVsyan3XvEii8AWbc+yFJ3M0GEloup7eBx1j4FtK7oq23F6mbQD1gNaozGKkN74fCJpIxF176hZA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-codegen/binding-linux-x64-gnu": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.6.5.tgz",
+			"integrity": "sha512-JZzAbPDh5eQ2GRAAbo7cKcFabPQ9UEAQglk1BE0psoWUDt1wktp4ZX9ZJgDgF9EbSH3UUACo0lIkWUtSjRyRoQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-codegen/binding-linux-x64-musl": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-x64-musl/-/binding-linux-x64-musl-0.6.5.tgz",
+			"integrity": "sha512-Dmh6Qhoo1UNM10eDLs/DND8E3cLfQQboFfZgnnNNIJ2RQ/G0GXGh7Kzff1QmglUNuRami42NkTrsF9VrkCttZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-codegen/binding-win32-arm64": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-win32-arm64/-/binding-win32-arm64-0.6.5.tgz",
+			"integrity": "sha512-UAq2wLFT0mRN2rzJfZjmaqVMJD9kYywARc6Wk8Ggnm4p8yJYigNxMkJ0gt3bpd0MOnvre4LFEDyAMr4esRubuQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@yuku-codegen/binding-win32-x64": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-codegen/binding-win32-x64/-/binding-win32-x64-0.6.5.tgz",
+			"integrity": "sha512-hlEo+UIMHaEoLHe8woLr9eI6fz+8LRwdRrid/iegVU1N+53zkh4WMkI8N7e4vUNKKMVN2kJo6Z73J+JfskHO1g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@yuku-parser/binding-darwin-arm64": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.6.5.tgz",
+			"integrity": "sha512-QVdaZzj9T3KdaprM8VYpiYIFJrcJB347P2U3bg683nPQaDNmX733CFtCqpkc1KHccFf199EXx4OazkJlnHvImA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@yuku-parser/binding-darwin-x64": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-darwin-x64/-/binding-darwin-x64-0.6.5.tgz",
+			"integrity": "sha512-9omiEXwzJo3hsJiaohFek44wKRmnNy8o8acf8PXJdVo19I9O5eY7c3Nhca1DRTozoLqIJEI68CH8OoR2/Dv7ww==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@yuku-parser/binding-freebsd-x64": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.6.5.tgz",
+			"integrity": "sha512-0BZ14CHc8H3EHmlAMhxTDVMYijsT1nNZUhl6JTm/xzl+Gaun/vahgdaJaFESuweLeZ1WnwVfPVPvjsdfnbTN8g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@yuku-parser/binding-linux-arm-gnu": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm-gnu/-/binding-linux-arm-gnu-0.6.5.tgz",
+			"integrity": "sha512-VidTdzelGosQDkVkU4X/9qrILPT5HunzL5shW9jrq860naAEjGS/41a4s3J5KBRsKRHscwOsbtSzUev1TMdgfg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-parser/binding-linux-arm-musl": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm-musl/-/binding-linux-arm-musl-0.6.5.tgz",
+			"integrity": "sha512-Xes/SwXQiPFPqLMhnwjRv0s6mlm6V7+jpw/kmCMkal9Q0UfS4hVpFo2T5NNIKNLCj5qAZ+2EPtgDBz0S1lH4xg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-parser/binding-linux-arm64-gnu": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.6.5.tgz",
+			"integrity": "sha512-MaFn3Vh+kBETYXtPYBaCQUMsUk5SqSatM+mp9Vz7COuCKXim7cG8kGcUpqq93wegLEkkEnv8pyiDFFx/gmNOiQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-parser/binding-linux-arm64-musl": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.6.5.tgz",
+			"integrity": "sha512-s7GAjJ7kzmnEBVAq5c5B+h/DCOSZG7WqTNpFRYUVGQU+D8wf1gMnfDQ5v8zFdByhpHiW+HNerxI8sml5dl47Rw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-parser/binding-linux-x64-gnu": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.6.5.tgz",
+			"integrity": "sha512-5/+mLrZdCtGoKOw/zNJC0+fSy4aKI97JvPm5rr8DXui/l3+BrvU5g7czp1DVHN67I7VzTLizu2n2y5cz2CjzEg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-parser/binding-linux-x64-musl": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.6.5.tgz",
+			"integrity": "sha512-Svj4h/WZQ1VdAxaFJrakVi85IzUJPYWcNw15gNPoeNg+/SGGTTkTeUzODiMRY/8ioJ/k3+/K7zQwASIEBF7L3Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@yuku-parser/binding-win32-arm64": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-win32-arm64/-/binding-win32-arm64-0.6.5.tgz",
+			"integrity": "sha512-N96G8zoKihVwhMaH+kLp8MFIA1i3+dRaBO4KYK0otTPVdX+3uS2wpUY5vDLj4JbkKARuQA/DUmfgjleoXL6ugA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@yuku-parser/binding-win32-x64": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@yuku-parser/binding-win32-x64/-/binding-win32-x64-0.6.5.tgz",
+			"integrity": "sha512-RP7rz120SodZI/vUc1H4uzIMEZrxeG//d11qWUI5inMbU4YSnufJAScwjV+qQHxD3FAwoueNxsPjrVxagwAymg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@yuku-toolchain/types": {
+			"version": "0.5.43",
+			"resolved": "https://registry.npmjs.org/@yuku-toolchain/types/-/types-0.5.43.tgz",
+			"integrity": "sha512-kSpvPntnXw5+lYjO71ffBEnQ5ycQ74KGIYknh0TS4xeyCuBkOqxyJumxZkMhLBBUCLjDAbx2+Icnr3Zh4ftjpQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.3",
@@ -2870,64 +2709,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/ast-kit": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-3.0.0.tgz",
-			"integrity": "sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^8.0.0",
-				"estree-walker": "^3.0.3",
-				"pathe": "^2.0.3"
-			},
-			"engines": {
-				"node": "^22.18.0 || >=24.11.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sxzz"
-			}
-		},
-		"node_modules/ast-kit/node_modules/@babel/helper-validator-identifier": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^22.18.0 || >=24.11.0"
-			}
-		},
-		"node_modules/ast-kit/node_modules/@babel/parser": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
-			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^8.0.4"
-			},
-			"bin": {
-				"parser": "bin/babel-parser.js"
-			},
-			"engines": {
-				"node": "^22.18.0 || >=24.11.0"
-			}
-		},
-		"node_modules/ast-kit/node_modules/@babel/types": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-string-parser": "^8.0.0",
-				"@babel/helper-validator-identifier": "^8.0.4"
-			},
-			"engines": {
-				"node": "^22.18.0 || >=24.11.0"
-			}
-		},
 		"node_modules/better-path-resolve": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
@@ -2939,16 +2720,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/birpc": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
-			"integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/braces": {
@@ -3188,6 +2959,13 @@
 				"node": ">=22.12.0"
 			}
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3220,6 +2998,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -3234,13 +3022,13 @@
 			}
 		},
 		"node_modules/dts-resolver": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-2.1.3.tgz",
-			"integrity": "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-3.0.0.tgz",
+			"integrity": "sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": "^22.18.0 || >=24.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sxzz"
@@ -3306,53 +3094,11 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/esbuild": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.1",
-				"@esbuild/android-arm": "0.28.1",
-				"@esbuild/android-arm64": "0.28.1",
-				"@esbuild/android-x64": "0.28.1",
-				"@esbuild/darwin-arm64": "0.28.1",
-				"@esbuild/darwin-x64": "0.28.1",
-				"@esbuild/freebsd-arm64": "0.28.1",
-				"@esbuild/freebsd-x64": "0.28.1",
-				"@esbuild/linux-arm": "0.28.1",
-				"@esbuild/linux-arm64": "0.28.1",
-				"@esbuild/linux-ia32": "0.28.1",
-				"@esbuild/linux-loong64": "0.28.1",
-				"@esbuild/linux-mips64el": "0.28.1",
-				"@esbuild/linux-ppc64": "0.28.1",
-				"@esbuild/linux-riscv64": "0.28.1",
-				"@esbuild/linux-s390x": "0.28.1",
-				"@esbuild/linux-x64": "0.28.1",
-				"@esbuild/netbsd-arm64": "0.28.1",
-				"@esbuild/netbsd-x64": "0.28.1",
-				"@esbuild/openbsd-arm64": "0.28.1",
-				"@esbuild/openbsd-x64": "0.28.1",
-				"@esbuild/openharmony-arm64": "0.28.1",
-				"@esbuild/sunos-x64": "0.28.1",
-				"@esbuild/win32-arm64": "0.28.1",
-				"@esbuild/win32-ia32": "0.28.1",
-				"@esbuild/win32-x64": "0.28.1"
-			}
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
@@ -3545,13 +3291,16 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.14.0",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+			"version": "5.0.0-beta.5",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.5.tgz",
+			"integrity": "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20.20.0"
 			},
 			"funding": {
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
@@ -3679,13 +3428,13 @@
 			}
 		},
 		"node_modules/import-without-cache": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.3.3.tgz",
-			"integrity": "sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.4.0.tgz",
+			"integrity": "sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": "^22.18.0 || >=24.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sxzz"
@@ -3802,19 +3551,6 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/jsesc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"jsesc": "bin/jsesc"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -3823,6 +3559,279 @@
 			"license": "MIT",
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/lint-staged": {
@@ -4137,9 +4146,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.15",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-			"integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -4234,9 +4243,9 @@
 			"license": "MIT"
 		},
 		"node_modules/oxfmt": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.58.0.tgz",
-			"integrity": "sha512-8feG/7NVEHDVwc1OUpP6Pks+TnaDFUw2jLLFIMi5bcmmwxAX2wBQvjSzj62RRTYBf2Op1Wt8xbkmagmPTR5ETg==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.59.0.tgz",
+			"integrity": "sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4252,25 +4261,25 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxfmt/binding-android-arm-eabi": "0.58.0",
-				"@oxfmt/binding-android-arm64": "0.58.0",
-				"@oxfmt/binding-darwin-arm64": "0.58.0",
-				"@oxfmt/binding-darwin-x64": "0.58.0",
-				"@oxfmt/binding-freebsd-x64": "0.58.0",
-				"@oxfmt/binding-linux-arm-gnueabihf": "0.58.0",
-				"@oxfmt/binding-linux-arm-musleabihf": "0.58.0",
-				"@oxfmt/binding-linux-arm64-gnu": "0.58.0",
-				"@oxfmt/binding-linux-arm64-musl": "0.58.0",
-				"@oxfmt/binding-linux-ppc64-gnu": "0.58.0",
-				"@oxfmt/binding-linux-riscv64-gnu": "0.58.0",
-				"@oxfmt/binding-linux-riscv64-musl": "0.58.0",
-				"@oxfmt/binding-linux-s390x-gnu": "0.58.0",
-				"@oxfmt/binding-linux-x64-gnu": "0.58.0",
-				"@oxfmt/binding-linux-x64-musl": "0.58.0",
-				"@oxfmt/binding-openharmony-arm64": "0.58.0",
-				"@oxfmt/binding-win32-arm64-msvc": "0.58.0",
-				"@oxfmt/binding-win32-ia32-msvc": "0.58.0",
-				"@oxfmt/binding-win32-x64-msvc": "0.58.0"
+				"@oxfmt/binding-android-arm-eabi": "0.59.0",
+				"@oxfmt/binding-android-arm64": "0.59.0",
+				"@oxfmt/binding-darwin-arm64": "0.59.0",
+				"@oxfmt/binding-darwin-x64": "0.59.0",
+				"@oxfmt/binding-freebsd-x64": "0.59.0",
+				"@oxfmt/binding-linux-arm-gnueabihf": "0.59.0",
+				"@oxfmt/binding-linux-arm-musleabihf": "0.59.0",
+				"@oxfmt/binding-linux-arm64-gnu": "0.59.0",
+				"@oxfmt/binding-linux-arm64-musl": "0.59.0",
+				"@oxfmt/binding-linux-ppc64-gnu": "0.59.0",
+				"@oxfmt/binding-linux-riscv64-gnu": "0.59.0",
+				"@oxfmt/binding-linux-riscv64-musl": "0.59.0",
+				"@oxfmt/binding-linux-s390x-gnu": "0.59.0",
+				"@oxfmt/binding-linux-x64-gnu": "0.59.0",
+				"@oxfmt/binding-linux-x64-musl": "0.59.0",
+				"@oxfmt/binding-openharmony-arm64": "0.59.0",
+				"@oxfmt/binding-win32-arm64-msvc": "0.59.0",
+				"@oxfmt/binding-win32-ia32-msvc": "0.59.0",
+				"@oxfmt/binding-win32-x64-msvc": "0.59.0"
 			},
 			"peerDependencies": {
 				"svelte": "^5.0.0",
@@ -4286,9 +4295,9 @@
 			}
 		},
 		"node_modules/oxlint": {
-			"version": "1.73.0",
-			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.73.0.tgz",
-			"integrity": "sha512-u91G9TJzU6yqKWNZUYprQB07W7YvntZXaRxQ6CkoytepYhLWUXWsr1M8zUJ34VatNPuUAr3Z8GH+O2A331CluQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.74.0.tgz",
+			"integrity": "sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -4301,25 +4310,25 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxlint/binding-android-arm-eabi": "1.73.0",
-				"@oxlint/binding-android-arm64": "1.73.0",
-				"@oxlint/binding-darwin-arm64": "1.73.0",
-				"@oxlint/binding-darwin-x64": "1.73.0",
-				"@oxlint/binding-freebsd-x64": "1.73.0",
-				"@oxlint/binding-linux-arm-gnueabihf": "1.73.0",
-				"@oxlint/binding-linux-arm-musleabihf": "1.73.0",
-				"@oxlint/binding-linux-arm64-gnu": "1.73.0",
-				"@oxlint/binding-linux-arm64-musl": "1.73.0",
-				"@oxlint/binding-linux-ppc64-gnu": "1.73.0",
-				"@oxlint/binding-linux-riscv64-gnu": "1.73.0",
-				"@oxlint/binding-linux-riscv64-musl": "1.73.0",
-				"@oxlint/binding-linux-s390x-gnu": "1.73.0",
-				"@oxlint/binding-linux-x64-gnu": "1.73.0",
-				"@oxlint/binding-linux-x64-musl": "1.73.0",
-				"@oxlint/binding-openharmony-arm64": "1.73.0",
-				"@oxlint/binding-win32-arm64-msvc": "1.73.0",
-				"@oxlint/binding-win32-ia32-msvc": "1.73.0",
-				"@oxlint/binding-win32-x64-msvc": "1.73.0"
+				"@oxlint/binding-android-arm-eabi": "1.74.0",
+				"@oxlint/binding-android-arm64": "1.74.0",
+				"@oxlint/binding-darwin-arm64": "1.74.0",
+				"@oxlint/binding-darwin-x64": "1.74.0",
+				"@oxlint/binding-freebsd-x64": "1.74.0",
+				"@oxlint/binding-linux-arm-gnueabihf": "1.74.0",
+				"@oxlint/binding-linux-arm-musleabihf": "1.74.0",
+				"@oxlint/binding-linux-arm64-gnu": "1.74.0",
+				"@oxlint/binding-linux-arm64-musl": "1.74.0",
+				"@oxlint/binding-linux-ppc64-gnu": "1.74.0",
+				"@oxlint/binding-linux-riscv64-gnu": "1.74.0",
+				"@oxlint/binding-linux-riscv64-musl": "1.74.0",
+				"@oxlint/binding-linux-s390x-gnu": "1.74.0",
+				"@oxlint/binding-linux-x64-gnu": "1.74.0",
+				"@oxlint/binding-linux-x64-musl": "1.74.0",
+				"@oxlint/binding-openharmony-arm64": "1.74.0",
+				"@oxlint/binding-win32-arm64-msvc": "1.74.0",
+				"@oxlint/binding-win32-ia32-msvc": "1.74.0",
+				"@oxlint/binding-win32-x64-msvc": "1.74.0"
 			},
 			"peerDependencies": {
 				"oxlint-tsgolint": ">=0.24.0",
@@ -4448,6 +4457,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/path-browserify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4516,9 +4532,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+			"version": "8.5.19",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+			"integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4704,14 +4720,14 @@
 			"license": "MIT"
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-			"integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.0.tgz",
+			"integrity": "sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.127.0",
-				"@rolldown/pluginutils": "1.0.0-rc.17"
+				"@oxc-project/types": "=0.140.0",
+				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -4720,59 +4736,56 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+				"@rolldown/binding-android-arm64": "1.2.0",
+				"@rolldown/binding-darwin-arm64": "1.2.0",
+				"@rolldown/binding-darwin-x64": "1.2.0",
+				"@rolldown/binding-freebsd-x64": "1.2.0",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.2.0",
+				"@rolldown/binding-linux-arm64-gnu": "1.2.0",
+				"@rolldown/binding-linux-arm64-musl": "1.2.0",
+				"@rolldown/binding-linux-ppc64-gnu": "1.2.0",
+				"@rolldown/binding-linux-s390x-gnu": "1.2.0",
+				"@rolldown/binding-linux-x64-gnu": "1.2.0",
+				"@rolldown/binding-linux-x64-musl": "1.2.0",
+				"@rolldown/binding-openharmony-arm64": "1.2.0",
+				"@rolldown/binding-wasm32-wasi": "1.2.0",
+				"@rolldown/binding-win32-arm64-msvc": "1.2.0",
+				"@rolldown/binding-win32-x64-msvc": "1.2.0"
 			}
 		},
 		"node_modules/rolldown-plugin-dts": {
-			"version": "0.23.2",
-			"resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.23.2.tgz",
-			"integrity": "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.27.10.tgz",
+			"integrity": "sha512-ngxgc85YD6BV5O6MjYsMU/XzuP9AVfxriQgfrNtxAmG1E4kZAbnUAl4Gx6zGd2PbkND6j0mFwTd3HS3MTQq57g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/generator": "8.0.0-rc.3",
-				"@babel/helper-validator-identifier": "8.0.0-rc.3",
-				"@babel/parser": "8.0.0-rc.3",
-				"@babel/types": "8.0.0-rc.3",
-				"ast-kit": "^3.0.0-beta.1",
-				"birpc": "^4.0.0",
-				"dts-resolver": "^2.1.3",
-				"get-tsconfig": "^4.13.7",
-				"obug": "^2.1.1",
-				"picomatch": "^4.0.4"
+				"@astrojs/ts-plugin": "^1.10.10",
+				"dts-resolver": "^3.0.0",
+				"get-tsconfig": "5.0.0-beta.5",
+				"obug": "^2.1.3",
+				"yuku-ast": "^0.1.7",
+				"yuku-codegen": "^0.6.3",
+				"yuku-parser": "^0.6.3"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": "^22.18.0 || >=24.11.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sxzz"
 			},
 			"peerDependencies": {
-				"@ts-macro/tsc": "^0.3.6",
-				"@typescript/native-preview": ">=7.0.0-dev.20260325.1",
-				"rolldown": "^1.0.0-rc.12",
-				"typescript": "^5.0.0 || ^6.0.0",
-				"vue-tsc": "~3.2.0"
+				"@typescript/native-preview": "*",
+				"@volar/typescript": "~2.4.0",
+				"rolldown": "^1.0.0",
+				"typescript": "^5.0.0 || ^6.0.0 || ~7.0.0",
+				"vue-tsc": "~3.2.0 || ~3.3.0"
 			},
 			"peerDependenciesMeta": {
-				"@ts-macro/tsc": {
+				"@typescript/native-preview": {
 					"optional": true
 				},
-				"@typescript/native-preview": {
+				"@volar/typescript": {
 					"optional": true
 				},
 				"typescript": {
@@ -4781,51 +4794,6 @@
 				"vue-tsc": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/rollup": {
-			"version": "4.62.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-			"integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "1.0.9"
-			},
-			"bin": {
-				"rollup": "dist/bin/rollup"
-			},
-			"engines": {
-				"node": ">=18.0.0",
-				"npm": ">=8.0.0"
-			},
-			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.62.2",
-				"@rollup/rollup-android-arm64": "4.62.2",
-				"@rollup/rollup-darwin-arm64": "4.62.2",
-				"@rollup/rollup-darwin-x64": "4.62.2",
-				"@rollup/rollup-freebsd-arm64": "4.62.2",
-				"@rollup/rollup-freebsd-x64": "4.62.2",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-				"@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-				"@rollup/rollup-linux-arm64-gnu": "4.62.2",
-				"@rollup/rollup-linux-arm64-musl": "4.62.2",
-				"@rollup/rollup-linux-loong64-gnu": "4.62.2",
-				"@rollup/rollup-linux-loong64-musl": "4.62.2",
-				"@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-				"@rollup/rollup-linux-ppc64-musl": "4.62.2",
-				"@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-				"@rollup/rollup-linux-riscv64-musl": "4.62.2",
-				"@rollup/rollup-linux-s390x-gnu": "4.62.2",
-				"@rollup/rollup-linux-x64-gnu": "4.62.2",
-				"@rollup/rollup-linux-x64-musl": "4.62.2",
-				"@rollup/rollup-openbsd-x64": "4.62.2",
-				"@rollup/rollup-openharmony-arm64": "4.62.2",
-				"@rollup/rollup-win32-arm64-msvc": "4.62.2",
-				"@rollup/rollup-win32-ia32-msvc": "4.62.2",
-				"@rollup/rollup-win32-x64-gnu": "4.62.2",
-				"@rollup/rollup-win32-x64-msvc": "4.62.2",
-				"fsevents": "~2.3.2"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -5004,9 +4972,9 @@
 			"license": "MIT"
 		},
 		"node_modules/std-env": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5384,46 +5352,47 @@
 			}
 		},
 		"node_modules/tsdown": {
-			"version": "0.21.10",
-			"resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.21.10.tgz",
-			"integrity": "sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==",
+			"version": "0.22.9",
+			"resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.22.9.tgz",
+			"integrity": "sha512-/0QEjQEhOU1t1YxOIAGzFN7bIssd8P0pBpkOmNLCQi3c5UtrcMF5bvq3f30xHJNW9QCA9aUNcNAorMr2CTd6Lg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansis": "^4.2.0",
+				"ansis": "^4.3.1",
 				"cac": "^7.0.0",
 				"defu": "^6.1.7",
-				"empathic": "^2.0.0",
+				"empathic": "^2.0.1",
 				"hookable": "^6.1.1",
-				"import-without-cache": "^0.3.3",
-				"obug": "^2.1.1",
-				"picomatch": "^4.0.4",
-				"rolldown": "1.0.0-rc.17",
-				"rolldown-plugin-dts": "^0.23.2",
-				"semver": "^7.7.4",
-				"tinyexec": "^1.1.1",
-				"tinyglobby": "^0.2.16",
+				"import-without-cache": "^0.4.0",
+				"obug": "^2.1.3",
+				"picomatch": "^4.0.5",
+				"rolldown": "~1.2.0",
+				"rolldown-plugin-dts": "^0.27.9",
+				"semver": "^7.8.5",
+				"tinyexec": "^1.2.4",
+				"tinyglobby": "^0.2.17",
 				"tree-kill": "^1.2.2",
-				"unconfig-core": "^7.5.0",
-				"unrun": "^0.2.37"
+				"unconfig-core": "^7.5.0"
 			},
 			"bin": {
 				"tsdown": "dist/run.mjs"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": "^22.18.0 || >=24.11.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sxzz"
 			},
 			"peerDependencies": {
 				"@arethetypeswrong/core": "^0.18.1",
-				"@tsdown/css": "0.21.10",
-				"@tsdown/exe": "0.21.10",
+				"@tsdown/css": "0.22.9",
+				"@tsdown/exe": "0.22.9",
 				"@vitejs/devtools": "*",
-				"publint": "^0.3.0",
-				"typescript": "^5.0.0 || ^6.0.0",
-				"unplugin-unused": "^0.5.0"
+				"publint": "^0.3.8",
+				"tsx": "*",
+				"typescript": "^5.0.0 || ^6.0.0 || ^7.0.0",
+				"unplugin-unused": "^0.5.0",
+				"unrun": "*"
 			},
 			"peerDependenciesMeta": {
 				"@arethetypeswrong/core": {
@@ -5441,10 +5410,16 @@
 				"publint": {
 					"optional": true
 				},
+				"tsx": {
+					"optional": true
+				},
 				"typescript": {
 					"optional": true
 				},
 				"unplugin-unused": {
+					"optional": true
+				},
+				"unrun": {
 					"optional": true
 				}
 			}
@@ -5529,33 +5504,6 @@
 				"node": ">= 4.0.0"
 			}
 		},
-		"node_modules/unrun": {
-			"version": "0.2.39",
-			"resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.39.tgz",
-			"integrity": "sha512-h9FxYVpztY/wwq+bauLOh6Y3CWu2IVeRLq5lxzneBiIU9Tn86OGp9xiQrGhnYspAmg5dzdY0Cc8+Y70kuTARCg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"rolldown": "1.0.0-rc.17"
-			},
-			"bin": {
-				"unrun": "dist/cli.mjs"
-			},
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/Gugustinette"
-			},
-			"peerDependencies": {
-				"synckit": "^0.11.11"
-			},
-			"peerDependenciesMeta": {
-				"synckit": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/validate-npm-package-name": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
@@ -5567,18 +5515,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.6",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-			"integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+			"integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.27.0 || ^0.28.0",
-				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3",
-				"postcss": "^8.5.6",
-				"rollup": "^4.43.0",
-				"tinyglobby": "^0.2.15"
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.17",
+				"rolldown": "~1.1.5",
+				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -5594,9 +5541,10 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.3.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
-				"lightningcss": "^1.21.0",
 				"sass": "^1.70.0",
 				"sass-embedded": "^1.70.0",
 				"stylus": ">=0.54.8",
@@ -5609,13 +5557,16 @@
 				"@types/node": {
 					"optional": true
 				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
 				"jiti": {
 					"optional": true
 				},
 				"less": {
-					"optional": true
-				},
-				"lightningcss": {
 					"optional": true
 				},
 				"sass": {
@@ -5641,32 +5592,385 @@
 				}
 			}
 		},
-		"node_modules/vitest": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-			"integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+		"node_modules/vite/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/vite/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/vite/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/vite/node_modules/@oxc-project/types": {
+			"version": "0.139.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+			"integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+			"integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+			"integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+			"integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+			"integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+			"integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+			"integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+			"integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+			"integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+			"integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+			"integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+			"integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+			"integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+			"integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.1",
+				"@emnapi/runtime": "1.11.1",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+			"integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+			"integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/vite/node_modules/rolldown": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+			"integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.0.18",
-				"@vitest/mocker": "4.0.18",
-				"@vitest/pretty-format": "4.0.18",
-				"@vitest/runner": "4.0.18",
-				"@vitest/snapshot": "4.0.18",
-				"@vitest/spy": "4.0.18",
-				"@vitest/utils": "4.0.18",
-				"es-module-lexer": "^1.7.0",
-				"expect-type": "^1.2.2",
+				"@oxc-project/types": "=0.139.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.1.5",
+				"@rolldown/binding-darwin-arm64": "1.1.5",
+				"@rolldown/binding-darwin-x64": "1.1.5",
+				"@rolldown/binding-freebsd-x64": "1.1.5",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.5",
+				"@rolldown/binding-linux-arm64-musl": "1.1.5",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-musl": "1.1.5",
+				"@rolldown/binding-openharmony-arm64": "1.1.5",
+				"@rolldown/binding-wasm32-wasi": "1.1.5",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.5",
+				"@rolldown/binding-win32-x64-msvc": "1.1.5"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
 				"obug": "^2.1.1",
 				"pathe": "^2.0.3",
 				"picomatch": "^4.0.3",
-				"std-env": "^3.10.0",
+				"std-env": "^4.0.0-rc.1",
 				"tinybench": "^2.9.0",
 				"tinyexec": "^1.0.2",
 				"tinyglobby": "^0.2.15",
-				"tinyrainbow": "^3.0.3",
-				"vite": "^6.0.0 || ^7.0.0",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -5682,12 +5986,15 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.0.18",
-				"@vitest/browser-preview": "4.0.18",
-				"@vitest/browser-webdriverio": "4.0.18",
-				"@vitest/ui": "4.0.18",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
 				"happy-dom": "*",
-				"jsdom": "*"
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
@@ -5708,6 +6015,12 @@
 				"@vitest/browser-webdriverio": {
 					"optional": true
 				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
 				"@vitest/ui": {
 					"optional": true
 				},
@@ -5716,8 +6029,25 @@
 				},
 				"jsdom": {
 					"optional": true
+				},
+				"vite": {
+					"optional": false
 				}
 			}
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -5832,7 +6162,6 @@
 			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"dev": true,
 			"license": "ISC",
-			"optional": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},
@@ -5872,19 +6201,75 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/yuku-ast": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/yuku-ast/-/yuku-ast-0.1.7.tgz",
+			"integrity": "sha512-2RiMEWv500TixY5rJy6OZd4fSy9WYZKWh6gGbIJ7y7vAGcuCugWOWwOLGaQcRZrXcPUfqtLtvpaJ3SdXtWlhKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@yuku-toolchain/types": "0.5.43"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/arshad-yaseen"
+			}
+		},
+		"node_modules/yuku-codegen": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/yuku-codegen/-/yuku-codegen-0.6.5.tgz",
+			"integrity": "sha512-g8gbp05j2NNSKe0Uu2ViBRvawzXaWggxS9YwcVJ2d3I99VxbeOeENSUseA8AXPCZj/gcLkQxl7uhTmtK36qh8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@yuku-toolchain/types": "0.5.43"
+			},
+			"optionalDependencies": {
+				"@yuku-codegen/binding-darwin-arm64": "0.6.5",
+				"@yuku-codegen/binding-darwin-x64": "0.6.5",
+				"@yuku-codegen/binding-freebsd-x64": "0.6.5",
+				"@yuku-codegen/binding-linux-arm-gnu": "0.6.5",
+				"@yuku-codegen/binding-linux-arm-musl": "0.6.5",
+				"@yuku-codegen/binding-linux-arm64-gnu": "0.6.5",
+				"@yuku-codegen/binding-linux-arm64-musl": "0.6.5",
+				"@yuku-codegen/binding-linux-x64-gnu": "0.6.5",
+				"@yuku-codegen/binding-linux-x64-musl": "0.6.5",
+				"@yuku-codegen/binding-win32-arm64": "0.6.5",
+				"@yuku-codegen/binding-win32-x64": "0.6.5"
+			}
+		},
+		"node_modules/yuku-parser": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/yuku-parser/-/yuku-parser-0.6.5.tgz",
+			"integrity": "sha512-9A5zaOqE3X3wcPOTK97CYInpKwaUGYnwfHWasJaI2Je1OhI4pQmRA6YCSh7oKewEb2iJM4xlJdbwwj4Aydty7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@yuku-toolchain/types": "0.5.43"
+			},
+			"optionalDependencies": {
+				"@yuku-parser/binding-darwin-arm64": "0.6.5",
+				"@yuku-parser/binding-darwin-x64": "0.6.5",
+				"@yuku-parser/binding-freebsd-x64": "0.6.5",
+				"@yuku-parser/binding-linux-arm-gnu": "0.6.5",
+				"@yuku-parser/binding-linux-arm-musl": "0.6.5",
+				"@yuku-parser/binding-linux-arm64-gnu": "0.6.5",
+				"@yuku-parser/binding-linux-arm64-musl": "0.6.5",
+				"@yuku-parser/binding-linux-x64-gnu": "0.6.5",
+				"@yuku-parser/binding-linux-x64-musl": "0.6.5",
+				"@yuku-parser/binding-win32-arm64": "0.6.5",
+				"@yuku-parser/binding-win32-x64": "0.6.5"
+			}
+		},
 		"packages/xml-poto": {
 			"name": "@cerios/xml-poto",
-			"version": "2.3.2",
+			"version": "2.3.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@arethetypeswrong/cli": "^0.18.5",
 				"@types/node": "^26.1.1",
-				"oxfmt": "^0.58.0",
-				"oxlint": "^1.73.0",
-				"oxlint-tsgolint": "^0.24.0",
-				"tsdown": "^0.21.10",
-				"typescript": "^6.0.3",
-				"vitest": "4.0.18"
+				"tsdown": "^0.22.9",
+				"typescript": "^7.0.2",
+				"vitest": "4.1.10"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -5892,7 +6277,7 @@
 		},
 		"packages/xml-poto-codegen": {
 			"name": "@cerios/xml-poto-codegen",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^15.0.0",
@@ -5902,20 +6287,87 @@
 				"xml-poto-codegen": "dist/cli.cjs"
 			},
 			"devDependencies": {
-				"@cerios/xml-poto": "2.3.2",
+				"@cerios/xml-poto": "2.3.3",
 				"@types/node": "^26.1.1",
-				"oxfmt": "^0.58.0",
-				"oxlint": "^1.73.0",
-				"oxlint-tsgolint": "^0.24.0",
-				"tsdown": "^0.21.10",
-				"typescript": "^6.0.3",
-				"vitest": "4.0.18"
+				"tsdown": "^0.22.9",
+				"typescript": "^7.0.2",
+				"vitest": "4.1.10"
 			},
 			"engines": {
 				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@cerios/xml-poto": "^2.3.2"
+				"@cerios/xml-poto": "^2.3.3"
+			}
+		},
+		"packages/xml-poto-codegen/node_modules/typescript": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc"
+			},
+			"engines": {
+				"node": ">=16.20.0"
+			},
+			"optionalDependencies": {
+				"@typescript/typescript-aix-ppc64": "7.0.2",
+				"@typescript/typescript-darwin-arm64": "7.0.2",
+				"@typescript/typescript-darwin-x64": "7.0.2",
+				"@typescript/typescript-freebsd-arm64": "7.0.2",
+				"@typescript/typescript-freebsd-x64": "7.0.2",
+				"@typescript/typescript-linux-arm": "7.0.2",
+				"@typescript/typescript-linux-arm64": "7.0.2",
+				"@typescript/typescript-linux-loong64": "7.0.2",
+				"@typescript/typescript-linux-mips64el": "7.0.2",
+				"@typescript/typescript-linux-ppc64": "7.0.2",
+				"@typescript/typescript-linux-riscv64": "7.0.2",
+				"@typescript/typescript-linux-s390x": "7.0.2",
+				"@typescript/typescript-linux-x64": "7.0.2",
+				"@typescript/typescript-netbsd-arm64": "7.0.2",
+				"@typescript/typescript-netbsd-x64": "7.0.2",
+				"@typescript/typescript-openbsd-arm64": "7.0.2",
+				"@typescript/typescript-openbsd-x64": "7.0.2",
+				"@typescript/typescript-sunos-x64": "7.0.2",
+				"@typescript/typescript-win32-arm64": "7.0.2",
+				"@typescript/typescript-win32-x64": "7.0.2"
+			}
+		},
+		"packages/xml-poto/node_modules/typescript": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc"
+			},
+			"engines": {
+				"node": ">=16.20.0"
+			},
+			"optionalDependencies": {
+				"@typescript/typescript-aix-ppc64": "7.0.2",
+				"@typescript/typescript-darwin-arm64": "7.0.2",
+				"@typescript/typescript-darwin-x64": "7.0.2",
+				"@typescript/typescript-freebsd-arm64": "7.0.2",
+				"@typescript/typescript-freebsd-x64": "7.0.2",
+				"@typescript/typescript-linux-arm": "7.0.2",
+				"@typescript/typescript-linux-arm64": "7.0.2",
+				"@typescript/typescript-linux-loong64": "7.0.2",
+				"@typescript/typescript-linux-mips64el": "7.0.2",
+				"@typescript/typescript-linux-ppc64": "7.0.2",
+				"@typescript/typescript-linux-riscv64": "7.0.2",
+				"@typescript/typescript-linux-s390x": "7.0.2",
+				"@typescript/typescript-linux-x64": "7.0.2",
+				"@typescript/typescript-netbsd-arm64": "7.0.2",
+				"@typescript/typescript-netbsd-x64": "7.0.2",
+				"@typescript/typescript-openbsd-arm64": "7.0.2",
+				"@typescript/typescript-openbsd-x64": "7.0.2",
+				"@typescript/typescript-sunos-x64": "7.0.2",
+				"@typescript/typescript-win32-arm64": "7.0.2",
+				"@typescript/typescript-win32-x64": "7.0.2"
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,9 @@
 				"npm-check-updates": "^22.2.9",
 				"oxfmt": "^0.59.0",
 				"oxlint": "^1.74.0",
-				"oxlint-tsgolint": "^0.24.0",
+				"oxlint-tsgolint": "^0.25.0",
 				"syncpack": "^15.3.2",
+				"typescript": "^7.0.2",
 				"vitest": "4.1.10"
 			},
 			"engines": {
@@ -81,6 +82,20 @@
 			},
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/@arethetypeswrong/core/node_modules/typescript": {
+			"version": "5.6.1-rc",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+			"integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/@astrojs/compiler": {
@@ -957,9 +972,9 @@
 			}
 		},
 		"node_modules/@oxlint-tsgolint/darwin-arm64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
-			"integrity": "sha512-C2uMmwK5Bc4ri4ysZ6sA8Rcu+A5zBQTp6ml2u0CLLbRZp4kMFPV3yWk8B5DK9Aw7y9bbjogIm75tUwGLFzlsYQ==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+			"integrity": "sha512-87opKlwFP8qS9WHAeETV+kA0fC9Oyj4sg7OxWdI4xQY0WC7zlN6BgG66uE5mvtN5mahkt/gL0i/AVEnX6POq2Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -971,9 +986,9 @@
 			]
 		},
 		"node_modules/@oxlint-tsgolint/darwin-x64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.24.0.tgz",
-			"integrity": "sha512-Wgvt/1lRbDxmoNqWQKKcL+UIiqLmdJ+EWLpQa1qzoNVAfNB0PJpa82/8dH1twT/3rSs4zrP5TXPWl4juB71WuQ==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.25.0.tgz",
+			"integrity": "sha512-HJmuZexsrhqp4WmETn+Soq7Ogt5F0jirv+cYRSniIPe+d/x5beQzLX69xOLhQRE+8FLGETe7FahWMVP8x0dW4g==",
 			"cpu": [
 				"x64"
 			],
@@ -985,9 +1000,9 @@
 			]
 		},
 		"node_modules/@oxlint-tsgolint/linux-arm64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.24.0.tgz",
-			"integrity": "sha512-PB1rxII7KV83+ASY4sSkXtqvpij6ME66+QCRL49uksi/ofs2Rf/UVboYr095n0Rkbl2wgvlsHGl6DHC361jQUQ==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.25.0.tgz",
+			"integrity": "sha512-aNyYsPREvCJi3qjfBA0sQB7DhT3y/W5Ac2JI2D8IJynoTOAhVZj401Si6901oDajlBWyqJqqojudn0VgHB6+7A==",
 			"cpu": [
 				"arm64"
 			],
@@ -999,9 +1014,9 @@
 			]
 		},
 		"node_modules/@oxlint-tsgolint/linux-x64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.24.0.tgz",
-			"integrity": "sha512-xcz3CxKmjTQLREtE/UShh+ruWmm9nAb7UM9zKcD65BStiuYgOakAKkPHl4YS5DztpVcDrE0+HqbOolTlRKYWmw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.25.0.tgz",
+			"integrity": "sha512-+60+VjK9Mch3uA5WlTdNHuAm5+WA7wPPjuWdPWlU0F6JJpYpGZXUpO1RPKuFEWsBpNbLcLeJ0LbCJ1doWu58NA==",
 			"cpu": [
 				"x64"
 			],
@@ -1013,9 +1028,9 @@
 			]
 		},
 		"node_modules/@oxlint-tsgolint/win32-arm64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.24.0.tgz",
-			"integrity": "sha512-A2i6ZGBec3i20S7RaxkgHc6r3HYtD5Mn7j/mb22NkTz14u0JuudvTu6JggAnbGMcv8+dBKQI//EasxSPJLD8pw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.25.0.tgz",
+			"integrity": "sha512-r53TO+eHp/t53nnUkQJfrYYXODPAxmtf3RUFQG5XsE2hD21IunliOaAdZXP2UwzCx+r/fbNaEelqTaAHcDr57w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1027,9 +1042,9 @@
 			]
 		},
 		"node_modules/@oxlint-tsgolint/win32-x64": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.24.0.tgz",
-			"integrity": "sha512-0ZbGd9qRB6zs82moekaKdEvncRANq49EAwfNX62JpTS46feXUhKAuoyVDvZMj6Rywejylrmmu79Wo6faYCo4Ew==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.25.0.tgz",
+			"integrity": "sha512-vqe66B+gL9HarhyHemdlfC2VWT7eoA+o/ufZ7zT6AGHv64boyDZIJS3U+rpZo+ey4O7wZtiS/vYR2fWqDoFeBw==",
 			"cpu": [
 				"x64"
 			],
@@ -4344,21 +4359,21 @@
 			}
 		},
 		"node_modules/oxlint-tsgolint": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.24.0.tgz",
-			"integrity": "sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.25.0.tgz",
+			"integrity": "sha512-7DBpqyLZCfyoXiivyfzt9Xmju/K1RcN+Y1W7buEwrgRCWWF11v9alypPqWGZBmh2erDkKL/kVyhKUH2Px+t13A==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"tsgolint": "bin/tsgolint.js"
 			},
 			"optionalDependencies": {
-				"@oxlint-tsgolint/darwin-arm64": "0.24.0",
-				"@oxlint-tsgolint/darwin-x64": "0.24.0",
-				"@oxlint-tsgolint/linux-arm64": "0.24.0",
-				"@oxlint-tsgolint/linux-x64": "0.24.0",
-				"@oxlint-tsgolint/win32-arm64": "0.24.0",
-				"@oxlint-tsgolint/win32-x64": "0.24.0"
+				"@oxlint-tsgolint/darwin-arm64": "0.25.0",
+				"@oxlint-tsgolint/darwin-x64": "0.25.0",
+				"@oxlint-tsgolint/linux-arm64": "0.25.0",
+				"@oxlint-tsgolint/linux-x64": "0.25.0",
+				"@oxlint-tsgolint/win32-arm64": "0.25.0",
+				"@oxlint-tsgolint/win32-x64": "0.25.0"
 			}
 		},
 		"node_modules/p-filter": {
@@ -5433,17 +5448,38 @@
 			"optional": true
 		},
 		"node_modules/typescript": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
+				"tsc": "bin/tsc"
 			},
 			"engines": {
-				"node": ">=14.17"
+				"node": ">=16.20.0"
+			},
+			"optionalDependencies": {
+				"@typescript/typescript-aix-ppc64": "7.0.2",
+				"@typescript/typescript-darwin-arm64": "7.0.2",
+				"@typescript/typescript-darwin-x64": "7.0.2",
+				"@typescript/typescript-freebsd-arm64": "7.0.2",
+				"@typescript/typescript-freebsd-x64": "7.0.2",
+				"@typescript/typescript-linux-arm": "7.0.2",
+				"@typescript/typescript-linux-arm64": "7.0.2",
+				"@typescript/typescript-linux-loong64": "7.0.2",
+				"@typescript/typescript-linux-mips64el": "7.0.2",
+				"@typescript/typescript-linux-ppc64": "7.0.2",
+				"@typescript/typescript-linux-riscv64": "7.0.2",
+				"@typescript/typescript-linux-s390x": "7.0.2",
+				"@typescript/typescript-linux-x64": "7.0.2",
+				"@typescript/typescript-netbsd-arm64": "7.0.2",
+				"@typescript/typescript-netbsd-x64": "7.0.2",
+				"@typescript/typescript-openbsd-arm64": "7.0.2",
+				"@typescript/typescript-openbsd-x64": "7.0.2",
+				"@typescript/typescript-sunos-x64": "7.0.2",
+				"@typescript/typescript-win32-arm64": "7.0.2",
+				"@typescript/typescript-win32-x64": "7.0.2"
 			}
 		},
 		"node_modules/unconfig-core": {
@@ -6298,76 +6334,6 @@
 			},
 			"peerDependencies": {
 				"@cerios/xml-poto": "^2.3.3"
-			}
-		},
-		"packages/xml-poto-codegen/node_modules/typescript": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc"
-			},
-			"engines": {
-				"node": ">=16.20.0"
-			},
-			"optionalDependencies": {
-				"@typescript/typescript-aix-ppc64": "7.0.2",
-				"@typescript/typescript-darwin-arm64": "7.0.2",
-				"@typescript/typescript-darwin-x64": "7.0.2",
-				"@typescript/typescript-freebsd-arm64": "7.0.2",
-				"@typescript/typescript-freebsd-x64": "7.0.2",
-				"@typescript/typescript-linux-arm": "7.0.2",
-				"@typescript/typescript-linux-arm64": "7.0.2",
-				"@typescript/typescript-linux-loong64": "7.0.2",
-				"@typescript/typescript-linux-mips64el": "7.0.2",
-				"@typescript/typescript-linux-ppc64": "7.0.2",
-				"@typescript/typescript-linux-riscv64": "7.0.2",
-				"@typescript/typescript-linux-s390x": "7.0.2",
-				"@typescript/typescript-linux-x64": "7.0.2",
-				"@typescript/typescript-netbsd-arm64": "7.0.2",
-				"@typescript/typescript-netbsd-x64": "7.0.2",
-				"@typescript/typescript-openbsd-arm64": "7.0.2",
-				"@typescript/typescript-openbsd-x64": "7.0.2",
-				"@typescript/typescript-sunos-x64": "7.0.2",
-				"@typescript/typescript-win32-arm64": "7.0.2",
-				"@typescript/typescript-win32-x64": "7.0.2"
-			}
-		},
-		"packages/xml-poto/node_modules/typescript": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc"
-			},
-			"engines": {
-				"node": ">=16.20.0"
-			},
-			"optionalDependencies": {
-				"@typescript/typescript-aix-ppc64": "7.0.2",
-				"@typescript/typescript-darwin-arm64": "7.0.2",
-				"@typescript/typescript-darwin-x64": "7.0.2",
-				"@typescript/typescript-freebsd-arm64": "7.0.2",
-				"@typescript/typescript-freebsd-x64": "7.0.2",
-				"@typescript/typescript-linux-arm": "7.0.2",
-				"@typescript/typescript-linux-arm64": "7.0.2",
-				"@typescript/typescript-linux-loong64": "7.0.2",
-				"@typescript/typescript-linux-mips64el": "7.0.2",
-				"@typescript/typescript-linux-ppc64": "7.0.2",
-				"@typescript/typescript-linux-riscv64": "7.0.2",
-				"@typescript/typescript-linux-s390x": "7.0.2",
-				"@typescript/typescript-linux-x64": "7.0.2",
-				"@typescript/typescript-netbsd-arm64": "7.0.2",
-				"@typescript/typescript-netbsd-x64": "7.0.2",
-				"@typescript/typescript-openbsd-arm64": "7.0.2",
-				"@typescript/typescript-openbsd-x64": "7.0.2",
-				"@typescript/typescript-sunos-x64": "7.0.2",
-				"@typescript/typescript-win32-arm64": "7.0.2",
-				"@typescript/typescript-win32-x64": "7.0.2"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -24,22 +24,15 @@
 		"version-packages:prepare-release": "npm run version-packages && npm run format"
 	},
 	"devDependencies": {
-		"@changesets/cli": "^2.31.0",
+		"@changesets/cli": "^2.31.1",
 		"husky": "^9.1.7",
 		"lint-staged": "^17.0.8",
 		"npm-check-updates": "^22.2.9",
-		"oxfmt": "^0.58.0",
-		"oxlint": "^1.73.0",
+		"oxfmt": "^0.59.0",
+		"oxlint": "^1.74.0",
 		"oxlint-tsgolint": "^0.24.0",
 		"syncpack": "^15.3.2",
-		"vitest": "4.0.18"
-	},
-	"overrides": {
-		"@arethetypeswrong/cli": "^0.18.5",
-		"@types/node": "^26.1.1",
-		"tsdown": "^0.21.10",
-		"typescript": "^6.0.3",
-		"vitest": "4.0.18"
+		"vitest": "4.1.10"
 	},
 	"engines": {
 		"node": ">=20.19.0"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
 		"npm-check-updates": "^22.2.9",
 		"oxfmt": "^0.59.0",
 		"oxlint": "^1.74.0",
-		"oxlint-tsgolint": "^0.24.0",
+		"oxlint-tsgolint": "^0.25.0",
 		"syncpack": "^15.3.2",
+		"typescript": "^7.0.2",
 		"vitest": "4.1.10"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.31.1",
+		"esbuild": "^0.28.1",
 		"husky": "^9.1.7",
 		"lint-staged": "^17.0.8",
 		"npm-check-updates": "^22.2.9",

--- a/packages/xml-poto-codegen/CHANGELOG.md
+++ b/packages/xml-poto-codegen/CHANGELOG.md
@@ -29,14 +29,12 @@
   which broke CJS consumers and `@arethetypeswrong/cli` resolution.
 
   Updated in both packages:
-
   - `main`: `./dist/index.js` → `./dist/index.cjs`
   - `types`: `./dist/index.d.ts` → `./dist/index.d.cts`
   - `exports["."].require.default`: `./dist/index.js` → `./dist/index.cjs`
   - `exports["."].require.types`: `./dist/index.d.ts` → `./dist/index.d.cts`
 
   In `@cerios/xml-poto-codegen` the `bin` entry was also corrected:
-
   - `bin["xml-poto-codegen"]`: `dist/cli.js` → `dist/cli.cjs`
 
   ESM entry points (`.mjs` / `.d.mts`) were already correct and are unchanged.
@@ -56,14 +54,12 @@
 - c4f2ffd: Add `useXmlRoot` config option to control whether root elements get `@XmlRoot` or `@XmlElement`.
 
   When an XSD represents a subset of a larger schema, root elements should be embeddable rather than standalone. Setting `useXmlRoot: false` causes all root elements to be generated with `@XmlElement` instead of `@XmlRoot`, including all XSD-derivable options (`form`, `isNullable`, `namespace`).
-
   - **`useXmlRoot: true`** (default) — root elements get `@XmlRoot`, preserving existing behaviour.
   - **`useXmlRoot: false`** — root elements get `@XmlElement` with full option support. The schema's `elementFormDefault` is propagated as the `form` option on the class-level decorator.
 
   The option is available both globally (`XmlPotoCodegenConfig.useXmlRoot`) and per source (`XsdSource.useXmlRoot`), with per-source taking precedence.
 
   **Changes:**
-
   - `XsdSource` / `XmlPotoCodegenConfig` — new `useXmlRoot?: boolean` option.
   - `ConfigLoader.validateConfig()` — validates `useXmlRoot` as boolean on both levels.
   - `ClassGenerator` — accepts `useXmlRoot` and `elementFormDefault`; when `useXmlRoot` is false, root promotion is skipped and `form` is propagated from the schema.
@@ -75,7 +71,6 @@
 - c4f2ffd: Fix `XsdParser` throwing a cryptic tag-mismatch error when the input is not a valid XSD schema (e.g. an HTML page downloaded from a repository browser instead of the raw file).
 
   **Changes:**
-
   - `XsdParser.parseString()` now validates up front that the content has a schema root element (`<xs:schema>`, `<xsd:schema>`, `<schema>`, or any namespace-prefixed variant). Invalid input throws a clear, actionable error message instead of a cryptic internal parser error.
   - XML declarations (`<?xml ... ?>`) and XML comments before the root element are stripped before parsing, so schemas with leading comments are now handled correctly.
   - Include/import resolution was extracted into a private `resolveExternalSchemas()` method to keep `parseString` within complexity limits.
@@ -83,13 +78,11 @@
 - c4f2ffd: Implement `form` namespace qualification for `@XmlElement`, `@XmlAttribute`, and `@XmlArray`.
 
   The `form` option (`"qualified"` | `"unqualified"`) now has runtime effect, matching the XSD `form` attribute semantics:
-
   - **`"qualified"`** — the element or attribute is serialized with its namespace prefix (e.g. `<ns:city>`).
   - **`"unqualified"`** — the prefix is suppressed even when a namespace is configured (e.g. `<city>`), matching local elements in schemas with `elementFormDefault="unqualified"`.
   - **default (undefined)** — existing behaviour is preserved: prefix applied when present for `@XmlElement`/`@XmlAttribute`; no prefix on `@XmlArray` containers.
 
   **Changes in `@cerios/xml-poto`:**
-
   - `XmlNamespaceUtil.buildElementName()` — respects `form` when building the prefixed element name. Cache key now includes `form` to avoid cross-contamination.
   - `XmlNamespaceUtil.buildAttributeName()` — same logic; parameter type extended to accept `form?`.
   - `XmlMappingUtil.serializeArrayValue()` — container element name is now prefixed when `form === "qualified"` and a namespace prefix is configured.
@@ -97,7 +90,6 @@
   - `XmlArrayOptions` and `XmlArrayMetadata` — `form` option added (was already present on `XmlElementOptions`/`XmlAttributeOptions`).
 
   **Changes in `@cerios/xml-poto-codegen`:**
-
   - `buildArrayDecorator()` — now emits `form: '...'` in generated `@XmlArray` decorators, consistent with `@XmlElement` and `@XmlAttribute`.
 
 - Updated dependencies [c4f2ffd]
@@ -124,7 +116,6 @@
 - 6cce581: Initial commit of `@cerios/xml-poto-codegen`.
 
   This first version introduces the XML schema to TypeScript generator for `@cerios/xml-poto`, including:
-
   - CLI commands (`init`, `generate`) for project setup and generation workflows.
   - JSON and TypeScript config support with per-source overrides.
   - Multi-XSD processing with import resolution across schema files.

--- a/packages/xml-poto-codegen/README.md
+++ b/packages/xml-poto-codegen/README.md
@@ -11,6 +11,9 @@ Generate TypeScript classes with [`@cerios/xml-poto`](https://www.npmjs.com/pack
 
 - 🎯 **Type-Safe Output** — Generated classes with full TypeScript types and decorator metadata
 - 📄 **XSD Driven** — Supports complex types, enumerations, inheritance, namespaces, groups, and more
+- 🧼 **WSDL Input** — Extracts and merges all XSD schemas embedded in a WSDL `<types>` section
+- ✅ **Validation Built In** — XSD facets (pattern, length, numeric bounds, digits, whiteSpace), fixed values, `xs:list`, and `xs:choice` groups are emitted as runtime-validated decorator options
+- 📝 **JSDoc from XSD** — `xs:documentation` annotations become JSDoc on classes, properties, and enums
 - 🔧 **Configurable** — JSON or TypeScript config with per-source overrides
 - 📁 **Flexible Output** — One file per class (`per-type`) or all-in-one (`per-xsd`)
 - 🏷️ **Enum Styles** — Generate unions, TS enums, or const-object patterns
@@ -224,22 +227,28 @@ export type StatusType = (typeof StatusType)[keyof typeof StatusType];
 
 ## 🔧 XSD to Decorator Mapping
 
-| XSD Concept                  | Generated Code                    |
-| ---------------------------- | --------------------------------- |
-| Root element + complexType   | `@XmlRoot({ name: '...' })`       |
-| Named complexType            | `@XmlElement()` class             |
-| Element in sequence          | `@XmlElement({ name: '...' })`    |
-| Element with `maxOccurs > 1` | `@XmlArray({ itemName: '...' })`  |
-| Attribute                    | `@XmlAttribute({ name: '...' })`  |
-| simpleContent                | `@XmlText()`                      |
-| Enumeration restriction      | `enumValues` option               |
-| Pattern restriction          | `pattern` option                  |
-| `nillable="true"`            | `isNullable: true`                |
-| `xs:any`                     | `@XmlDynamic()`                   |
-| Extension base               | TypeScript `extends`              |
-| `xs:import`                  | Cross-file type resolution        |
-| `substitutionGroup`          | Resolved to concrete types        |
-| Groups / attributeGroups     | Inlined into the containing class |
+| XSD Concept                    | Generated Code                                                                  |
+| ------------------------------ | ------------------------------------------------------------------------------- |
+| Root element + complexType     | `@XmlRoot({ name: '...' })`                                                      |
+| Named complexType              | `@XmlElement()` class                                                            |
+| Element in sequence            | `@XmlElement({ name: '...' })`                                                   |
+| Element with `maxOccurs > 1`   | `@XmlArray({ itemName: '...' })` (+ `minOccurs`/`maxOccurs` for finite bounds)   |
+| Attribute                      | `@XmlAttribute({ name: '...' })`                                                 |
+| simpleContent                  | `@XmlText()`                                                                     |
+| Enumeration restriction        | `enumValues` option                                                              |
+| Pattern restriction            | `pattern` option (multiple `xs:pattern` facets are ORed)                         |
+| Facet restrictions             | `length`, `minLength`, `maxLength`, `min/maxInclusive`, `min/maxExclusive`, `totalDigits`, `fractionDigits`, `whiteSpace` |
+| `fixed="..."`                  | `fixedValue` option (default when absent, constraint when present)               |
+| `xs:list`                      | `list` option — space-separated text round-trips as a typed array                |
+| `xs:choice`                    | `choiceGroup` / `choiceRequired` options (exclusive-member validation)           |
+| `nillable="true"`              | `isNullable: true` (round-trips `xsi:nil`)                                       |
+| `xs:annotation/documentation`  | JSDoc comments                                                                   |
+| `xs:any`                       | `@XmlDynamic()`                                                                  |
+| Extension base                 | TypeScript `extends`                                                             |
+| `xs:import` / `xs:include`     | Cross-file type resolution                                                       |
+| WSDL `<definitions>` documents | Embedded `<types>` schemas extracted and merged                                  |
+| `substitutionGroup`            | Resolved to concrete types                                                       |
+| Groups / attributeGroups       | Inlined into the containing class                                                |
 
 ### Coverage Notes
 
@@ -248,6 +257,11 @@ Codegen focuses on what can be inferred from XSD structure and constraints. The 
 - Generated from XSD: `@XmlRoot`, `@XmlElement`, `@XmlAttribute`, `@XmlText`, `@XmlArray`, `@XmlDynamic`
 - Not generated (manual only): `@XmlComment`, `@XmlIgnore`
 - Partial option coverage by design: runtime tuning options such as custom converters/transforms, CDATA toggles, mixed-content behavior flags, and advanced `@XmlDynamic` parse/cache/lazy settings are not inferred from XSD and must be added manually when needed.
+- Parsed but reported as warnings only (no class-level representation): identity constraints (`xs:key`/`xs:keyref`/`xs:unique`), `xs:notation`, `xs:redefine` overrides, `use="prohibited"` attributes (omitted), and remote (`http(s)`) `schemaLocation` references (not fetched).
+
+### WSDL Input
+
+Files whose root element is `<definitions>` (SOAP/WSDL) are detected automatically — the extension does not matter (`.xsd` or `.wsdl`). All `<schema>` elements inside the WSDL `<types>` section are extracted, inherit the namespace declarations from `<definitions>`, and are merged into a single schema before generation. WSDL-only artifacts (messages, port types, bindings, services) are ignored.
 
 ## 📁 Output Styles
 

--- a/packages/xml-poto-codegen/README.md
+++ b/packages/xml-poto-codegen/README.md
@@ -286,6 +286,12 @@ src/generated/
   └── my-schema.ts
 ```
 
+### Declaration Order & Circular Types
+
+Generated classes are always declared dependency-first (base types and referenced types before their dependents), regardless of the declaration order in the XSD — the order is stable, so schemas already in a valid order generate unchanged output.
+
+Circular and self-referencing types (e.g. a `Section` containing `Section` children), which no declaration order can satisfy, are emitted as lazy references (`type: () => Section`). In `per-type` mode, classes connected by an `extends` relationship inside a reference cycle are placed together in one file (named after the base class), because a cyclic `extends` split across ES modules cannot evaluate in any import order.
+
 ## 💡 Why Codegen?
 
 ### Without codegen ❌

--- a/packages/xml-poto-codegen/README.md
+++ b/packages/xml-poto-codegen/README.md
@@ -227,28 +227,28 @@ export type StatusType = (typeof StatusType)[keyof typeof StatusType];
 
 ## 🔧 XSD to Decorator Mapping
 
-| XSD Concept                    | Generated Code                                                                  |
-| ------------------------------ | ------------------------------------------------------------------------------- |
-| Root element + complexType     | `@XmlRoot({ name: '...' })`                                                      |
-| Named complexType              | `@XmlElement()` class                                                            |
-| Element in sequence            | `@XmlElement({ name: '...' })`                                                   |
-| Element with `maxOccurs > 1`   | `@XmlArray({ itemName: '...' })` (+ `minOccurs`/`maxOccurs` for finite bounds)   |
-| Attribute                      | `@XmlAttribute({ name: '...' })`                                                 |
-| simpleContent                  | `@XmlText()`                                                                     |
-| Enumeration restriction        | `enumValues` option                                                              |
-| Pattern restriction            | `pattern` option (multiple `xs:pattern` facets are ORed)                         |
+| XSD Concept                    | Generated Code                                                                                                            |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| Root element + complexType     | `@XmlRoot({ name: '...' })`                                                                                               |
+| Named complexType              | `@XmlElement()` class                                                                                                     |
+| Element in sequence            | `@XmlElement({ name: '...' })`                                                                                            |
+| Element with `maxOccurs > 1`   | `@XmlArray({ itemName: '...' })` (+ `minOccurs`/`maxOccurs` for finite bounds)                                            |
+| Attribute                      | `@XmlAttribute({ name: '...' })`                                                                                          |
+| simpleContent                  | `@XmlText()`                                                                                                              |
+| Enumeration restriction        | `enumValues` option                                                                                                       |
+| Pattern restriction            | `pattern` option (multiple `xs:pattern` facets are ORed)                                                                  |
 | Facet restrictions             | `length`, `minLength`, `maxLength`, `min/maxInclusive`, `min/maxExclusive`, `totalDigits`, `fractionDigits`, `whiteSpace` |
-| `fixed="..."`                  | `fixedValue` option (default when absent, constraint when present)               |
-| `xs:list`                      | `list` option — space-separated text round-trips as a typed array                |
-| `xs:choice`                    | `choiceGroup` / `choiceRequired` options (exclusive-member validation)           |
-| `nillable="true"`              | `isNullable: true` (round-trips `xsi:nil`)                                       |
-| `xs:annotation/documentation`  | JSDoc comments                                                                   |
-| `xs:any`                       | `@XmlDynamic()`                                                                  |
-| Extension base                 | TypeScript `extends`                                                             |
-| `xs:import` / `xs:include`     | Cross-file type resolution                                                       |
-| WSDL `<definitions>` documents | Embedded `<types>` schemas extracted and merged                                  |
-| `substitutionGroup`            | Resolved to concrete types                                                       |
-| Groups / attributeGroups       | Inlined into the containing class                                                |
+| `fixed="..."`                  | `fixedValue` option (default when absent, constraint when present)                                                        |
+| `xs:list`                      | `list` option — space-separated text round-trips as a typed array                                                         |
+| `xs:choice`                    | `choiceGroup` / `choiceRequired` options (exclusive-member validation)                                                    |
+| `nillable="true"`              | `isNullable: true` (round-trips `xsi:nil`)                                                                                |
+| `xs:annotation/documentation`  | JSDoc comments                                                                                                            |
+| `xs:any`                       | `@XmlDynamic()`                                                                                                           |
+| Extension base                 | TypeScript `extends`                                                                                                      |
+| `xs:import` / `xs:include`     | Cross-file type resolution                                                                                                |
+| WSDL `<definitions>` documents | Embedded `<types>` schemas extracted and merged                                                                           |
+| `substitutionGroup`            | Resolved to concrete types                                                                                                |
+| Groups / attributeGroups       | Inlined into the containing class                                                                                         |
 
 ### Coverage Notes
 

--- a/packages/xml-poto-codegen/package.json
+++ b/packages/xml-poto-codegen/package.json
@@ -62,6 +62,7 @@
 	"devDependencies": {
 		"@cerios/xml-poto": "2.3.3",
 		"@types/node": "^26.1.1",
+		"esbuild": "^0.28.1",
 		"tsdown": "^0.22.9",
 		"typescript": "^7.0.2",
 		"vitest": "4.1.10"

--- a/packages/xml-poto-codegen/package.json
+++ b/packages/xml-poto-codegen/package.json
@@ -48,7 +48,7 @@
 		"./package.json": "./package.json"
 	},
 	"scripts": {
-		"build": "tsdown --config-loader bundle",
+		"build": "tsdown",
 		"test": "vitest --run",
 		"test:coverage": "vitest --coverage",
 		"test:watch": "vitest --watch",

--- a/packages/xml-poto-codegen/package.json
+++ b/packages/xml-poto-codegen/package.json
@@ -62,12 +62,9 @@
 	"devDependencies": {
 		"@cerios/xml-poto": "2.3.3",
 		"@types/node": "^26.1.1",
-		"oxfmt": "^0.58.0",
-		"oxlint": "^1.73.0",
-		"oxlint-tsgolint": "^0.24.0",
-		"tsdown": "^0.21.10",
-		"typescript": "^6.0.3",
-		"vitest": "4.0.18"
+		"tsdown": "^0.22.9",
+		"typescript": "^7.0.2",
+		"vitest": "4.1.10"
 	},
 	"peerDependencies": {
 		"@cerios/xml-poto": "^2.3.3"

--- a/packages/xml-poto-codegen/src/commands/generate.ts
+++ b/packages/xml-poto-codegen/src/commands/generate.ts
@@ -133,9 +133,9 @@ function looksLikeTypeScriptFile(value: string): boolean {
 function reportCoverageWarnings(resolved: ReturnType<XsdResolver["resolve"]>): void {
 	reportMultiRootAliasWarnings(resolved);
 
-	const { unsupportedFacetProps, fixedConstraintProps } = collectPropertyCoverageWarnings(resolved);
-	warnUnsupportedFacets(unsupportedFacetProps);
-	warnFixedConstraints(fixedConstraintProps);
+	for (const note of resolved.coverageNotes ?? []) {
+		console.warn(`  Warning: ${note}`);
+	}
 }
 
 function reportMultiRootAliasWarnings(resolved: ReturnType<XsdResolver["resolve"]>): void {
@@ -160,60 +160,4 @@ function reportMultiRootAliasWarnings(resolved: ReturnType<XsdResolver["resolve"
 			`  Warning: Type '${typeName}' is referenced by multiple root elements (${rootNames.join(", ")}). Using '${rootNames[0]}' as the generated @XmlRoot name.`,
 		);
 	}
-}
-
-function collectPropertyCoverageWarnings(resolved: ReturnType<XsdResolver["resolve"]>): {
-	unsupportedFacetProps: string[];
-	fixedConstraintProps: string[];
-} {
-	const unsupportedFacetProps: string[] = [];
-	const fixedConstraintProps: string[] = [];
-
-	for (const type of resolved.types) {
-		for (const prop of type.properties) {
-			if (hasUnsupportedFacet(prop)) {
-				unsupportedFacetProps.push(`${type.className}.${prop.propertyName}`);
-			}
-
-			if (prop.fixedValue !== undefined) {
-				fixedConstraintProps.push(`${type.className}.${prop.propertyName}`);
-			}
-		}
-	}
-
-	return { unsupportedFacetProps, fixedConstraintProps };
-}
-
-function hasUnsupportedFacet(prop: ReturnType<XsdResolver["resolve"]>["types"][number]["properties"][number]): boolean {
-	return (
-		prop.minLength !== undefined ||
-		prop.maxLength !== undefined ||
-		prop.minInclusive !== undefined ||
-		prop.maxInclusive !== undefined ||
-		prop.minExclusive !== undefined ||
-		prop.maxExclusive !== undefined ||
-		prop.totalDigits !== undefined ||
-		prop.fractionDigits !== undefined ||
-		prop.whiteSpace !== undefined
-	);
-}
-
-function warnUnsupportedFacets(unsupportedFacetProps: string[]): void {
-	if (unsupportedFacetProps.length === 0) {
-		return;
-	}
-
-	console.warn(
-		`  Warning: ${unsupportedFacetProps.length} property(ies) use XSD facets not fully enforced by generated decorators (${unsupportedFacetProps.join(", ")}).`,
-	);
-}
-
-function warnFixedConstraints(fixedConstraintProps: string[]): void {
-	if (fixedConstraintProps.length === 0) {
-		return;
-	}
-
-	console.warn(
-		`  Warning: ${fixedConstraintProps.length} property(ies) use XSD fixed constraints. Generated code applies defaults, but strict fixed-value enforcement may require manual validation (${fixedConstraintProps.join(", ")}).`,
-	);
 }

--- a/packages/xml-poto-codegen/src/commands/init.ts
+++ b/packages/xml-poto-codegen/src/commands/init.ts
@@ -259,7 +259,7 @@ function buildPerXsdDefaultOutputPath(xsdPath: string): string {
 
 async function askForXsdPath(): Promise<string> {
 	while (true) {
-		const xsdPath = await ask("XSD file path: ");
+		const xsdPath = await ask("XSD or WSDL file path: ");
 
 		if (!xsdPath) {
 			console.log("XSD path is required.");

--- a/packages/xml-poto-codegen/src/generator/class-generator.ts
+++ b/packages/xml-poto-codegen/src/generator/class-generator.ts
@@ -9,7 +9,7 @@ export interface ClassGeneratorOptions {
 }
 
 import { collectImports, mapClassDecorator, mapPropertyDecorator } from "./decorator-mapper";
-import { buildFileHeader, buildImport, buildProperty, toKebabCase } from "./ts-builder";
+import { buildFileHeader, buildImport, buildJsDoc, buildProperty, indent, toKebabCase } from "./ts-builder";
 
 export interface GeneratedFile {
 	/** Filename (without directory) */
@@ -170,14 +170,15 @@ export class ClassGenerator {
 	// ── Source generation ──
 
 	private generateEnumSource(enumDef: ResolvedEnum): string {
+		const jsDoc = enumDef.documentation ? `${buildJsDoc(enumDef.documentation)}\n` : "";
 		switch (this.enumStyle) {
 			case "enum":
-				return this.generateEnumAsEnum(enumDef);
+				return jsDoc + this.generateEnumAsEnum(enumDef);
 			case "const-object":
-				return this.generateEnumAsConstObject(enumDef);
+				return jsDoc + this.generateEnumAsConstObject(enumDef);
 			case "union":
 			default:
-				return this.generateEnumAsUnion(enumDef);
+				return jsDoc + this.generateEnumAsUnion(enumDef);
 		}
 	}
 
@@ -214,6 +215,11 @@ export class ClassGenerator {
 	private generateClassSource(type: ResolvedType): string {
 		const lines: string[] = [];
 
+		// JSDoc from xs:documentation
+		if (type.documentation) {
+			lines.push(buildJsDoc(type.documentation));
+		}
+
 		// Class decorator
 		lines.push(mapClassDecorator(type));
 
@@ -227,6 +233,9 @@ export class ClassGenerator {
 			// Treat only `required === true` as required; `false` or `undefined` are optional.
 			const isOptional = prop.required !== true;
 			const initializer = isOptional ? undefined : prop.initializer;
+			if (prop.documentation) {
+				lines.push(indent(buildJsDoc(prop.documentation), 1));
+			}
 			lines.push(`\t${decorator}`);
 			lines.push(`\t${buildProperty(prop.propertyName, prop.tsType, initializer, isOptional)}`);
 			lines.push("");

--- a/packages/xml-poto-codegen/src/generator/class-generator.ts
+++ b/packages/xml-poto-codegen/src/generator/class-generator.ts
@@ -10,6 +10,7 @@ export interface ClassGeneratorOptions {
 
 import { collectImports, mapClassDecorator, mapPropertyDecorator } from "./decorator-mapper";
 import { buildFileHeader, buildImport, buildJsDoc, buildProperty, indent, toKebabCase } from "./ts-builder";
+import { sortTypesByDependency } from "./type-sorter";
 
 export interface GeneratedFile {
 	/** Filename (without directory) */
@@ -41,17 +42,39 @@ export class ClassGenerator {
 	 * Generate files in 'per-type' mode: one file per class/enum + barrel index.
 	 */
 	generatePerType(schema: ResolvedSchema): GeneratedFile[] {
-		const files: GeneratedFile[] = [];
-		const resolvedTypes = this.applyRootElements(schema.types, schema.rootElements);
+		const { sorted, lazyRefs, sameModuleClusters } = sortTypesByDependency(
+			this.applyRootElements(schema.types, schema.rootElements),
+		);
 
-		// Generate enum files
-		for (const enumDef of schema.enums) {
-			files.push(this.generateEnumFile(enumDef));
+		// One file per class, except classes linked by an extends edge inside a
+		// dependency cycle: those must share a module (an extends clause
+		// evaluates eagerly, so splitting the cycle across modules always leaves
+		// some import order that hits the base class's temporal dead zone).
+		// A shared file is named after its first (base) class.
+		const fileBaseByClass = new Map<string, string>();
+		for (const cluster of sameModuleClusters) {
+			const fileBase = toKebabCase(cluster[0]);
+			for (const className of cluster) {
+				fileBaseByClass.set(className, fileBase);
+			}
+		}
+		for (const type of sorted) {
+			if (!fileBaseByClass.has(type.className)) {
+				fileBaseByClass.set(type.className, toKebabCase(type.className));
+			}
 		}
 
-		// Generate class files
-		for (const type of resolvedTypes) {
-			files.push(this.generateClassFile(type, resolvedTypes, schema.enums));
+		const fileGroups = new Map<string, ResolvedType[]>();
+		for (const type of sorted) {
+			const fileBase = fileBaseByClass.get(type.className) as string;
+			const group = fileGroups.get(fileBase);
+			if (group) group.push(type);
+			else fileGroups.set(fileBase, [type]);
+		}
+
+		const files = schema.enums.map((enumDef) => this.generateEnumFile(enumDef));
+		for (const [fileBase, groupTypes] of fileGroups) {
+			files.push(this.generateClassFile(fileBase, groupTypes, fileBaseByClass, schema.enums, lazyRefs));
 		}
 
 		// Generate barrel export
@@ -84,26 +107,38 @@ export class ClassGenerator {
 		};
 	}
 
-	private generateClassFile(type: ResolvedType, allTypes: ResolvedType[], allEnums: ResolvedEnum[]): GeneratedFile {
-		const fileName = `${toKebabCase(type.className)}.ts`;
-		const imports = collectImports(type);
-		const localImports = this.collectLocalImports(type, allTypes, allEnums);
+	private generateClassFile(
+		fileBase: string,
+		types: ResolvedType[],
+		fileBaseByClass: ReadonlyMap<string, string>,
+		allEnums: ResolvedEnum[],
+		lazyRefs: ReadonlyMap<string, Set<string>>,
+	): GeneratedFile {
+		const imports = new Set<string>();
+		for (const type of types) {
+			for (const imp of collectImports(type)) {
+				imports.add(imp);
+			}
+		}
+		const localImports = this.collectLocalImports(types, fileBase, fileBaseByClass, allEnums);
 
 		const lines: string[] = [buildFileHeader(this.xsdPath), buildImport([...imports], this.importPath)];
 
 		// Add local imports for referenced types
-		for (const [name, file] of localImports) {
-			lines.push(buildImport([name], `./${file.replace(".ts", "")}`));
+		for (const [file, names] of localImports) {
+			lines.push(buildImport(names, `./${file}`));
 		}
 
 		lines.push("");
-		lines.push(this.generateClassSource(type));
-		lines.push("");
+		for (const type of types) {
+			lines.push(this.generateClassSource(type, lazyRefs.get(type.className)));
+			lines.push("");
+		}
 
 		return {
-			fileName,
+			fileName: `${fileBase}.ts`,
 			content: lines.join("\n"),
-			exports: [type.className],
+			exports: types.map((type) => type.className),
 		};
 	}
 
@@ -128,17 +163,20 @@ export class ClassGenerator {
 		const allImports = new Set<string>();
 		const allExports: string[] = [];
 		const parts: string[] = [buildFileHeader(this.xsdPath)];
-		const resolvedTypes = this.applyRootElements(schema.types, schema.rootElements);
+		// Emit classes dependency-first: extends clauses and decorator `type:`
+		// references are evaluated at class-definition time, so a class must be
+		// declared after everything it references (thunks cover the cyclic rest).
+		const { sorted, lazyRefs } = sortTypesByDependency(this.applyRootElements(schema.types, schema.rootElements));
 
 		// Collect all imports
-		for (const type of resolvedTypes) {
+		for (const type of sorted) {
 			for (const imp of collectImports(type)) {
 				allImports.add(imp);
 			}
 		}
 
 		// Check if DynamicElement is needed
-		const needsDynamic = resolvedTypes.some((t) => t.properties.some((p) => p.kind === "dynamic"));
+		const needsDynamic = sorted.some((t) => t.properties.some((p) => p.kind === "dynamic"));
 		if (needsDynamic) {
 			allImports.add("DynamicElement");
 		}
@@ -154,8 +192,8 @@ export class ClassGenerator {
 		}
 
 		// Generate classes
-		for (const type of resolvedTypes) {
-			parts.push(this.generateClassSource(type));
+		for (const type of sorted) {
+			parts.push(this.generateClassSource(type, lazyRefs.get(type.className)));
 			parts.push("");
 			allExports.push(type.className);
 		}
@@ -212,7 +250,7 @@ export class ClassGenerator {
 		return `${constDecl}\n${typeDecl}`;
 	}
 
-	private generateClassSource(type: ResolvedType): string {
+	private generateClassSource(type: ResolvedType, lazyTypeNames?: ReadonlySet<string>): string {
 		const lines: string[] = [];
 
 		// JSDoc from xs:documentation
@@ -229,15 +267,19 @@ export class ClassGenerator {
 
 		// Properties
 		for (const prop of type.properties) {
-			const decorator = mapPropertyDecorator(prop);
+			const decorator = mapPropertyDecorator(prop, lazyTypeNames);
 			// Treat only `required === true` as required; `false` or `undefined` are optional.
 			const isOptional = prop.required !== true;
-			const initializer = isOptional ? undefined : prop.initializer;
+			// Required enum-typed properties: the resolver's initializer is the base
+			// type's ('' / 0), which is not assignable to the enum type. Emit a
+			// definite-assignment assertion instead of inventing an enum value.
+			const useDefiniteAssignment = !isOptional && prop.enumTypeName !== undefined;
+			const initializer = isOptional || useDefiniteAssignment ? undefined : prop.initializer;
 			if (prop.documentation) {
 				lines.push(indent(buildJsDoc(prop.documentation), 1));
 			}
 			lines.push(`\t${decorator}`);
-			lines.push(`\t${buildProperty(prop.propertyName, prop.tsType, initializer, isOptional)}`);
+			lines.push(`\t${buildProperty(prop.propertyName, prop.tsType, initializer, isOptional, useDefiniteAssignment)}`);
 			lines.push("");
 		}
 
@@ -253,37 +295,40 @@ export class ClassGenerator {
 
 	// ── Helpers ──
 
+	/**
+	 * Collect imports for the referenced classes/enums of all types in a file,
+	 * grouped by the target file they are generated into. References to classes
+	 * in the same file (including self-references) need no import.
+	 */
 	private collectLocalImports(
-		type: ResolvedType,
-		allTypes: ResolvedType[],
+		types: ResolvedType[],
+		ownFileBase: string,
+		fileBaseByClass: ReadonlyMap<string, string>,
 		allEnums: ResolvedEnum[],
-	): Map<string, string> {
-		const imports = new Map<string, string>();
-		const typeNames = new Set(allTypes.map((t) => t.className));
+	): Map<string, string[]> {
 		const enumNames = new Set(allEnums.map((e) => e.name));
+		const namesByFile = new Map<string, Set<string>>();
 
-		// Check base type
-		if (type.baseTypeName && typeNames.has(type.baseTypeName)) {
-			imports.set(type.baseTypeName, `${toKebabCase(type.baseTypeName)}.ts`);
+		const addImport = (name: string | undefined): void => {
+			if (!name) return;
+			// Classes live in the file the sorter assigned them to; enums each in their own file.
+			const targetFile = fileBaseByClass.get(name) ?? (enumNames.has(name) ? toKebabCase(name) : undefined);
+			if (targetFile === undefined || targetFile === ownFileBase) return;
+			const names = namesByFile.get(targetFile);
+			if (names) names.add(name);
+			else namesByFile.set(targetFile, new Set([name]));
+		};
+
+		for (const type of types) {
+			addImport(type.baseTypeName);
+			for (const prop of type.properties) {
+				addImport(prop.complexTypeName);
+				addImport(prop.arrayItemType);
+				addImport(prop.enumTypeName);
+			}
 		}
 
-		// Check property types
-		for (const prop of type.properties) {
-			if (prop.complexTypeName && typeNames.has(prop.complexTypeName)) {
-				imports.set(prop.complexTypeName, `${toKebabCase(prop.complexTypeName)}.ts`);
-			}
-			if (prop.arrayItemType && typeNames.has(prop.arrayItemType)) {
-				imports.set(prop.arrayItemType, `${toKebabCase(prop.arrayItemType)}.ts`);
-			}
-			if (prop.enumTypeName && enumNames.has(prop.enumTypeName)) {
-				imports.set(prop.enumTypeName, `${toKebabCase(prop.enumTypeName)}.ts`);
-			}
-		}
-
-		// Remove self-reference
-		imports.delete(type.className);
-
-		return imports;
+		return new Map([...namesByFile.entries()].map(([file, names]) => [file, [...names]]));
 	}
 
 	private applyRootElements(types: ResolvedType[], rootElements: ResolvedSchema["rootElements"]): ResolvedType[] {

--- a/packages/xml-poto-codegen/src/generator/decorator-mapper.ts
+++ b/packages/xml-poto-codegen/src/generator/decorator-mapper.ts
@@ -33,17 +33,24 @@ export function mapClassDecorator(type: ResolvedType): string {
 	return buildDecorator("XmlElement", opts);
 }
 
-/** Get the property-level decorator string for a resolved property */
-export function mapPropertyDecorator(prop: ResolvedProperty): string {
+/**
+ * Get the property-level decorator string for a resolved property.
+ *
+ * `lazyTypeNames` lists referenced classes that cannot be declared before this
+ * one (circular/self references); their `type:` options are emitted as
+ * `() => Foo` thunks instead of direct identifiers, which would be evaluated
+ * while the referenced class is still in its temporal dead zone.
+ */
+export function mapPropertyDecorator(prop: ResolvedProperty, lazyTypeNames?: ReadonlySet<string>): string {
 	switch (prop.kind) {
 		case "element":
-			return buildElementDecorator(prop);
+			return buildElementDecorator(prop, lazyTypeNames);
 		case "attribute":
 			return buildAttributeDecorator(prop);
 		case "text":
 			return buildTextDecorator(prop);
 		case "array":
-			return buildArrayDecorator(prop);
+			return buildArrayDecorator(prop, lazyTypeNames);
 		case "dynamic":
 			return buildDynamicDecorator(prop);
 		default:
@@ -118,7 +125,12 @@ function applyChoiceOptions(opts: Record<string, unknown>, prop: ResolvedPropert
 	if (prop.choiceRequired) opts.choiceRequired = true;
 }
 
-function buildElementDecorator(prop: ResolvedProperty): string {
+/** Emit a runtime class reference: a direct identifier, or a thunk for lazy (circular) references */
+function formatTypeRef(className: string, lazyTypeNames?: ReadonlySet<string>): string {
+	return lazyTypeNames?.has(className) ? `() => ${className}` : className;
+}
+
+function buildElementDecorator(prop: ResolvedProperty, lazyTypeNames?: ReadonlySet<string>): string {
 	const opts: Record<string, unknown> = {};
 
 	opts.name = `'${prop.xmlName}'`;
@@ -129,7 +141,7 @@ function buildElementDecorator(prop: ResolvedProperty): string {
 	if (prop.form) opts.form = `'${prop.form}'`;
 	if (prop.namespace) opts.namespace = buildNamespaceObj(prop.namespace);
 	if (prop.defaultValue !== undefined) opts.defaultValue = formatDefault(prop.tsType, prop.defaultValue);
-	if (prop.complexTypeName) opts.type = prop.complexTypeName;
+	if (prop.complexTypeName) opts.type = formatTypeRef(prop.complexTypeName, lazyTypeNames);
 	if (prop.dataType) opts.dataType = `'${prop.dataType}'`;
 	applyFacetOptions(opts, prop);
 	applyListOption(opts, prop);
@@ -165,12 +177,12 @@ function buildTextDecorator(prop: ResolvedProperty): string {
 	return buildDecorator("XmlText", opts);
 }
 
-function buildArrayDecorator(prop: ResolvedProperty): string {
+function buildArrayDecorator(prop: ResolvedProperty, lazyTypeNames?: ReadonlySet<string>): string {
 	const opts: Record<string, unknown> = {};
 
 	if (prop.arrayItemName) opts.itemName = `'${prop.arrayItemName}'`;
 	if (prop.arrayContainerName) opts.containerName = `'${prop.arrayContainerName}'`;
-	if (prop.arrayItemType) opts.type = prop.arrayItemType;
+	if (prop.arrayItemType) opts.type = formatTypeRef(prop.arrayItemType, lazyTypeNames);
 	if (prop.order !== undefined) opts.order = prop.order;
 	if (prop.isNullable) opts.isNullable = true;
 	if (prop.form) opts.form = `'${prop.form}'`;

--- a/packages/xml-poto-codegen/src/generator/decorator-mapper.ts
+++ b/packages/xml-poto-codegen/src/generator/decorator-mapper.ts
@@ -84,6 +84,40 @@ export function collectImports(type: ResolvedType): Set<string> {
 
 // ── Individual Decorator Builders ──
 
+/**
+ * Emit the shared XSD facet options (validated at runtime by xml-poto).
+ * enumValues/pattern come first to keep the historical option order.
+ */
+function applyFacetOptions(opts: Record<string, unknown>, prop: ResolvedProperty): void {
+	if (prop.enumValues && prop.enumValues.length > 0)
+		opts.enumValues = prop.enumValues.map((v) => `'${escapeString(v)}'`);
+	if (prop.pattern) opts.pattern = `new RegExp(${JSON.stringify(prop.pattern)})`;
+	if (prop.length !== undefined) opts.length = prop.length;
+	if (prop.minLength !== undefined) opts.minLength = prop.minLength;
+	if (prop.maxLength !== undefined) opts.maxLength = prop.maxLength;
+	if (prop.minInclusive !== undefined) opts.minInclusive = prop.minInclusive;
+	if (prop.maxInclusive !== undefined) opts.maxInclusive = prop.maxInclusive;
+	if (prop.minExclusive !== undefined) opts.minExclusive = prop.minExclusive;
+	if (prop.maxExclusive !== undefined) opts.maxExclusive = prop.maxExclusive;
+	if (prop.totalDigits !== undefined) opts.totalDigits = prop.totalDigits;
+	if (prop.fractionDigits !== undefined) opts.fractionDigits = prop.fractionDigits;
+	if (prop.whiteSpace) opts.whiteSpace = `'${prop.whiteSpace}'`;
+	if (prop.fixedValue !== undefined) opts.fixedValue = formatFixedValue(prop, prop.fixedValue);
+}
+
+/** Emit the xs:list option for list-valued properties */
+function applyListOption(opts: Record<string, unknown>, prop: ResolvedProperty): void {
+	if (!prop.isList) return;
+	opts.list = prop.listItemType && prop.listItemType !== "string" ? `{ itemType: '${prop.listItemType}' }` : true;
+}
+
+/** Emit choice group options for xs:choice members */
+function applyChoiceOptions(opts: Record<string, unknown>, prop: ResolvedProperty): void {
+	if (!prop.choiceGroup) return;
+	opts.choiceGroup = `'${prop.choiceGroup}'`;
+	if (prop.choiceRequired) opts.choiceRequired = true;
+}
+
 function buildElementDecorator(prop: ResolvedProperty): string {
 	const opts: Record<string, unknown> = {};
 
@@ -97,6 +131,9 @@ function buildElementDecorator(prop: ResolvedProperty): string {
 	if (prop.defaultValue !== undefined) opts.defaultValue = formatDefault(prop.tsType, prop.defaultValue);
 	if (prop.complexTypeName) opts.type = prop.complexTypeName;
 	if (prop.dataType) opts.dataType = `'${prop.dataType}'`;
+	applyFacetOptions(opts, prop);
+	applyListOption(opts, prop);
+	applyChoiceOptions(opts, prop);
 
 	return buildDecorator("XmlElement", opts);
 }
@@ -109,9 +146,8 @@ function buildAttributeDecorator(prop: ResolvedProperty): string {
 	if (prop.required) opts.required = true;
 	if (prop.form) opts.form = `'${prop.form}'`;
 	if (prop.defaultValue !== undefined) opts.defaultValue = formatDefault(prop.tsType, prop.defaultValue);
-	if (prop.enumValues && prop.enumValues.length > 0)
-		opts.enumValues = prop.enumValues.map((v) => `'${escapeString(v)}'`);
-	if (prop.pattern) opts.pattern = `new RegExp(${JSON.stringify(prop.pattern)})`;
+	applyFacetOptions(opts, prop);
+	applyListOption(opts, prop);
 	if (prop.dataType) opts.dataType = `'${prop.dataType}'`;
 	if (prop.namespace) opts.namespace = buildNamespaceObj(prop.namespace);
 
@@ -123,6 +159,8 @@ function buildTextDecorator(prop: ResolvedProperty): string {
 
 	if (prop.required) opts.required = true;
 	if (prop.dataType) opts.dataType = `'${prop.dataType}'`;
+	applyFacetOptions(opts, prop);
+	applyListOption(opts, prop);
 
 	return buildDecorator("XmlText", opts);
 }
@@ -138,6 +176,10 @@ function buildArrayDecorator(prop: ResolvedProperty): string {
 	if (prop.form) opts.form = `'${prop.form}'`;
 	if (prop.namespace) opts.namespace = buildNamespaceObj(prop.namespace);
 	if (prop.dataType) opts.dataType = `'${prop.dataType}'`;
+	applyFacetOptions(opts, prop);
+	if (prop.minOccursCount !== undefined) opts.minOccurs = prop.minOccursCount;
+	if (prop.maxOccursCount !== undefined) opts.maxOccurs = prop.maxOccursCount;
+	applyChoiceOptions(opts, prop);
 
 	return buildDecorator("XmlArray", opts);
 }
@@ -162,6 +204,12 @@ function formatDefault(tsType: string, value: string): string {
 	if (tsType === "number") return value;
 	if (tsType === "boolean") return value === "true" ? "true" : "false";
 	return `'${escapeString(value)}'`;
+}
+
+function formatFixedValue(prop: ResolvedProperty, value: string): string {
+	// For lists, the fixed value applies to items — format by the item type.
+	const tsType = prop.isList ? (prop.listItemType ?? "string") : prop.tsType;
+	return formatDefault(tsType, value);
 }
 
 function escapeString(value: string): string {

--- a/packages/xml-poto-codegen/src/generator/ts-builder.ts
+++ b/packages/xml-poto-codegen/src/generator/ts-builder.ts
@@ -96,12 +96,18 @@ function wrapText(text: string, width: number): string[] {
 }
 
 /** Build a class property declaration line */
-export function buildProperty(name: string, type: string, initializer?: string, optional = false): string {
-	const optionalMark = optional ? "?" : "";
+export function buildProperty(
+	name: string,
+	type: string,
+	initializer?: string,
+	optional = false,
+	definite = false,
+): string {
+	const marker = optional ? "?" : definite ? "!" : "";
 	if (initializer === undefined) {
-		return `${name}${optionalMark}: ${type};`;
+		return `${name}${marker}: ${type};`;
 	}
-	return `${name}${optionalMark}: ${type} = ${initializer};`;
+	return `${name}${marker}: ${type} = ${initializer};`;
 }
 
 /** Build the auto-generated file header */

--- a/packages/xml-poto-codegen/src/generator/ts-builder.ts
+++ b/packages/xml-poto-codegen/src/generator/ts-builder.ts
@@ -65,6 +65,36 @@ export function formatValue(value: unknown): string {
 	return String(value);
 }
 
+/** Build a JSDoc comment block from documentation text (lines wrapped at ~100 chars) */
+export function buildJsDoc(text: string): string {
+	const escaped = text.replace(/\*\//g, "*\\/");
+	const lines: string[] = [];
+	for (const paragraph of escaped.split("\n")) {
+		lines.push(...wrapText(paragraph, 100));
+	}
+
+	if (lines.length === 1) {
+		return `/** ${lines[0]} */`;
+	}
+	return ["/**", ...lines.map((l) => ` * ${l}`), " */"].join("\n");
+}
+
+function wrapText(text: string, width: number): string[] {
+	const words = text.split(/\s+/).filter(Boolean);
+	const lines: string[] = [];
+	let current = "";
+	for (const word of words) {
+		if (current && current.length + word.length + 1 > width) {
+			lines.push(current);
+			current = word;
+		} else {
+			current = current ? `${current} ${word}` : word;
+		}
+	}
+	if (current) lines.push(current);
+	return lines;
+}
+
 /** Build a class property declaration line */
 export function buildProperty(name: string, type: string, initializer?: string, optional = false): string {
 	const optionalMark = optional ? "?" : "";

--- a/packages/xml-poto-codegen/src/generator/type-sorter.ts
+++ b/packages/xml-poto-codegen/src/generator/type-sorter.ts
@@ -1,0 +1,356 @@
+import type { ResolvedType } from "../xsd/xsd-resolver";
+
+/**
+ * Sorts resolved types so every dependency is declared before its dependents.
+ *
+ * Generated classes reference each other at module-evaluation time through
+ * `extends <Base>` clauses and decorator options (`type: Foo`). Since xml-poto
+ * uses standard TC39 decorators, both are evaluated while later classes are
+ * still in their temporal dead zone — so declaration order must satisfy the
+ * dependency graph.
+ *
+ * Two edge kinds are distinguished:
+ * - **hard** edges (`extends` via `baseTypeName`): must be satisfied by
+ *   ordering — a thunk cannot defer an extends clause. A cycle of hard edges
+ *   is invalid XSD and raises an error.
+ * - **soft** edges (decorator `type:` refs via `complexTypeName` /
+ *   `arrayItemType`): satisfied by ordering where possible. Edges inside a
+ *   strongly connected component (including self-references) cannot be
+ *   linearized and are reported in `lazyRefs`, so the generator emits them as
+ *   hoist-safe `() => Foo` thunks instead of direct identifiers.
+ *
+ * Ordering is stable and deterministic: input already in a valid dependency
+ * order is returned unchanged, and independent types keep their original
+ * (XSD document) order. This is implemented as Tarjan SCC condensation
+ * followed by Kahn's algorithm that always emits the ready component whose
+ * smallest original index is lowest.
+ */
+export interface TypeSortResult {
+	/** Types in dependency-first order (stable among independent types) */
+	sorted: ResolvedType[];
+	/** className -> referenced classNames that must be emitted as `() => X` thunks */
+	lazyRefs: Map<string, Set<string>>;
+	/**
+	 * Groups of classes (2+) that must be emitted into the same module in
+	 * per-type mode: classes linked by an `extends` edge inside a dependency
+	 * cycle. An extends clause evaluates eagerly during module evaluation, so
+	 * if base and derived sit in different modules of an import cycle, some
+	 * entry order always hits the base's temporal dead zone. (Cycles made of
+	 * decorator references only are safe across modules — those are thunks.)
+	 * Each group lists classNames in emit order (base before derived).
+	 */
+	sameModuleClusters: string[][];
+}
+
+export function sortTypesByDependency(types: ResolvedType[]): TypeSortResult {
+	const { hardEdges, softEdges } = buildEdges(types);
+	const n = types.length;
+
+	const sccOf = computeSccs(n, (v) => [...hardEdges[v], ...softEdges[v]]);
+	const sccCount = Math.max(-1, ...sccOf) + 1;
+	const sccMembers: number[][] = Array.from({ length: sccCount }, () => []);
+	for (let v = 0; v < n; v++) {
+		sccMembers[sccOf[v]].push(v);
+	}
+	for (const members of sccMembers) {
+		members.sort((a, b) => a - b);
+	}
+
+	const graph: DependencyGraph = { types, hardEdges, softEdges, sccOf, sccMembers };
+	const lazyRefs = collectLazyRefs(graph);
+	const sorted = orderCondensation(graph);
+	const sameModuleClusters = collectSameModuleClusters(graph, sorted);
+
+	return { sorted, lazyRefs, sameModuleClusters };
+}
+
+interface DependencyGraph {
+	types: ResolvedType[];
+	hardEdges: number[][];
+	softEdges: number[][];
+	sccOf: number[];
+	sccMembers: number[][];
+}
+
+/**
+ * Build the dependency edges between types, by node index. Hard edges are
+ * extends relations (`baseTypeName`), soft edges are decorator `type:`
+ * references (`complexTypeName` / `arrayItemType`). References to
+ * built-in/external names are not part of the graph.
+ */
+function buildEdges(types: ResolvedType[]): { hardEdges: number[][]; softEdges: number[][] } {
+	const n = types.length;
+	const indexByName = new Map<string, number>();
+	for (let i = 0; i < n; i++) {
+		// Resolver guarantees unique class names; keep the first occurrence defensively.
+		if (!indexByName.has(types[i].className)) {
+			indexByName.set(types[i].className, i);
+		}
+	}
+
+	const hardEdges: number[][] = Array.from({ length: n }, () => []);
+	const softEdges: number[][] = Array.from({ length: n }, () => []);
+
+	for (let i = 0; i < n; i++) {
+		const type = types[i];
+		if (type.baseTypeName !== undefined) {
+			const target = indexByName.get(type.baseTypeName);
+			if (target !== undefined) {
+				hardEdges[i].push(target);
+			}
+		}
+
+		const softTargets = new Set<number>();
+		for (const prop of type.properties) {
+			for (const ref of [prop.complexTypeName, prop.arrayItemType]) {
+				if (ref === undefined) continue;
+				const target = indexByName.get(ref);
+				if (target !== undefined) {
+					softTargets.add(target);
+				}
+			}
+		}
+		softEdges[i] = [...softTargets].sort((a, b) => a - b);
+	}
+
+	return { hardEdges, softEdges };
+}
+
+/**
+ * Classify intra-SCC soft edges as lazy refs. Intra-SCC hard edges are fine
+ * as long as the hard edges alone are acyclic — orderSccMembers verifies that.
+ * A self-extends is always fatal.
+ */
+function collectLazyRefs(graph: DependencyGraph): Map<string, Set<string>> {
+	const { types, hardEdges, softEdges, sccOf, sccMembers } = graph;
+	const lazyRefs = new Map<string, Set<string>>();
+	for (let v = 0; v < types.length; v++) {
+		if (hardEdges[v].includes(v)) {
+			throw new Error(
+				`Cannot order generated classes: class ${types[v].className} extends itself. ` +
+					`This indicates an invalid XSD type hierarchy.`,
+			);
+		}
+		const inCycle = sccMembers[sccOf[v]].length > 1;
+		for (const target of softEdges[v]) {
+			if (target === v || (inCycle && sccOf[target] === sccOf[v])) {
+				let refs = lazyRefs.get(types[v].className);
+				if (!refs) {
+					refs = new Set<string>();
+					lazyRefs.set(types[v].className, refs);
+				}
+				refs.add(types[target].className);
+			}
+		}
+	}
+	return lazyRefs;
+}
+
+/**
+ * Stable Kahn's algorithm over the SCC condensation DAG: always emit the ready
+ * component whose smallest member index is lowest, so document order is
+ * preserved wherever the dependency graph allows it.
+ */
+function orderCondensation(graph: DependencyGraph): ResolvedType[] {
+	const { types, hardEdges, softEdges, sccOf, sccMembers } = graph;
+	const sccCount = sccMembers.length;
+
+	// Condensation DAG: component -> set of components it depends on.
+	const sccDependencies: Array<Set<number>> = Array.from({ length: sccCount }, () => new Set());
+	for (let v = 0; v < types.length; v++) {
+		for (const target of [...hardEdges[v], ...softEdges[v]]) {
+			if (sccOf[target] !== sccOf[v]) {
+				sccDependencies[sccOf[v]].add(sccOf[target]);
+			}
+		}
+	}
+
+	const remainingDeps = sccDependencies.map((deps) => deps.size);
+	const dependents: number[][] = Array.from({ length: sccCount }, () => []);
+	for (let scc = 0; scc < sccCount; scc++) {
+		for (const dep of sccDependencies[scc]) {
+			dependents[dep].push(scc);
+		}
+	}
+
+	const emitted: boolean[] = Array.from({ length: sccCount }, () => false);
+	const sorted: ResolvedType[] = [];
+	for (let step = 0; step < sccCount; step++) {
+		let next = -1;
+		for (let scc = 0; scc < sccCount; scc++) {
+			if (emitted[scc] || remainingDeps[scc] > 0) continue;
+			if (next === -1 || sccMembers[scc][0] < sccMembers[next][0]) {
+				next = scc;
+			}
+		}
+		/* v8 ignore next 3 -- unreachable: every digraph condensation is acyclic */
+		if (next === -1) {
+			throw new Error("Cannot order generated classes: dependency graph could not be linearized.");
+		}
+
+		emitted[next] = true;
+		for (const member of orderSccMembers(sccMembers[next], hardEdges, sccOf, types)) {
+			sorted.push(types[member]);
+		}
+		for (const dependent of dependents[next]) {
+			remainingDeps[dependent]--;
+		}
+	}
+	return sorted;
+}
+
+/**
+ * Same-module clusters: connected components over hard edges that lie inside a
+ * multi-member SCC (see TypeSortResult.sameModuleClusters). Cluster members and
+ * the clusters themselves are listed in sorted (emit) order.
+ */
+function collectSameModuleClusters(graph: DependencyGraph, sorted: ResolvedType[]): string[][] {
+	const { types, hardEdges, sccOf, sccMembers } = graph;
+	const n = types.length;
+
+	const parent = Array.from({ length: n }, (_, i) => i);
+	const find = (x: number): number => {
+		while (parent[x] !== x) {
+			parent[x] = parent[parent[x]];
+			x = parent[x];
+		}
+		return x;
+	};
+	for (let v = 0; v < n; v++) {
+		if (sccMembers[sccOf[v]].length < 2) continue;
+		for (const target of hardEdges[v]) {
+			if (sccOf[target] === sccOf[v]) {
+				parent[find(v)] = find(target);
+			}
+		}
+	}
+
+	const sortedPos = new Map<string, number>();
+	sorted.forEach((t, i) => sortedPos.set(t.className, i));
+	const clusterByRoot = new Map<number, number[]>();
+	for (let v = 0; v < n; v++) {
+		const root = find(v);
+		const members = clusterByRoot.get(root);
+		if (members) members.push(v);
+		else clusterByRoot.set(root, [v]);
+	}
+	return [...clusterByRoot.values()]
+		.filter((members) => members.length > 1)
+		.map((members) =>
+			members.map((v) => types[v].className).sort((a, b) => (sortedPos.get(a) ?? 0) - (sortedPos.get(b) ?? 0)),
+		)
+		.sort((a, b) => (sortedPos.get(a[0]) ?? 0) - (sortedPos.get(b[0]) ?? 0));
+}
+
+/**
+ * Order the members of one SCC so hard (extends) edges are satisfied; soft
+ * edges inside the SCC are emitted as thunks and need no ordering. If the hard
+ * edges alone form a cycle, no declaration order can satisfy the extends
+ * clauses and an error is raised.
+ */
+function orderSccMembers(members: number[], hardEdges: number[][], sccOf: number[], types: ResolvedType[]): number[] {
+	if (members.length === 1) return members;
+
+	const memberSet = new Set(members);
+	const remainingDeps = new Map<number, number>();
+	const dependents = new Map<number, number[]>();
+	for (const v of members) {
+		let deps = 0;
+		for (const target of hardEdges[v]) {
+			if (memberSet.has(target) && sccOf[target] === sccOf[v]) {
+				deps++;
+				const list = dependents.get(target);
+				if (list) list.push(v);
+				else dependents.set(target, [v]);
+			}
+		}
+		remainingDeps.set(v, deps);
+	}
+
+	const ordered: number[] = [];
+	const emitted = new Set<number>();
+	while (ordered.length < members.length) {
+		// Members are pre-sorted by original index, so the first ready one preserves document order.
+		const next = members.find((v) => !emitted.has(v) && remainingDeps.get(v) === 0);
+		if (next === undefined) {
+			const cycleNames = members.filter((v) => !emitted.has(v)).map((v) => types[v].className);
+			throw new Error(
+				`Cannot order generated classes: inheritance (extends) cycle involving ${cycleNames.join(", ")}. ` +
+					`This indicates an invalid XSD type hierarchy.`,
+			);
+		}
+		emitted.add(next);
+		ordered.push(next);
+		for (const dependent of dependents.get(next) ?? []) {
+			remainingDeps.set(dependent, (remainingDeps.get(dependent) ?? 0) - 1);
+		}
+	}
+	return ordered;
+}
+
+/**
+ * Tarjan's strongly-connected-components algorithm (iterative, to be safe on
+ * deep dependency chains). Returns the component id per node; ids are then
+ * only used for grouping, so their numbering order is irrelevant.
+ */
+function computeSccs(n: number, neighborsOf: (v: number) => number[]): number[] {
+	const sccOf: number[] = Array.from({ length: n }, () => -1);
+	const index: number[] = Array.from({ length: n }, () => -1);
+	const lowlink: number[] = Array.from({ length: n }, () => -1);
+	const onStack: boolean[] = Array.from({ length: n }, () => false);
+	const stack: number[] = [];
+	let nextIndex = 0;
+	let nextScc = 0;
+
+	for (let root = 0; root < n; root++) {
+		if (index[root] !== -1) continue;
+
+		// Explicit DFS stack: [node, position in its neighbor list]
+		const work: Array<[number, number]> = [[root, 0]];
+		while (work.length > 0) {
+			const frame = work[work.length - 1];
+			const [v, neighborPos] = frame;
+
+			if (neighborPos === 0) {
+				index[v] = nextIndex;
+				lowlink[v] = nextIndex;
+				nextIndex++;
+				stack.push(v);
+				onStack[v] = true;
+			}
+
+			const neighbors = neighborsOf(v);
+			let advanced = false;
+			for (let i = neighborPos; i < neighbors.length; i++) {
+				const w = neighbors[i];
+				if (index[w] === -1) {
+					frame[1] = i + 1;
+					work.push([w, 0]);
+					advanced = true;
+					break;
+				}
+				if (onStack[w]) {
+					lowlink[v] = Math.min(lowlink[v], index[w]);
+				}
+			}
+			if (advanced) continue;
+
+			work.pop();
+			if (work.length > 0) {
+				const parent = work[work.length - 1][0];
+				lowlink[parent] = Math.min(lowlink[parent], lowlink[v]);
+			}
+			if (lowlink[v] === index[v]) {
+				let w: number;
+				do {
+					w = stack.pop() as number;
+					onStack[w] = false;
+					sccOf[w] = nextScc;
+				} while (w !== v);
+				nextScc++;
+			}
+		}
+	}
+
+	return sccOf;
+}

--- a/packages/xml-poto-codegen/src/xsd/xsd-parser.ts
+++ b/packages/xml-poto-codegen/src/xsd/xsd-parser.ts
@@ -17,8 +17,10 @@ import type {
 	XsdElement,
 	XsdGroup,
 	XsdGroupRef,
+	XsdIdentityConstraint,
 	XsdImport,
 	XsdInclude,
+	XsdRedefine,
 	XsdRestriction,
 	XsdSchema,
 	XsdSequence,
@@ -53,29 +55,42 @@ export class XsdParser {
 	}
 
 	/**
-	 * Parse an XSD string into a structured schema model.
+	 * Parse an XSD or WSDL string into a structured schema model.
+	 * WSDL documents are detected by their `<definitions>` root; all XSD schemas
+	 * embedded in the WSDL `<types>` section are extracted and merged.
 	 */
 	parseString(xsdContent: string, baseDir?: string): XsdSchema {
 		// Strip the optional XML declaration and any XML comments, then check
-		// that the root element is a schema element (any namespace prefix is accepted).
-		// This is done before handing off to the XML parser so invalid input produces
-		// a clear, actionable error instead of a cryptic tag-mismatch.
+		// that the root element is a schema or WSDL definitions element (any
+		// namespace prefix is accepted). This is done before handing off to the
+		// XML parser so invalid input produces a clear, actionable error instead
+		// of a cryptic tag-mismatch.
 		const normalized = xsdContent
 			.replace(/<\?xml[^?]*\?>/i, "") // optional XML declaration
 			.replace(/<!--[\s\S]*?-->/g, "") // XML comments before root
 			.trim();
 
-		if (!/^<(?:[a-zA-Z_][\w.-]*:)?schema[\s/>]/i.test(normalized)) {
+		const isSchemaRoot = /^<(?:[a-zA-Z_][\w.-]*:)?schema[\s/>]/i.test(normalized);
+		const isWsdlRoot = /^<(?:[a-zA-Z_][\w.-]*:)?definitions[\s/>]/i.test(normalized);
+		if (!isSchemaRoot && !isWsdlRoot) {
 			throw new Error(
-				"The provided content does not appear to be a valid XSD schema. " +
-					"Expected a root <xs:schema>, <xsd:schema>, or <schema> element.",
+				"The provided content does not appear to be a valid XSD schema or WSDL document. " +
+					"Expected a root <xs:schema>, <xsd:schema>, or <schema> element (XSD), " +
+					"or a <definitions> element (WSDL).",
 			);
 		}
 
 		const parsed = this.parser.parse(normalized);
 		const rootKey = this.findSchemaRootKey(parsed);
 		if (!rootKey) {
-			throw new Error("No XSD schema root element found. Expected <xs:schema>, <xsd:schema>, or <schema>.");
+			const definitionsKey = this.findDefinitionsRootKey(parsed);
+			if (definitionsKey) {
+				return this.parseWsdlDefinitions(parsed[definitionsKey] as Record<string, unknown>, baseDir);
+			}
+			throw new Error(
+				"No XSD schema root element found. Expected <xs:schema>, <xsd:schema>, or <schema> (XSD), " +
+					"or <definitions> (WSDL).",
+			);
 		}
 
 		const schemaObj = parsed[rootKey];
@@ -90,38 +105,157 @@ export class XsdParser {
 		return schema;
 	}
 
+	/**
+	 * Extract and merge all XSD schemas embedded in a WSDL `<types>` section.
+	 * Namespace declarations on the WSDL `<definitions>` root are inherited by
+	 * each embedded schema (schema-local declarations win), because WSDL files
+	 * commonly declare `xmlns:xsd`/`xmlns:tns` on the root only.
+	 */
+	private parseWsdlDefinitions(defObj: Record<string, unknown>, baseDir?: string): XsdSchema {
+		const schemaObjs = this.collectWsdlSchemaObjects(defObj);
+
+		if (schemaObjs.length === 0) {
+			throw new Error(
+				"The WSDL document contains no XSD schemas. Expected at least one <schema> element " +
+					"inside the WSDL <types> section.",
+			);
+		}
+
+		// Inherit xmlns declarations from <definitions> onto each embedded schema.
+		for (const schemaObj of schemaObjs) {
+			this.inheritNamespaceDeclarations(defObj, schemaObj);
+		}
+
+		// The XSD prefix can differ per embedded schema, so detect it immediately
+		// before parsing each one (prefix is instance state used by parseSchema).
+		const schemas = schemaObjs.map((schemaObj) => {
+			this.detectXsdPrefix(schemaObj);
+			return this.parseSchema(schemaObj);
+		});
+
+		const merged = schemas[0];
+		for (const other of schemas.slice(1)) {
+			if (other.targetNamespace && merged.targetNamespace && other.targetNamespace !== merged.targetNamespace) {
+				console.warn(
+					`Warning: WSDL contains schemas with multiple target namespaces ` +
+						`('${merged.targetNamespace}' and '${other.targetNamespace}'). ` +
+						`Only the first target namespace is used for namespace generation.`,
+				);
+			}
+			this.mergeSchema(merged, other);
+		}
+
+		if (baseDir) {
+			this.resolveExternalSchemas(merged, baseDir);
+		}
+
+		return merged;
+	}
+
+	/** Collect all embedded schema objects from the WSDL <types> section(s). */
+	private collectWsdlSchemaObjects(defObj: Record<string, unknown>): Record<string, unknown>[] {
+		const typesKeys = Object.keys(defObj).filter((k) => k === "types" || k.endsWith(":types"));
+
+		const schemaObjs: Record<string, unknown>[] = [];
+		for (const typesKey of typesKeys) {
+			for (const typesObj of this.parseChildren(defObj, typesKey)) {
+				for (const key of Object.keys(typesObj)) {
+					if (key === "schema" || key.endsWith(":schema")) {
+						schemaObjs.push(...this.parseChildren(typesObj, key));
+					}
+				}
+			}
+		}
+		return schemaObjs;
+	}
+
+	/** Copy xmlns declarations from a parent object onto a child (child-local declarations win). */
+	private inheritNamespaceDeclarations(parent: Record<string, unknown>, child: Record<string, unknown>): void {
+		for (const key of Object.keys(parent)) {
+			if ((key === "@_xmlns" || key.startsWith("@_xmlns:")) && !(key in child)) {
+				child[key] = parent[key];
+			}
+		}
+	}
+
 	private resolveExternalSchemas(schema: XsdSchema, baseDir: string): void {
-		for (const inc of schema.includes) {
+		// Iterate snapshots: mergeSchema appends the merged file's own (already
+		// recursively resolved) includes/imports to this schema's arrays.
+		for (const inc of [...schema.includes]) {
 			if (inc.schemaLocation) {
-				const incPath = path.resolve(baseDir, inc.schemaLocation);
-				if (fs.existsSync(incPath)) {
+				const incPath = this.resolveSchemaLocation(inc.schemaLocation, baseDir, "include");
+				if (incPath) {
 					this.mergeSchema(schema, this.parseFile(incPath));
 				}
 			}
 		}
 
-		for (const imp of schema.imports) {
-			if (imp.schemaLocation) {
-				const impPath = path.resolve(baseDir, imp.schemaLocation);
-				if (fs.existsSync(impPath)) {
-					const imported = this.parseFile(impPath);
-					this.mergeSchema(schema, imported);
-					if (imp.namespace && imported.targetNamespace) {
-						for (const [prefix, uri] of imported.namespaces) {
-							if (uri === imported.targetNamespace && prefix !== "" && !schema.namespaces.has(prefix)) {
-								schema.namespaces.set(prefix, uri);
-							}
-						}
-					}
+		for (const red of [...schema.redefines]) {
+			if (red.schemaLocation) {
+				const redPath = this.resolveSchemaLocation(red.schemaLocation, baseDir, "redefine");
+				if (redPath) {
+					console.warn(
+						`Warning: xs:redefine of '${red.schemaLocation}' is merged like an include; ` +
+							`redefinition overrides are not applied.`,
+					);
+					this.mergeSchema(schema, this.parseFile(redPath));
 				}
 			}
 		}
+
+		for (const imp of [...schema.imports]) {
+			if (imp.schemaLocation) {
+				const impPath = this.resolveSchemaLocation(imp.schemaLocation, baseDir, "import");
+				if (impPath) {
+					this.mergeImportedSchema(schema, impPath, imp.namespace);
+				}
+			}
+		}
+	}
+
+	/** Merge an imported schema file and adopt the prefix bound to its target namespace. */
+	private mergeImportedSchema(schema: XsdSchema, importPath: string, importNamespace?: string): void {
+		const imported = this.parseFile(importPath);
+		this.mergeSchema(schema, imported);
+		if (!importNamespace || !imported.targetNamespace) return;
+
+		for (const [prefix, uri] of imported.namespaces) {
+			if (uri === imported.targetNamespace && prefix !== "" && !schema.namespaces.has(prefix)) {
+				schema.namespaces.set(prefix, uri);
+			}
+		}
+	}
+
+	/**
+	 * Resolve a schemaLocation to a local file path, warning (instead of silently
+	 * skipping) when the location is remote or does not exist on disk.
+	 */
+	private resolveSchemaLocation(schemaLocation: string, baseDir: string, kind: string): string | undefined {
+		if (/^https?:\/\//i.test(schemaLocation)) {
+			console.warn(
+				`Warning: xs:${kind} schemaLocation '${schemaLocation}' is a remote URL and is not fetched. ` +
+					`Download the schema locally and reference it by file path to include its types.`,
+			);
+			return undefined;
+		}
+
+		const resolved = path.resolve(baseDir, schemaLocation);
+		if (!fs.existsSync(resolved)) {
+			console.warn(`Warning: xs:${kind} schemaLocation '${schemaLocation}' not found at '${resolved}'. Skipped.`);
+			return undefined;
+		}
+
+		return resolved;
 	}
 
 	private findSchemaRootKey(parsed: Record<string, unknown>): string | undefined {
 		return Object.keys(parsed).find(
 			(k) => k === "schema" || k.endsWith(":schema") || k === "xs:schema" || k === "xsd:schema",
 		);
+	}
+
+	private findDefinitionsRootKey(parsed: Record<string, unknown>): string | undefined {
+		return Object.keys(parsed).find((k) => k === "definitions" || k.endsWith(":definitions"));
 	}
 
 	private detectXsdPrefix(schemaObj: Record<string, unknown>): void {
@@ -163,8 +297,56 @@ export class XsdParser {
 			attributeGroups: this.parseChildren(obj, this.xsd("attributeGroup")).map((e) => this.parseAttributeGroup(e)),
 			imports: this.parseChildren(obj, this.xsd("import")).map((e) => this.parseImport(e)),
 			includes: this.parseChildren(obj, this.xsd("include")).map((e) => this.parseInclude(e)),
+			redefines: this.parseChildren(obj, this.xsd("redefine")).map((e) => this.parseRedefine(e)),
+			notations: this.parseChildren(obj, this.xsd("notation"))
+				.map((n) => attr(n, "name"))
+				.filter((n): n is string => n !== undefined),
+			documentation: this.parseDocumentation(obj),
 		};
+
+		// xs:redefine can also contain type/group definitions that override the
+		// redefined schema; parse them as regular definitions of this schema.
+		for (const red of this.parseChildren(obj, this.xsd("redefine"))) {
+			schema.complexTypes.push(
+				...this.parseChildren(red, this.xsd("complexType")).map((e) => this.parseComplexType(e)),
+			);
+			schema.simpleTypes.push(...this.parseChildren(red, this.xsd("simpleType")).map((e) => this.parseSimpleType(e)));
+			schema.groups.push(...this.parseChildren(red, this.xsd("group")).map((e) => this.parseGroup(e)));
+			schema.attributeGroups.push(
+				...this.parseChildren(red, this.xsd("attributeGroup")).map((e) => this.parseAttributeGroup(e)),
+			);
+		}
+
 		return schema;
+	}
+
+	/**
+	 * Extract the text of xs:annotation/xs:documentation children.
+	 * Multiple documentation nodes are joined with newlines.
+	 */
+	private parseDocumentation(obj: Record<string, unknown>): string | undefined {
+		const annotation = this.getChild(obj, this.xsd("annotation"));
+		if (!annotation) return undefined;
+
+		const texts: string[] = [];
+		const raw = annotation[this.xsd("documentation")];
+		const nodes = Array.isArray(raw) ? raw : raw !== undefined && raw !== null ? [raw] : [];
+		for (const node of nodes) {
+			// A documentation node parses as a plain string, or as an object with
+			// '#text' when it carries attributes such as xml:lang.
+			let text: unknown;
+			if (typeof node === "string") {
+				text = node;
+			} else if (typeof node === "object" && node !== null) {
+				text = (node as Record<string, unknown>)["#text"];
+			}
+			if (typeof text === "string" || typeof text === "number") {
+				const cleaned = String(text).replace(/\s+/g, " ").trim();
+				if (cleaned) texts.push(cleaned);
+			}
+		}
+
+		return texts.length > 0 ? texts.join("\n") : undefined;
 	}
 
 	private extractNamespaces(obj: Record<string, unknown>): Map<string, string> {
@@ -193,7 +375,13 @@ export class XsdParser {
 			fixed: attr(obj, "fixed"),
 			form: attr(obj, "form") as "qualified" | "unqualified" | undefined,
 			substitutionGroup: attr(obj, "substitutionGroup"),
+			documentation: this.parseDocumentation(obj),
 		};
+
+		const identityConstraints = this.parseIdentityConstraints(obj);
+		if (identityConstraints.length > 0) {
+			el.identityConstraints = identityConstraints;
+		}
 
 		const ct = this.getChild(obj, this.xsd("complexType"));
 		if (ct) {
@@ -208,6 +396,16 @@ export class XsdParser {
 		return el;
 	}
 
+	private parseIdentityConstraints(obj: Record<string, unknown>): XsdIdentityConstraint[] {
+		const constraints: XsdIdentityConstraint[] = [];
+		for (const kind of ["key", "keyref", "unique"] as const) {
+			for (const c of this.parseChildren(obj, this.xsd(kind))) {
+				constraints.push({ kind, name: attr(c, "name") ?? "" });
+			}
+		}
+		return constraints;
+	}
+
 	// ── Complex Type parsing ──
 
 	private parseComplexType(obj: Record<string, unknown>): XsdComplexType {
@@ -219,6 +417,7 @@ export class XsdParser {
 			groupRefs: this.parseGroupRefs(obj),
 			attributeGroupRefs: this.parseAttributeGroupRefs(obj),
 			anyAttribute: this.getChild(obj, this.xsd("anyAttribute")) !== undefined || undefined,
+			documentation: this.parseDocumentation(obj),
 		};
 
 		const seq = this.getChild(obj, this.xsd("sequence"));
@@ -244,6 +443,7 @@ export class XsdParser {
 	private parseSimpleType(obj: Record<string, unknown>): XsdSimpleType {
 		const st: XsdSimpleType = {
 			name: attr(obj, "name"),
+			documentation: this.parseDocumentation(obj),
 		};
 
 		const restriction = this.getChild(obj, this.xsd("restriction"));
@@ -271,7 +471,8 @@ export class XsdParser {
 		return {
 			base: attr(obj, "base") ?? "",
 			enumerations: this.parseChildren(obj, this.xsd("enumeration")).map((e) => attr(e, "value") ?? ""),
-			pattern: attr(this.getChild(obj, this.xsd("pattern")) ?? {}, "value"),
+			pattern: this.parsePatterns(obj),
+			length: numAttr(this.getChild(obj, this.xsd("length")) ?? {}, "value"),
 			minLength: numAttr(this.getChild(obj, this.xsd("minLength")) ?? {}, "value"),
 			maxLength: numAttr(this.getChild(obj, this.xsd("maxLength")) ?? {}, "value"),
 			minInclusive: numAttr(this.getChild(obj, this.xsd("minInclusive")) ?? {}, "value"),
@@ -288,6 +489,20 @@ export class XsdParser {
 		};
 	}
 
+	/**
+	 * Parse xs:pattern facets. Per the XSD spec, multiple pattern facets in one
+	 * restriction step are ORed together, so they combine into a single regex.
+	 */
+	private parsePatterns(obj: Record<string, unknown>): string | undefined {
+		const patterns = this.parseChildren(obj, this.xsd("pattern"))
+			.map((p) => attr(p, "value"))
+			.filter((p): p is string => p !== undefined);
+
+		if (patterns.length === 0) return undefined;
+		if (patterns.length === 1) return patterns[0];
+		return patterns.map((p) => `(?:${p})`).join("|");
+	}
+
 	// ── Attribute parsing ──
 
 	private parseAttribute(obj: Record<string, unknown>): XsdAttribute {
@@ -299,6 +514,7 @@ export class XsdParser {
 			fixed: attr(obj, "fixed"),
 			form: attr(obj, "form") as "qualified" | "unqualified" | undefined,
 			ref: attr(obj, "ref"),
+			documentation: this.parseDocumentation(obj),
 		};
 
 		const st = this.getChild(obj, this.xsd("simpleType"));
@@ -334,6 +550,8 @@ export class XsdParser {
 	private parseAll(obj: Record<string, unknown>): XsdAll {
 		return {
 			elements: this.parseChildren(obj, this.xsd("element")).map((e) => this.parseElement(e)),
+			choices: this.parseChildren(obj, this.xsd("choice")).map((c) => this.parseChoice(c)),
+			minOccurs: numAttr(obj, "minOccurs"),
 		};
 	}
 
@@ -375,7 +593,8 @@ export class XsdParser {
 		return {
 			base: attr(obj, "base") ?? "",
 			enumerations: this.parseChildren(obj, this.xsd("enumeration")).map((e) => attr(e, "value") ?? ""),
-			pattern: attr(this.getChild(obj, this.xsd("pattern")) ?? {}, "value"),
+			pattern: this.parsePatterns(obj),
+			length: numAttr(this.getChild(obj, this.xsd("length")) ?? {}, "value"),
 			minLength: numAttr(this.getChild(obj, this.xsd("minLength")) ?? {}, "value"),
 			maxLength: numAttr(this.getChild(obj, this.xsd("maxLength")) ?? {}, "value"),
 			minInclusive: numAttr(this.getChild(obj, this.xsd("minInclusive")) ?? {}, "value"),
@@ -435,10 +654,18 @@ export class XsdParser {
 		const rest: XsdComplexContentRestriction = {
 			base: attr(obj, "base") ?? "",
 			attributes: this.parseChildren(obj, this.xsd("attribute")).map((a) => this.parseAttribute(a)),
+			groupRefs: this.parseGroupRefs(obj),
+			attributeGroupRefs: this.parseAttributeGroupRefs(obj),
 		};
 
 		const seq = this.getChild(obj, this.xsd("sequence"));
 		if (seq) rest.sequence = this.parseSequence(seq);
+
+		const choice = this.getChild(obj, this.xsd("choice"));
+		if (choice) rest.choice = this.parseChoice(choice);
+
+		const all = this.getChild(obj, this.xsd("all"));
+		if (all) rest.all = this.parseAll(all);
 
 		return rest;
 	}
@@ -501,6 +728,12 @@ export class XsdParser {
 		};
 	}
 
+	private parseRedefine(obj: Record<string, unknown>): XsdRedefine {
+		return {
+			schemaLocation: attr(obj, "schemaLocation") ?? "",
+		};
+	}
+
 	// ── Schema merging (for includes) ──
 
 	private mergeSchema(target: XsdSchema, source: XsdSchema): void {
@@ -509,6 +742,17 @@ export class XsdParser {
 		target.simpleTypes.push(...source.simpleTypes);
 		target.groups.push(...source.groups);
 		target.attributeGroups.push(...source.attributeGroups);
+		target.imports.push(...source.imports);
+		target.includes.push(...source.includes);
+		target.redefines.push(...source.redefines);
+		target.notations.push(...source.notations);
+		for (const [prefix, uri] of source.namespaces) {
+			// Skip the default namespace ("" prefix): inheriting it across documents
+			// would change how unprefixed type references resolve in the target.
+			if (prefix !== "" && !target.namespaces.has(prefix)) {
+				target.namespaces.set(prefix, uri);
+			}
+		}
 	}
 
 	// ── Utility: child access in parsed XML object ──

--- a/packages/xml-poto-codegen/src/xsd/xsd-resolver.ts
+++ b/packages/xml-poto-codegen/src/xsd/xsd-resolver.ts
@@ -302,9 +302,35 @@ export class XsdResolver {
 		}
 
 		resolved.types = [...this.resolvedTypeMap.values()];
+		for (const type of resolved.types) {
+			this.dedupeProperties(type);
+		}
 		resolved.coverageNotes = [...new Set(this.coverageNotes)];
 
 		return resolved;
+	}
+
+	/**
+	 * Merge duplicate properties within a type. Duplicates arise when the same
+	 * element appears in multiple xs:choice branches (e.g. a choice between two
+	 * sequences that both contain the element). One class property represents
+	 * all occurrences; it is only required when every occurrence is required.
+	 */
+	private dedupeProperties(type: ResolvedType): void {
+		const seen = new Map<string, ResolvedProperty>();
+		const deduped: ResolvedProperty[] = [];
+		for (const prop of type.properties) {
+			const existing = seen.get(prop.propertyName);
+			if (!existing) {
+				seen.set(prop.propertyName, prop);
+				deduped.push(prop);
+				continue;
+			}
+			if (prop.required !== true) {
+				existing.required = false;
+			}
+		}
+		type.properties = deduped;
 	}
 
 	private noteIdentityConstraints(el: XsdElement): void {
@@ -535,9 +561,24 @@ export class XsdResolver {
 		}
 	}
 
+	/**
+	 * Drop a base type that resolves to the type itself. This happens with
+	 * xs:redefine, where the redefinition derives from the original definition
+	 * of the same name: redefines are merged like includes (overrides are not
+	 * applied), so keeping the base would generate `class X extends X`.
+	 */
+	private dropSelfReferentialBase(resolved: ResolvedType): void {
+		if (resolved.baseTypeName !== resolved.className) return;
+		this.coverageNotes.push(
+			`Type '${resolved.className}' derives from itself (xs:redefine); the extends clause was dropped.`,
+		);
+		resolved.baseTypeName = undefined;
+	}
+
 	private resolveComplexContent(cc: NonNullable<XsdComplexType["complexContent"]>, resolved: ResolvedType): void {
 		if (cc.extension) {
 			resolved.baseTypeName = toPascalCase(stripPrefix(cc.extension.base));
+			this.dropSelfReferentialBase(resolved);
 
 			let order = 1;
 			if (cc.extension.sequence) {
@@ -560,6 +601,7 @@ export class XsdResolver {
 			}
 		} else if (cc.restriction) {
 			resolved.baseTypeName = toPascalCase(stripPrefix(cc.restriction.base));
+			this.dropSelfReferentialBase(resolved);
 			let order = 1;
 			if (cc.restriction.sequence) {
 				order = this.resolveSequenceProperties(cc.restriction.sequence, resolved.properties, order);

--- a/packages/xml-poto-codegen/src/xsd/xsd-resolver.ts
+++ b/packages/xml-poto-codegen/src/xsd/xsd-resolver.ts
@@ -22,6 +22,8 @@ export interface ResolvedSchema {
 	enums: ResolvedEnum[];
 	/** Top-level elements that reference named types (root element candidates) */
 	rootElements: ResolvedRootElement[];
+	/** Notes about XSD constructs that are not (fully) represented in generated code */
+	coverageNotes?: string[];
 }
 
 export interface ResolvedRootElement {
@@ -53,6 +55,8 @@ export interface ResolvedType {
 	rootNillable?: boolean;
 	/** Namespace form (qualified/unqualified) */
 	form?: "qualified" | "unqualified";
+	/** xs:documentation text, emitted as JSDoc */
+	documentation?: string;
 }
 
 export type PropertyKind = "element" | "attribute" | "text" | "array" | "dynamic";
@@ -98,7 +102,8 @@ export interface ResolvedProperty {
 	dataType?: string;
 	/** XSD fixed value constraint */
 	fixedValue?: string;
-	/** XSD restriction facets retained for diagnostics/manual post-processing */
+	/** XSD restriction facets, emitted as decorator validation options */
+	length?: number;
 	minLength?: number;
 	maxLength?: number;
 	minInclusive?: number;
@@ -108,6 +113,20 @@ export interface ResolvedProperty {
 	totalDigits?: number;
 	fractionDigits?: number;
 	whiteSpace?: "preserve" | "replace" | "collapse";
+	/** xs:documentation text, emitted as JSDoc */
+	documentation?: string;
+	/** xs:list — value is a space-separated list serialized in a single element/attribute */
+	isList?: boolean;
+	/** Item type for xs:list values */
+	listItemType?: "string" | "number" | "boolean";
+	/** xs:choice group name shared by all direct members of the same choice */
+	choiceGroup?: string;
+	/** Whether at least one member of the choice group must be present */
+	choiceRequired?: boolean;
+	/** For arrays: minimum item count (xs:minOccurs > 1) */
+	minOccursCount?: number;
+	/** For arrays: maximum item count (finite xs:maxOccurs) */
+	maxOccursCount?: number;
 }
 
 export interface ResolvedEnum {
@@ -119,6 +138,32 @@ export interface ResolvedEnum {
 	values: string[];
 	/** Base restriction type */
 	baseType: string;
+	/** xs:documentation text, emitted as JSDoc */
+	documentation?: string;
+}
+
+/** Type information resolved from an XSD type reference or inline simpleType */
+export interface ResolvedTypeInfo {
+	tsType: string;
+	initializer: string;
+	complexTypeName?: string;
+	enumTypeName?: string;
+	enumValues?: string[];
+	pattern?: string;
+	dataType?: string;
+	length?: number;
+	minLength?: number;
+	maxLength?: number;
+	minInclusive?: number;
+	maxInclusive?: number;
+	minExclusive?: number;
+	maxExclusive?: number;
+	totalDigits?: number;
+	fractionDigits?: number;
+	whiteSpace?: "preserve" | "replace" | "collapse";
+	documentation?: string;
+	isList?: boolean;
+	listItemType?: "string" | "number" | "boolean";
 }
 
 // ── XSD Built-in Type Mapping ──
@@ -184,11 +229,17 @@ export class XsdResolver {
 	private resolvedTypeMap = new Map<string, ResolvedType>();
 	/** Maps head element name → list of substitute element names */
 	private substitutionMap = new Map<string, string[]>();
+	/** Notes about constructs not (fully) represented in generated code */
+	private coverageNotes: string[] = [];
+	/** Counter for unique xs:choice group names across the schema */
+	private choiceCounter = 0;
 
 	resolve(schema: XsdSchema): ResolvedSchema {
 		this.schema = schema;
 		this.buildLookups();
 		this.resolvedTypeMap.clear();
+		this.coverageNotes = [];
+		this.choiceCounter = 0;
 
 		const resolved: ResolvedSchema = {
 			targetNamespace: schema.targetNamespace,
@@ -197,7 +248,12 @@ export class XsdResolver {
 			types: [],
 			enums: [],
 			rootElements: [],
+			coverageNotes: [],
 		};
+
+		for (const notation of schema.notations) {
+			this.coverageNotes.push(`xs:notation '${notation}' is not represented in generated code.`);
+		}
 
 		// Resolve enums first (simpleTypes with enumerations)
 		for (const st of schema.simpleTypes) {
@@ -207,6 +263,7 @@ export class XsdResolver {
 					xmlName: st.name,
 					values: st.restriction.enumerations,
 					baseType: stripPrefix(st.restriction.base),
+					documentation: st.documentation,
 				});
 			}
 		}
@@ -220,9 +277,12 @@ export class XsdResolver {
 
 		// Resolve top-level elements
 		for (const el of schema.elements) {
+			this.noteIdentityConstraints(el);
 			if (el.complexType) {
 				// Element with inline complex type → root class
-				this.addResolvedType(this.resolveComplexType(el.complexType, el.name, true));
+				const rootType = this.resolveComplexType(el.complexType, el.name, true);
+				rootType.documentation = el.documentation ?? rootType.documentation;
+				this.addResolvedType(rootType);
 			} else if (el.type) {
 				const localType = stripPrefix(el.type);
 				// Reference to a named complex type → mark as root element
@@ -242,8 +302,17 @@ export class XsdResolver {
 		}
 
 		resolved.types = [...this.resolvedTypeMap.values()];
+		resolved.coverageNotes = [...new Set(this.coverageNotes)];
 
 		return resolved;
+	}
+
+	private noteIdentityConstraints(el: XsdElement): void {
+		for (const constraint of el.identityConstraints ?? []) {
+			this.coverageNotes.push(
+				`Identity constraint '${constraint.name}' (xs:${constraint.kind}) on element '${el.name}' is not enforced by generated code.`,
+			);
+		}
 	}
 
 	private addResolvedType(type: ResolvedType): void {
@@ -363,6 +432,7 @@ export class XsdResolver {
 			isRootElement: isRoot,
 			mixed: ct.mixed,
 			abstract: ct.abstract,
+			documentation: ct.documentation,
 		};
 
 		if (this.schema.targetNamespace) {
@@ -420,6 +490,7 @@ export class XsdResolver {
 				kind: "dynamic",
 				tsType: "DynamicElement",
 				initializer: "undefined!",
+				documentation: "xs:anyAttribute wildcard.",
 			});
 		}
 
@@ -448,6 +519,7 @@ export class XsdResolver {
 				initializer: baseInfo.initializer,
 				enumValues: sc.restriction.enumerations.length > 0 ? sc.restriction.enumerations : undefined,
 				pattern: sc.restriction.pattern,
+				length: sc.restriction.length,
 				minLength: sc.restriction.minLength,
 				maxLength: sc.restriction.maxLength,
 				minInclusive: sc.restriction.minInclusive,
@@ -488,10 +560,25 @@ export class XsdResolver {
 			}
 		} else if (cc.restriction) {
 			resolved.baseTypeName = toPascalCase(stripPrefix(cc.restriction.base));
+			let order = 1;
 			if (cc.restriction.sequence) {
-				this.resolveSequenceProperties(cc.restriction.sequence, resolved.properties, 1);
+				order = this.resolveSequenceProperties(cc.restriction.sequence, resolved.properties, order);
+			}
+			if (cc.restriction.choice) {
+				order = this.resolveChoiceProperties(cc.restriction.choice, resolved.properties, order);
+			}
+			if (cc.restriction.all) {
+				this.resolveAllProperties(cc.restriction.all, resolved.properties);
+			}
+			for (const gRef of cc.restriction.groupRefs) {
+				order = this.resolveGroupRef(gRef, resolved.properties, order);
 			}
 			this.resolveAttributes(cc.restriction.attributes, resolved.properties);
+			for (const agRef of cc.restriction.attributeGroupRefs) {
+				const refName = stripPrefix(agRef.ref);
+				const attrs = this.attributeGroupMap.get(refName);
+				if (attrs) this.resolveAttributes(attrs, resolved.properties);
+			}
 		}
 	}
 
@@ -515,6 +602,12 @@ export class XsdResolver {
 		}
 
 		for (const any of seq.any) {
+			const wildcardDetails = [
+				any.namespace ? `namespace="${any.namespace}"` : undefined,
+				any.processContents ? `processContents="${any.processContents}"` : undefined,
+			]
+				.filter(Boolean)
+				.join(", ");
 			props.push({
 				propertyName: `dynamicContent${order}`,
 				xmlName: "",
@@ -522,6 +615,7 @@ export class XsdResolver {
 				tsType: "DynamicElement",
 				initializer: "undefined!",
 				order: order++,
+				documentation: `xs:any wildcard${wildcardDetails ? ` (${wildcardDetails})` : ""}.`,
 			});
 			// xs:any defaults minOccurs to 1 when omitted.
 			if (any.minOccurs === undefined || any.minOccurs > 0) {
@@ -534,14 +628,21 @@ export class XsdResolver {
 
 	private resolveChoiceProperties(choice: XsdChoice, props: ResolvedProperty[], startOrder: number): number {
 		let order = startOrder;
+		const groupName = `choice${++this.choiceCounter}`;
+		// XSD defaults minOccurs to 1: one member of the choice must be present.
+		const choiceRequired = choice.minOccurs === undefined || choice.minOccurs > 0;
 
 		// Choice elements are all optional (only one is present at a time)
 		for (const el of choice.elements) {
 			const prop = this.resolveElementProperty(el, order++);
 			prop.required = false; // choices are inherently optional
+			prop.choiceGroup = groupName;
+			prop.choiceRequired = choiceRequired || undefined;
 			props.push(prop);
 		}
 
+		// Members of nested sequences are not part of the exclusive group
+		// (a sequence branch may set several of them together).
 		for (const seq of choice.sequences) {
 			order = this.resolveSequenceProperties(seq, props, order);
 		}
@@ -554,9 +655,23 @@ export class XsdResolver {
 	}
 
 	private resolveAllProperties(all: XsdAll, props: ResolvedProperty[]): void {
+		// When the xs:all group itself is optional, none of its members can be required.
+		const allOptional = all.minOccurs === 0;
+
 		// xs:all elements have no order requirement
 		for (const el of all.elements) {
-			props.push(this.resolveElementProperty(el));
+			const prop = this.resolveElementProperty(el);
+			if (allOptional) prop.required = false;
+			props.push(prop);
+		}
+
+		// XSD 1.1 allows xs:choice inside xs:all
+		for (const choice of all.choices) {
+			const before = props.length;
+			this.resolveChoiceProperties(choice, props, 0);
+			for (let i = before; i < props.length; i++) {
+				props[i].order = undefined; // xs:all members are unordered
+			}
 		}
 	}
 
@@ -565,17 +680,15 @@ export class XsdResolver {
 		const compositor = this.groupMap.get(refName);
 		if (!compositor) return startOrder;
 
-		if ("elements" in compositor && "choices" in compositor) {
-			// It's a sequence
+		// Discriminate by structure: only XsdSequence has 'any';
+		// XsdChoice has 'sequences' but no 'any'; XsdAll has neither.
+		if ("any" in compositor) {
 			return this.resolveSequenceProperties(compositor, props, startOrder);
 		}
-		if ("elements" in compositor && !("choices" in compositor)) {
-			// Could be XsdAll or XsdChoice
-			if ("sequences" in compositor) {
-				return this.resolveChoiceProperties(compositor, props, startOrder);
-			}
-			this.resolveAllProperties(compositor, props);
+		if ("sequences" in compositor) {
+			return this.resolveChoiceProperties(compositor, props, startOrder);
 		}
+		this.resolveAllProperties(compositor, props);
 		return startOrder;
 	}
 
@@ -584,59 +697,18 @@ export class XsdResolver {
 		const isRequired = el.minOccurs === undefined || el.minOccurs > 0;
 		const form = el.form ?? this.resolveElementForm();
 
+		this.noteIdentityConstraints(el);
+
 		// Resolve element name (could be a ref)
 		const name = el.ref ? stripPrefix(el.ref) : el.name;
 
 		// Check if this element is a substitution group head
-		if (this.substitutionMap.has(name)) {
-			return {
-				propertyName: toCamelCase(name),
-				xmlName: name,
-				kind: "dynamic",
-				tsType: "DynamicElement",
-				initializer: "undefined!",
-				required: isRequired,
-				order,
-			};
+		const substitutes = this.substitutionMap.get(name);
+		if (substitutes) {
+			return this.resolveSubstitutionHeadProperty(el, name, substitutes, isRequired, order);
 		}
 
-		// Resolve the type
-		let typeInfo: {
-			tsType: string;
-			initializer: string;
-			complexTypeName?: string;
-			enumTypeName?: string;
-			enumValues?: string[];
-			pattern?: string;
-			dataType?: string;
-			minLength?: number;
-			maxLength?: number;
-			minInclusive?: number;
-			maxInclusive?: number;
-			minExclusive?: number;
-			maxExclusive?: number;
-			totalDigits?: number;
-			fractionDigits?: number;
-			whiteSpace?: "preserve" | "replace" | "collapse";
-		};
-
-		if (el.complexType) {
-			// Inline complex type — will need to generate a class for it
-			const inlineTypeName = toPascalCase(name) + "Type";
-			this.addResolvedType(this.resolveComplexType(el.complexType, name, false, inlineTypeName));
-			typeInfo = {
-				tsType: inlineTypeName,
-				initializer: `new ${inlineTypeName}()`,
-				complexTypeName: inlineTypeName,
-			};
-		} else if (el.simpleType) {
-			typeInfo = this.resolveSimpleTypeInline(el.simpleType);
-		} else if (el.type) {
-			typeInfo = this.resolveTypeReference(el.type);
-		} else {
-			// No type means xs:anyType
-			typeInfo = { tsType: "string", initializer: "''" };
-		}
+		const typeInfo = this.resolveElementTypeInfo(el, name);
 
 		const prop: ResolvedProperty = {
 			propertyName: toCamelCase(name),
@@ -656,6 +728,7 @@ export class XsdResolver {
 			pattern: typeInfo.pattern,
 			enumTypeName: typeInfo.enumTypeName,
 			dataType: typeInfo.dataType,
+			length: typeInfo.length,
 			minLength: typeInfo.minLength,
 			maxLength: typeInfo.maxLength,
 			minInclusive: typeInfo.minInclusive,
@@ -665,54 +738,89 @@ export class XsdResolver {
 			totalDigits: typeInfo.totalDigits,
 			fractionDigits: typeInfo.fractionDigits,
 			whiteSpace: typeInfo.whiteSpace,
+			documentation: el.documentation ?? typeInfo.documentation,
+			isList: typeInfo.isList,
+			listItemType: typeInfo.listItemType,
 		};
 
 		if (isArray) {
-			prop.arrayItemName = name;
-			prop.arrayItemType = typeInfo.complexTypeName;
+			this.applyArrayOccurs(prop, el, name, typeInfo);
 		}
 
 		return prop;
 	}
 
+	/** Build the dynamic property emitted for a substitution group head element */
+	private resolveSubstitutionHeadProperty(
+		el: XsdElement,
+		name: string,
+		substitutes: string[],
+		isRequired: boolean,
+		order?: number,
+	): ResolvedProperty {
+		return {
+			propertyName: toCamelCase(name),
+			xmlName: name,
+			kind: "dynamic",
+			tsType: "DynamicElement",
+			initializer: "undefined!",
+			required: isRequired,
+			order,
+			documentation:
+				el.documentation ?? `Substitution group head '${name}'; substitutable elements: ${substitutes.join(", ")}.`,
+		};
+	}
+
+	/** Resolve the type information for an element declaration */
+	private resolveElementTypeInfo(el: XsdElement, name: string): ResolvedTypeInfo {
+		if (el.complexType) {
+			// Inline complex type — will need to generate a class for it
+			const inlineTypeName = toPascalCase(name) + "Type";
+			this.addResolvedType(this.resolveComplexType(el.complexType, name, false, inlineTypeName));
+			return {
+				tsType: inlineTypeName,
+				initializer: `new ${inlineTypeName}()`,
+				complexTypeName: inlineTypeName,
+			};
+		}
+		if (el.simpleType) {
+			return this.resolveSimpleTypeInline(el.simpleType);
+		}
+		if (el.type) {
+			return this.resolveTypeReference(el.type);
+		}
+		// No type means xs:anyType
+		return { tsType: "string", initializer: "''" };
+	}
+
+	/** Populate array-specific fields (item name/type and occurs bounds) */
+	private applyArrayOccurs(prop: ResolvedProperty, el: XsdElement, name: string, typeInfo: ResolvedTypeInfo): void {
+		prop.arrayItemName = name;
+		prop.arrayItemType = typeInfo.complexTypeName;
+		if (typeof el.minOccurs === "number" && el.minOccurs > 1) {
+			prop.minOccursCount = el.minOccurs;
+		}
+		if (typeof el.maxOccurs === "number" && el.maxOccurs > 1) {
+			prop.maxOccursCount = el.maxOccurs;
+		}
+	}
+
 	private resolveAttributes(attrs: XsdAttribute[], props: ResolvedProperty[]): void {
 		for (const a of attrs) {
-			if (a.ref) {
-				const form = a.form ?? this.resolveAttributeForm();
-				const defaultOrFixed = a.defaultValue ?? a.fixed;
-				// Attribute reference — resolve it if possible
-				props.push({
-					propertyName: toCamelCase(stripPrefix(a.ref)),
-					xmlName: stripPrefix(a.ref),
-					kind: "attribute",
-					tsType: "string",
-					initializer: defaultOrFixed ? `'${escapeString(defaultOrFixed)}'` : "''",
-					required: a.use === "required",
-					form,
-					namespace: this.resolveNamespaceForForm(form),
-					defaultValue: defaultOrFixed,
-					fixedValue: a.fixed,
-				});
+			// Prohibited attributes must not appear in instances — omit the property.
+			if (a.use === "prohibited") {
+				this.coverageNotes.push(
+					`Attribute '${a.name || stripPrefix(a.ref ?? "")}' with use="prohibited" was omitted from generated code.`,
+				);
 				continue;
 			}
 
-			let typeInfo: {
-				tsType: string;
-				initializer: string;
-				enumValues?: string[];
-				pattern?: string;
-				enumTypeName?: string;
-				dataType?: string;
-				minLength?: number;
-				maxLength?: number;
-				minInclusive?: number;
-				maxInclusive?: number;
-				minExclusive?: number;
-				maxExclusive?: number;
-				totalDigits?: number;
-				fractionDigits?: number;
-				whiteSpace?: "preserve" | "replace" | "collapse";
-			};
+			if (a.ref) {
+				props.push(this.resolveAttributeRef(a));
+				continue;
+			}
+
+			let typeInfo: ResolvedTypeInfo;
 
 			if (a.simpleType) {
 				typeInfo = this.resolveSimpleTypeInline(a.simpleType);
@@ -744,6 +852,7 @@ export class XsdResolver {
 				pattern: typeInfo.pattern,
 				enumTypeName: typeInfo.enumTypeName,
 				dataType: typeInfo.dataType,
+				length: typeInfo.length,
 				minLength: typeInfo.minLength,
 				maxLength: typeInfo.maxLength,
 				minInclusive: typeInfo.minInclusive,
@@ -753,28 +862,33 @@ export class XsdResolver {
 				totalDigits: typeInfo.totalDigits,
 				fractionDigits: typeInfo.fractionDigits,
 				whiteSpace: typeInfo.whiteSpace,
+				documentation: a.documentation ?? typeInfo.documentation,
+				isList: typeInfo.isList,
+				listItemType: typeInfo.listItemType,
 			});
 		}
 	}
 
-	private resolveTypeReference(typeRef: string): {
-		tsType: string;
-		initializer: string;
-		complexTypeName?: string;
-		enumTypeName?: string;
-		enumValues?: string[];
-		pattern?: string;
-		dataType?: string;
-		minLength?: number;
-		maxLength?: number;
-		minInclusive?: number;
-		maxInclusive?: number;
-		minExclusive?: number;
-		maxExclusive?: number;
-		totalDigits?: number;
-		fractionDigits?: number;
-		whiteSpace?: "preserve" | "replace" | "collapse";
-	} {
+	/** Resolve an attribute declared via ref="..." */
+	private resolveAttributeRef(a: XsdAttribute): ResolvedProperty {
+		const form = a.form ?? this.resolveAttributeForm();
+		const defaultOrFixed = a.defaultValue ?? a.fixed;
+		return {
+			propertyName: toCamelCase(stripPrefix(a.ref!)),
+			xmlName: stripPrefix(a.ref!),
+			kind: "attribute",
+			tsType: "string",
+			initializer: defaultOrFixed ? `'${escapeString(defaultOrFixed)}'` : "''",
+			required: a.use === "required",
+			form,
+			namespace: this.resolveNamespaceForForm(form),
+			defaultValue: defaultOrFixed,
+			fixedValue: a.fixed,
+			documentation: a.documentation,
+		};
+	}
+
+	private resolveTypeReference(typeRef: string): ResolvedTypeInfo {
 		const localName = stripPrefix(typeRef);
 
 		// Check XSD built-in types
@@ -801,26 +915,10 @@ export class XsdResolver {
 		return { tsType: "string", initializer: "''" };
 	}
 
-	private resolveSimpleTypeInline(st: XsdSimpleType): {
-		tsType: string;
-		initializer: string;
-		enumValues?: string[];
-		pattern?: string;
-		enumTypeName?: string;
-		dataType?: string;
-		minLength?: number;
-		maxLength?: number;
-		minInclusive?: number;
-		maxInclusive?: number;
-		minExclusive?: number;
-		maxExclusive?: number;
-		totalDigits?: number;
-		fractionDigits?: number;
-		whiteSpace?: "preserve" | "replace" | "collapse";
-	} {
+	private resolveSimpleTypeInline(st: XsdSimpleType): ResolvedTypeInfo {
 		if (st.restriction) {
 			const baseInfo = this.resolveTypeReference(st.restriction.base);
-			const result: ReturnType<typeof this.resolveSimpleTypeInline> = {
+			const result: ResolvedTypeInfo = {
 				...baseInfo,
 			};
 
@@ -837,6 +935,7 @@ export class XsdResolver {
 			if (st.restriction.pattern) {
 				result.pattern = st.restriction.pattern;
 			}
+			result.length = st.restriction.length;
 			result.minLength = st.restriction.minLength;
 			result.maxLength = st.restriction.maxLength;
 			result.minInclusive = st.restriction.minInclusive;
@@ -846,15 +945,23 @@ export class XsdResolver {
 			result.totalDigits = st.restriction.totalDigits;
 			result.fractionDigits = st.restriction.fractionDigits;
 			result.whiteSpace = st.restriction.whiteSpace;
+			result.documentation = st.documentation ?? result.documentation;
 
 			return result;
 		}
 
 		if (st.list) {
+			// Copy the item type's facets so they validate each list item
 			const itemInfo = this.resolveTypeReference(st.list.itemType);
 			return {
+				...itemInfo,
 				tsType: `${itemInfo.tsType}[]`,
 				initializer: "[]",
+				isList: true,
+				listItemType: itemInfo.tsType === "number" ? "number" : itemInfo.tsType === "boolean" ? "boolean" : "string",
+				complexTypeName: undefined,
+				enumTypeName: undefined,
+				documentation: st.documentation ?? itemInfo.documentation,
 			};
 		}
 
@@ -864,13 +971,19 @@ export class XsdResolver {
 				const memberInfos = st.union.memberTypes.map((mt) => this.resolveTypeReference(mt));
 				const uniqueTypes = [...new Set(memberInfos.map((m) => m.tsType))];
 				const tsType = uniqueTypes.join(" | ");
-				// Use the initializer of the first member type
-				return { tsType, initializer: memberInfos[0].initializer };
+				// Prefer a string member's initializer as the safest default for mixed unions.
+				const stringMember = memberInfos.find((m) => m.tsType === "string");
+				const memberDoc = `xs:union of ${st.union.memberTypes.join(", ")}.`;
+				return {
+					tsType,
+					initializer: (stringMember ?? memberInfos[0]).initializer,
+					documentation: st.documentation ? `${st.documentation}\n${memberDoc}` : memberDoc,
+				};
 			}
-			return { tsType: "string", initializer: "''" };
+			return { tsType: "string", initializer: "''", documentation: st.documentation };
 		}
 
-		return { tsType: "string", initializer: "''" };
+		return { tsType: "string", initializer: "''", documentation: st.documentation };
 	}
 
 	private resolveSimpleRootElement(el: XsdElement): ResolvedType {
@@ -894,6 +1007,7 @@ export class XsdResolver {
 				},
 			],
 			isRootElement: true,
+			documentation: el.documentation ?? typeInfo.documentation,
 		};
 
 		if (this.schema.targetNamespace) {

--- a/packages/xml-poto-codegen/src/xsd/xsd-types.ts
+++ b/packages/xml-poto-codegen/src/xsd/xsd-types.ts
@@ -21,6 +21,12 @@ export interface XsdSchema {
 	attributeGroups: XsdAttributeGroup[];
 	imports: XsdImport[];
 	includes: XsdInclude[];
+	/** xs:redefine references (merged like includes; redefinition overrides are not applied) */
+	redefines: XsdRedefine[];
+	/** xs:notation names declared in the schema */
+	notations: string[];
+	/** Schema-level xs:annotation/xs:documentation text */
+	documentation?: string;
 }
 
 // ── Elements ──
@@ -41,6 +47,15 @@ export interface XsdElement {
 	complexType?: XsdComplexType;
 	/** Inline simpleType definition */
 	simpleType?: XsdSimpleType;
+	/** xs:annotation/xs:documentation text */
+	documentation?: string;
+	/** Identity constraints (xs:key/xs:keyref/xs:unique) declared on this element */
+	identityConstraints?: XsdIdentityConstraint[];
+}
+
+export interface XsdIdentityConstraint {
+	kind: "key" | "keyref" | "unique";
+	name: string;
 }
 
 // ── Complex Types ──
@@ -61,6 +76,8 @@ export interface XsdComplexType {
 	attributeGroupRefs: XsdAttributeGroupRef[];
 	/** xs:anyAttribute */
 	anyAttribute?: boolean;
+	/** xs:annotation/xs:documentation text */
+	documentation?: string;
 }
 
 // ── Simple Types ──
@@ -70,12 +87,15 @@ export interface XsdSimpleType {
 	restriction?: XsdRestriction;
 	list?: XsdList;
 	union?: XsdUnion;
+	/** xs:annotation/xs:documentation text */
+	documentation?: string;
 }
 
 export interface XsdRestriction {
 	base: string;
 	enumerations: string[];
 	pattern?: string;
+	length?: number;
 	minLength?: number;
 	maxLength?: number;
 	minInclusive?: number;
@@ -106,6 +126,8 @@ export interface XsdAttribute {
 	form?: "qualified" | "unqualified";
 	ref?: string;
 	simpleType?: XsdSimpleType;
+	/** xs:annotation/xs:documentation text */
+	documentation?: string;
 }
 
 // ── Compositors ──
@@ -128,6 +150,9 @@ export interface XsdChoice {
 
 export interface XsdAll {
 	elements: XsdElement[];
+	/** Nested choices (XSD 1.1 allows xs:choice inside xs:all) */
+	choices: XsdChoice[];
+	minOccurs?: number;
 }
 
 export interface XsdAny {
@@ -153,6 +178,7 @@ export interface XsdSimpleContentRestriction {
 	base: string;
 	enumerations: string[];
 	pattern?: string;
+	length?: number;
 	minLength?: number;
 	maxLength?: number;
 	minInclusive?: number;
@@ -184,7 +210,11 @@ export interface XsdComplexContentExtension {
 export interface XsdComplexContentRestriction {
 	base: string;
 	sequence?: XsdSequence;
+	choice?: XsdChoice;
+	all?: XsdAll;
 	attributes: XsdAttribute[];
+	groupRefs: XsdGroupRef[];
+	attributeGroupRefs: XsdAttributeGroupRef[];
 }
 
 // ── Groups ──
@@ -220,5 +250,9 @@ export interface XsdImport {
 }
 
 export interface XsdInclude {
+	schemaLocation: string;
+}
+
+export interface XsdRedefine {
 	schemaLocation: string;
 }

--- a/packages/xml-poto-codegen/tests/fixtures/all-occurs.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/all-occurs.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:element name="Config">
+		<xs:complexType>
+			<xs:all minOccurs="0">
+				<xs:element name="Host" type="xs:string"/>
+				<xs:element name="Port" type="xs:integer"/>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/circular.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/circular.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Circular type references that no declaration order can satisfy:
+     - SectionType contains itself (self-recursion)
+     - PersonType references ManagerType, which extends PersonType (mixed cycle)
+     The generator must emit `() => Foo` thunks for the cyclic references. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="PersonType">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Manager" type="ManagerType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ManagerType">
+		<xs:complexContent>
+			<xs:extension base="PersonType">
+				<xs:sequence>
+					<xs:element name="Title" type="xs:string"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SectionType">
+		<xs:sequence>
+			<xs:element name="Heading" type="xs:string"/>
+			<xs:element name="Section" type="SectionType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="Document">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Person" type="PersonType"/>
+				<xs:element name="Section" type="SectionType"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/documentation.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/documentation.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:annotation>
+		<xs:documentation>Schema-level documentation.</xs:documentation>
+	</xs:annotation>
+
+	<xs:simpleType name="StatusType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The processing status of an order.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="open"/>
+			<xs:enumeration value="closed"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:complexType name="CustomerType">
+		<xs:annotation>
+			<xs:documentation>A customer with a name and status.
+				Spans multiple lines in the source document.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>The full name of the customer.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Status" type="StatusType" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>Unique customer identifier.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+
+	<xs:element name="Customer" type="CustomerType">
+		<xs:annotation>
+			<xs:documentation>Root element for a single customer.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/facets.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/facets.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:simpleType name="CountryCode">
+		<xs:restriction base="xs:string">
+			<xs:length value="2"/>
+			<xs:pattern value="[A-Z]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="Amount">
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="8"/>
+			<xs:fractionDigits value="2"/>
+			<xs:minInclusive value="0"/>
+			<xs:maxExclusive value="1000000"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="ShortName">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="2"/>
+			<xs:maxLength value="20"/>
+			<xs:whiteSpace value="collapse"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="PhoneOrFax">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="P[0-9]+"/>
+			<xs:pattern value="F[0-9]+"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:element name="Payment">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Country" type="CountryCode"/>
+				<xs:element name="Total" type="Amount"/>
+				<xs:element name="Beneficiary" type="ShortName"/>
+				<xs:element name="Contact" type="PhoneOrFax" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="reference" use="required">
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:maxLength value="16"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/fixed.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/fixed.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:element name="Manifest">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Format" type="xs:string" fixed="jsonl"/>
+				<xs:element name="Name" type="xs:string"/>
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:string" fixed="2.1" use="required"/>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/identity-constraints.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/identity-constraints.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:notation name="jpeg" public="image/jpeg"/>
+
+	<xs:element name="Library">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Book" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Isbn" type="xs:string"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:key name="bookKey">
+			<xs:selector xpath="Book"/>
+			<xs:field xpath="Isbn"/>
+		</xs:key>
+		<xs:unique name="uniqueIsbn">
+			<xs:selector xpath="Book"/>
+			<xs:field xpath="Isbn"/>
+		</xs:unique>
+	</xs:element>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/list.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/list.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:simpleType name="IntList">
+		<xs:list itemType="xs:integer"/>
+	</xs:simpleType>
+
+	<xs:simpleType name="RestrictedInt">
+		<xs:restriction base="xs:integer">
+			<xs:maxInclusive value="100"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="RestrictedIntList">
+		<xs:list itemType="RestrictedInt"/>
+	</xs:simpleType>
+
+	<xs:element name="Measurements">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Sizes" type="IntList"/>
+				<xs:element name="Scores" type="RestrictedIntList" minOccurs="0"/>
+				<xs:element name="Labels" minOccurs="0">
+					<xs:simpleType>
+						<xs:list itemType="xs:string"/>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="ids" type="IntList"/>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/out-of-order.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/out-of-order.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Types are declared alphabetically, so referencing types appear BEFORE the
+     types they depend on (derived before base, referrer before referee).
+     Mirrors real-world schemas that order declarations alphabetically. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="AdminType">
+		<xs:complexContent>
+			<xs:extension base="UserType">
+				<xs:sequence>
+					<xs:element name="Permissions" type="xs:string"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CompanyType">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Owner" type="UserType"/>
+			<xs:element name="Admin" type="AdminType" minOccurs="0"/>
+			<xs:element name="Employee" type="UserType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UserType">
+		<xs:sequence>
+			<xs:element name="FullName" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="Company" type="CompanyType"/>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/prohibited.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/prohibited.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="BaseDocument">
+		<xs:sequence>
+			<xs:element name="Body" type="xs:string"/>
+		</xs:sequence>
+		<xs:attribute name="draft" type="xs:boolean"/>
+		<xs:attribute name="author" type="xs:string" use="required"/>
+	</xs:complexType>
+
+	<xs:complexType name="FinalDocument">
+		<xs:complexContent>
+			<xs:restriction base="BaseDocument">
+				<xs:sequence>
+					<xs:element name="Body" type="xs:string"/>
+				</xs:sequence>
+				<xs:attribute name="draft" type="xs:boolean" use="prohibited"/>
+				<xs:attribute name="author" type="xs:string" use="required"/>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/redefine-base.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/redefine-base.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="AddressType">
+		<xs:sequence>
+			<xs:element name="Street" type="xs:string"/>
+			<xs:element name="City" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/redefine-main.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/redefine-main.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:redefine schemaLocation="redefine-base.xsd">
+		<xs:complexType name="AddressType">
+			<xs:complexContent>
+				<xs:extension base="AddressType">
+					<xs:sequence>
+						<xs:element name="Country" type="xs:string"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:redefine>
+
+	<xs:element name="Shipment">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Destination" type="AddressType"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/restriction-content.xsd
+++ b/packages/xml-poto-codegen/tests/fixtures/restriction-content.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="BaseShape">
+		<xs:sequence>
+			<xs:element name="Id" type="xs:string"/>
+			<xs:element name="Label" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="ChoiceShape">
+		<xs:complexContent>
+			<xs:restriction base="BaseShape">
+				<xs:choice>
+					<xs:element name="Circle" type="xs:string"/>
+					<xs:element name="Square" type="xs:string"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:complexType name="AllShape">
+		<xs:complexContent>
+			<xs:restriction base="BaseShape">
+				<xs:all>
+					<xs:element name="Width" type="xs:integer"/>
+					<xs:element name="Height" type="xs:integer"/>
+				</xs:all>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+</xs:schema>

--- a/packages/xml-poto-codegen/tests/fixtures/service.wsdl
+++ b/packages/xml-poto-codegen/tests/fixtures/service.wsdl
@@ -1,0 +1,70 @@
+<!-- Test fixture: WSDL with embedded XSD schemas. xmlns declarations live on <definitions> only. -->
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:tns="http://example.com/service/v1" targetNamespace="http://example.com/service/v1">
+    <types>
+        <xsd:schema targetNamespace="http://example.com/service/v1" version="0.1">
+            <xsd:complexType name="identification">
+                <xsd:sequence>
+                    <xsd:element name="indicator" type="xsd:string" minOccurs="1" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="nl">The consumer indicator.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="user" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="record">
+                <xsd:sequence>
+                    <xsd:element name="number" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="value" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="serviceRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="identification" type="tns:identification" minOccurs="1" maxOccurs="1"/>
+                        <xsd:element name="record" type="tns:record" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="historic" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+        <xsd:schema targetNamespace="http://example.com/service/v1" version="0.1">
+            <xsd:element name="serviceFault">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="faultCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                        <xsd:element name="faultDescription" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </types>
+    <message name="serviceRequest">
+        <part name="parameters" element="tns:serviceRequest"/>
+    </message>
+    <message name="serviceException">
+        <part name="fault" element="tns:serviceFault"/>
+    </message>
+    <portType name="ServicePort">
+        <operation name="executeRequest">
+            <input message="tns:serviceRequest"/>
+            <fault name="serviceException" message="tns:serviceException"/>
+        </operation>
+    </portType>
+    <binding name="ServiceBinding" type="tns:ServicePort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="executeRequest">
+            <soap:operation soapAction="executeRequest" style="document"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+        </operation>
+    </binding>
+    <service name="ExampleService">
+        <port name="ServicePort" binding="tns:ServiceBinding">
+            <soap:address location="https://example.com/service"/>
+        </port>
+    </service>
+</definitions>

--- a/packages/xml-poto-codegen/tests/generator/class-generator.test.ts
+++ b/packages/xml-poto-codegen/tests/generator/class-generator.test.ts
@@ -280,6 +280,51 @@ describe("ClassGenerator", () => {
 			expect(classFile!.content).toContain("@XmlArray({ itemName: 'Item', order: 2 })");
 			expect(classFile!.content).toContain("@XmlDynamic({ order: 3 })");
 		});
+
+		it("should merge extends-cycle classes into one file and emit thunks for the back-reference", () => {
+			const schema = makeSchema([
+				{
+					className: "PersonType",
+					xmlName: "PersonType",
+					isRootElement: false,
+					properties: [
+						{
+							propertyName: "manager",
+							xmlName: "Manager",
+							kind: "element",
+							tsType: "ManagerType",
+							initializer: "new ManagerType()",
+							complexTypeName: "ManagerType",
+						},
+					],
+				},
+				{
+					className: "ManagerType",
+					xmlName: "ManagerType",
+					isRootElement: false,
+					baseTypeName: "PersonType",
+					properties: [],
+				},
+			]);
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd" });
+			const files = gen.generatePerType(schema);
+
+			// Base and derived share a cycle through an extends edge, so they must
+			// live in the same module (named after the base class).
+			expect(files.some((f) => f.fileName === "manager-type.ts")).toBe(false);
+			const personFile = files.find((f) => f.fileName === "person-type.ts")!;
+			expect(personFile.exports).toEqual(["PersonType", "ManagerType"]);
+			expect(personFile.content.indexOf("class PersonType")).toBeLessThan(
+				personFile.content.indexOf("class ManagerType extends PersonType"),
+			);
+			// The cyclic decorator reference is a thunk; no self-file import is emitted.
+			expect(personFile.content).toContain("type: () => ManagerType");
+			expect(personFile.content).not.toContain('from "./manager-type"');
+
+			const indexFile = files.find((f) => f.fileName === "index.ts")!;
+			expect(indexFile.content).toContain('export { PersonType, ManagerType } from "./person-type";');
+		});
 	});
 
 	describe("generatePerXsd", () => {
@@ -387,6 +432,156 @@ describe("ClassGenerator", () => {
 			const files = gen.generatePerXsd(schema, "output");
 
 			expect(files[0].content).toContain("class User extends BaseEntity");
+		});
+
+		it("should declare classes dependency-first when the XSD declares them out of order", () => {
+			// Derived and referencing types come first, as in alphabetically-ordered XSDs.
+			const schema = makeSchema([
+				{
+					className: "AdminType",
+					xmlName: "AdminType",
+					isRootElement: false,
+					baseTypeName: "UserType",
+					properties: [],
+				},
+				{
+					className: "CompanyType",
+					xmlName: "CompanyType",
+					isRootElement: false,
+					properties: [
+						{
+							propertyName: "owner",
+							xmlName: "Owner",
+							kind: "element",
+							tsType: "UserType",
+							initializer: "new UserType()",
+							complexTypeName: "UserType",
+						},
+						{
+							propertyName: "admins",
+							xmlName: "Admin",
+							kind: "array",
+							tsType: "AdminType[]",
+							initializer: "[]",
+							arrayItemType: "AdminType",
+						},
+					],
+				},
+				{
+					className: "UserType",
+					xmlName: "UserType",
+					isRootElement: false,
+					properties: [],
+				},
+			]);
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd" });
+			const content = gen.generatePerXsd(schema, "output")[0].content;
+
+			const userAt = content.indexOf("class UserType");
+			const adminAt = content.indexOf("class AdminType");
+			const companyAt = content.indexOf("class CompanyType");
+			expect(userAt).toBeGreaterThanOrEqual(0);
+			expect(userAt).toBeLessThan(adminAt);
+			expect(adminAt).toBeLessThan(companyAt);
+			// References stay direct identifiers — no thunks needed for acyclic types
+			expect(content).toContain("type: UserType");
+			expect(content).toContain("type: AdminType");
+			expect(content).not.toContain("() =>");
+		});
+
+		it("should emit () => thunks for circular and self references", () => {
+			const schema = makeSchema([
+				{
+					className: "PersonType",
+					xmlName: "PersonType",
+					isRootElement: false,
+					properties: [
+						{
+							propertyName: "manager",
+							xmlName: "Manager",
+							kind: "element",
+							tsType: "ManagerType",
+							initializer: "new ManagerType()",
+							complexTypeName: "ManagerType",
+						},
+					],
+				},
+				{
+					className: "ManagerType",
+					xmlName: "ManagerType",
+					isRootElement: false,
+					baseTypeName: "PersonType",
+					properties: [],
+				},
+				{
+					className: "SectionType",
+					xmlName: "SectionType",
+					isRootElement: false,
+					properties: [
+						{
+							propertyName: "sections",
+							xmlName: "Section",
+							kind: "array",
+							tsType: "SectionType[]",
+							initializer: "[]",
+							arrayItemType: "SectionType",
+						},
+					],
+				},
+			]);
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd" });
+			const content = gen.generatePerXsd(schema, "output")[0].content;
+
+			// The extends edge is satisfied by ordering; the soft back-edge becomes a thunk.
+			expect(content.indexOf("class PersonType")).toBeLessThan(content.indexOf("class ManagerType"));
+			expect(content).toContain("class ManagerType extends PersonType");
+			expect(content).toContain("type: () => ManagerType");
+			// Self-recursion always needs a thunk.
+			expect(content).toContain("type: () => SectionType");
+		});
+
+		it("should emit a definite-assignment assertion for required enum-typed properties", () => {
+			const schema = makeSchema(
+				[
+					{
+						className: "Order",
+						xmlName: "Order",
+						isRootElement: true,
+						properties: [
+							{
+								propertyName: "status",
+								xmlName: "Status",
+								kind: "element",
+								tsType: "StatusType",
+								// The resolver carries the base type's initializer, which is not
+								// assignable to the enum type.
+								initializer: "''",
+								required: true,
+								enumTypeName: "StatusType",
+							},
+							{
+								propertyName: "priority",
+								xmlName: "Priority",
+								kind: "element",
+								tsType: "StatusType",
+								initializer: "''",
+								required: false,
+								enumTypeName: "StatusType",
+							},
+						],
+					},
+				],
+				[{ name: "StatusType", xmlName: "StatusType", values: ["open", "closed"], baseType: "string" }],
+			);
+
+			const gen = new ClassGenerator({ xsdPath: "test.xsd" });
+			const content = gen.generatePerXsd(schema, "output")[0].content;
+
+			expect(content).toContain("status!: StatusType;");
+			expect(content).not.toContain("status!: StatusType = ");
+			expect(content).toContain("priority?: StatusType;");
 		});
 	});
 

--- a/packages/xml-poto-codegen/tests/generator/type-sorter.test.ts
+++ b/packages/xml-poto-codegen/tests/generator/type-sorter.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+
+import { sortTypesByDependency } from "../../src/generator/type-sorter";
+import type { ResolvedProperty, ResolvedType } from "../../src/xsd/xsd-resolver";
+
+interface TypeSpec {
+	name: string;
+	base?: string;
+	elementRefs?: string[];
+	arrayRefs?: string[];
+}
+
+function makeType(spec: TypeSpec): ResolvedType {
+	const properties: ResolvedProperty[] = [];
+	for (const ref of spec.elementRefs ?? []) {
+		properties.push({
+			propertyName: ref.toLowerCase(),
+			xmlName: ref,
+			kind: "element",
+			tsType: ref,
+			initializer: `new ${ref}()`,
+			complexTypeName: ref,
+		});
+	}
+	for (const ref of spec.arrayRefs ?? []) {
+		properties.push({
+			propertyName: `${ref.toLowerCase()}Items`,
+			xmlName: ref,
+			kind: "array",
+			tsType: `${ref}[]`,
+			initializer: "[]",
+			arrayItemType: ref,
+		});
+	}
+	return {
+		className: spec.name,
+		xmlName: spec.name,
+		isRootElement: false,
+		properties,
+		baseTypeName: spec.base,
+	};
+}
+
+function sortedNames(specs: TypeSpec[]): string[] {
+	return sortTypesByDependency(specs.map(makeType)).sorted.map((t) => t.className);
+}
+
+describe("sortTypesByDependency", () => {
+	it("returns an empty result for no types", () => {
+		const result = sortTypesByDependency([]);
+		expect(result.sorted).toEqual([]);
+		expect(result.lazyRefs.size).toBe(0);
+	});
+
+	it("preserves document order for independent types", () => {
+		expect(sortedNames([{ name: "C" }, { name: "A" }, { name: "B" }])).toEqual(["C", "A", "B"]);
+	});
+
+	it("returns already-valid dependency order unchanged", () => {
+		expect(
+			sortedNames([{ name: "Base" }, { name: "Derived", base: "Base" }, { name: "Wrapper", elementRefs: ["Derived"] }]),
+		).toEqual(["Base", "Derived", "Wrapper"]);
+	});
+
+	it("moves a base class before its derived class", () => {
+		expect(sortedNames([{ name: "Derived", base: "Base" }, { name: "Base" }])).toEqual(["Base", "Derived"]);
+	});
+
+	it("reorders a reversed inheritance chain", () => {
+		expect(sortedNames([{ name: "C", base: "B" }, { name: "B", base: "A" }, { name: "A" }])).toEqual(["A", "B", "C"]);
+	});
+
+	it("moves decorator-referenced types before their referrers", () => {
+		// Mirrors an alphabetically-ordered XSD: referencing type declared first.
+		expect(
+			sortedNames([
+				{ name: "AanvullendeAangifte", elementRefs: ["CollectieveAangifte"] },
+				{ name: "CollectieveAangifte", arrayRefs: ["TotaalRegeling"] },
+				{ name: "TotaalRegeling" },
+			]),
+		).toEqual(["TotaalRegeling", "CollectieveAangifte", "AanvullendeAangifte"]);
+	});
+
+	it("handles diamond dependencies while preserving document order among peers", () => {
+		expect(
+			sortedNames([
+				{ name: "Top", elementRefs: ["Left", "Right"] },
+				{ name: "Left", elementRefs: ["Bottom"] },
+				{ name: "Right", elementRefs: ["Bottom"] },
+				{ name: "Bottom" },
+			]),
+		).toEqual(["Bottom", "Left", "Right", "Top"]);
+	});
+
+	it("ignores base types and references outside the type set", () => {
+		const result = sortTypesByDependency([
+			makeType({ name: "A", base: "ExternalBase", elementRefs: ["ExternalRef"] }),
+			makeType({ name: "B" }),
+		]);
+		expect(result.sorted.map((t) => t.className)).toEqual(["A", "B"]);
+		expect(result.lazyRefs.size).toBe(0);
+	});
+
+	it("marks both directions of a two-type cycle as lazy", () => {
+		const result = sortTypesByDependency([
+			makeType({ name: "A", elementRefs: ["B"] }),
+			makeType({ name: "B", elementRefs: ["A"] }),
+		]);
+		expect(result.sorted.map((t) => t.className)).toEqual(["A", "B"]);
+		expect(result.lazyRefs.get("A")).toEqual(new Set(["B"]));
+		expect(result.lazyRefs.get("B")).toEqual(new Set(["A"]));
+	});
+
+	it("marks a self-reference as lazy", () => {
+		const result = sortTypesByDependency([makeType({ name: "Section", arrayRefs: ["Section"] })]);
+		expect(result.sorted.map((t) => t.className)).toEqual(["Section"]);
+		expect(result.lazyRefs.get("Section")).toEqual(new Set(["Section"]));
+	});
+
+	it("orders extends edges inside a mixed cycle and marks only the soft back-edge lazy", () => {
+		// B extends A (hard), A references B via decorator (soft): one SCC.
+		// The extends edge must still be satisfied by order (A before B); only
+		// the decorator reference becomes a thunk.
+		const result = sortTypesByDependency([
+			makeType({ name: "B", base: "A" }),
+			makeType({ name: "A", elementRefs: ["B"] }),
+		]);
+		expect(result.sorted.map((t) => t.className)).toEqual(["A", "B"]);
+		expect(result.lazyRefs.get("A")).toEqual(new Set(["B"]));
+		expect(result.lazyRefs.has("B")).toBe(false);
+	});
+
+	it("does not mark acyclic references as lazy even when cycles exist elsewhere", () => {
+		const result = sortTypesByDependency([
+			makeType({ name: "A", elementRefs: ["B"] }),
+			makeType({ name: "B", elementRefs: ["A"] }),
+			makeType({ name: "C", elementRefs: ["A"] }),
+		]);
+		expect(result.lazyRefs.has("C")).toBe(false);
+		expect(result.sorted.map((t) => t.className)).toEqual(["A", "B", "C"]);
+	});
+
+	it("throws a descriptive error on an inheritance cycle", () => {
+		expect(() =>
+			sortTypesByDependency([makeType({ name: "A", base: "B" }), makeType({ name: "B", base: "A" })]),
+		).toThrow(/extends.*A, B/s);
+	});
+
+	it("throws on a self-extending type", () => {
+		expect(() => sortTypesByDependency([makeType({ name: "A", base: "A" })])).toThrow(/extends/);
+	});
+
+	it("reports no same-module clusters for acyclic input or soft-only cycles", () => {
+		const acyclic = sortTypesByDependency([makeType({ name: "Base" }), makeType({ name: "Derived", base: "Base" })]);
+		expect(acyclic.sameModuleClusters).toEqual([]);
+
+		// Soft-only cycles are safe across modules (all back-refs are thunks).
+		const softCycle = sortTypesByDependency([
+			makeType({ name: "A", elementRefs: ["B"] }),
+			makeType({ name: "B", elementRefs: ["A"] }),
+		]);
+		expect(softCycle.sameModuleClusters).toEqual([]);
+	});
+
+	it("clusters classes linked by an extends edge inside a cycle, base first", () => {
+		const result = sortTypesByDependency([
+			makeType({ name: "B", base: "A" }),
+			makeType({ name: "A", elementRefs: ["B"] }),
+			makeType({ name: "C" }),
+		]);
+		expect(result.sameModuleClusters).toEqual([["A", "B"]]);
+	});
+
+	it("clusters a whole inheritance chain that closes a cycle", () => {
+		// C extends B extends A, A soft-refs C: one SCC, both extends edges inside it.
+		const result = sortTypesByDependency([
+			makeType({ name: "A", elementRefs: ["C"] }),
+			makeType({ name: "B", base: "A" }),
+			makeType({ name: "C", base: "B" }),
+		]);
+		expect(result.sameModuleClusters).toEqual([["A", "B", "C"]]);
+	});
+
+	it("handles a larger cycle through mixed reference kinds", () => {
+		const result = sortTypesByDependency([
+			makeType({ name: "A", elementRefs: ["B"] }),
+			makeType({ name: "B", arrayRefs: ["C"] }),
+			makeType({ name: "C", elementRefs: ["A"] }),
+		]);
+		expect(result.sorted.map((t) => t.className)).toEqual(["A", "B", "C"]);
+		expect(result.lazyRefs.get("A")).toEqual(new Set(["B"]));
+		expect(result.lazyRefs.get("B")).toEqual(new Set(["C"]));
+		expect(result.lazyRefs.get("C")).toEqual(new Set(["A"]));
+	});
+});

--- a/packages/xml-poto-codegen/tests/integration/facets-roundtrip.test.ts
+++ b/packages/xml-poto-codegen/tests/integration/facets-roundtrip.test.ts
@@ -1,0 +1,177 @@
+/**
+ * End-to-end proof that codegen output and the xml-poto runtime agree on the
+ * new XSD validation options: facets, fixed values, xs:list, and choice groups.
+ * Generates classes from fixture XSDs, imports them, and round-trips XML.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+
+import { XmlDecoratorSerializer } from "@cerios/xml-poto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ClassGenerator } from "../../src/generator/class-generator";
+import { writeGeneratedFiles } from "../../src/generator/file-writer";
+import { XsdParser } from "../../src/xsd/xsd-parser";
+import { XsdResolver } from "../../src/xsd/xsd-resolver";
+
+const FIXTURES = path.resolve(__dirname, "../fixtures");
+const TMP_DIR = path.resolve(__dirname, "../tmp-facets-roundtrip");
+
+function generateFixtureToDir(fixtureName: string, outputDir: string): void {
+	const parser = new XsdParser();
+	const resolver = new XsdResolver();
+	const generator = new ClassGenerator({ xsdPath: fixtureName });
+	const schema = parser.parseFile(path.join(FIXTURES, fixtureName));
+	const resolved = resolver.resolve(schema);
+	const files = generator.generatePerType(resolved);
+	writeGeneratedFiles(outputDir, files);
+}
+
+describe("Generated facet/list/fixed/choice options round-trip through xml-poto", () => {
+	let tempDir: string;
+	let serializer: XmlDecoratorSerializer;
+
+	beforeEach(() => {
+		tempDir = path.join(TMP_DIR, `test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		serializer = new XmlDecoratorSerializer();
+	});
+
+	afterEach(() => {
+		if (existsSync(TMP_DIR)) {
+			rmSync(TMP_DIR, { recursive: true, force: true });
+		}
+	});
+
+	describe("facets.xsd", () => {
+		it("emits facet options in the generated decorators", () => {
+			generateFixtureToDir("facets.xsd", tempDir);
+			const content = readFileSync(path.join(tempDir, "payment.ts"), "utf-8");
+
+			expect(content).toContain("length: 2");
+			expect(content).toContain('pattern: new RegExp("[A-Z]{2}")');
+			expect(content).toContain("totalDigits: 8");
+			expect(content).toContain("fractionDigits: 2");
+			expect(content).toContain("minInclusive: 0");
+			expect(content).toContain("maxExclusive: 1000000");
+			expect(content).toContain("minLength: 2");
+			expect(content).toContain("maxLength: 20");
+			expect(content).toContain("whiteSpace: 'collapse'");
+			// Combined multi-pattern from PhoneOrFax
+			expect(content).toContain("(?:P[0-9]+)|(?:F[0-9]+)");
+			// Attribute facet
+			expect(content).toContain("maxLength: 16");
+		});
+
+		it("enforces the generated facets at runtime", async () => {
+			generateFixtureToDir("facets.xsd", tempDir);
+			const { Payment } = await import(/* @vite-ignore */ path.join(tempDir, "payment.ts"));
+
+			const payment = new Payment();
+			payment.reference = "REF-1";
+			payment.country = "NL";
+			payment.total = 100.5;
+			payment.beneficiary = "Acme";
+
+			const xml: string = serializer.toXml(payment);
+			const parsed = serializer.fromXml(xml, Payment);
+			expect(parsed.country).toBe("NL");
+			expect(parsed.total).toBe(100.5);
+
+			payment.country = "nl"; // violates pattern [A-Z]{2}
+			expect(() => serializer.toXml(payment)).toThrow(/does not match pattern/);
+
+			payment.country = "NL";
+			payment.total = 5000000; // violates maxExclusive 1000000
+			expect(() => serializer.toXml(payment)).toThrow(/maxExclusive/);
+		});
+	});
+
+	describe("list.xsd", () => {
+		it("emits list options in the generated decorators", () => {
+			generateFixtureToDir("list.xsd", tempDir);
+			const content = readFileSync(path.join(tempDir, "measurements.ts"), "utf-8");
+
+			expect(content).toContain("list: { itemType: 'number' }");
+			expect(content).toContain("sizes: number[]");
+		});
+
+		it("round-trips list values as space-separated text", async () => {
+			generateFixtureToDir("list.xsd", tempDir);
+			const { Measurements } = await import(/* @vite-ignore */ path.join(tempDir, "measurements.ts"));
+
+			const measurements = new Measurements();
+			measurements.sizes = [1, 2, 3];
+			measurements.ids = [10, 20];
+
+			const xml: string = serializer.toXml(measurements);
+			expect(xml).toContain("<Sizes>1 2 3</Sizes>");
+			expect(xml).toContain(`ids="10 20"`);
+
+			const parsed = serializer.fromXml(xml, Measurements);
+			expect(parsed.sizes).toEqual([1, 2, 3]);
+			expect(parsed.ids).toEqual([10, 20]);
+		});
+
+		it("applies list itemType facets to each item", async () => {
+			generateFixtureToDir("list.xsd", tempDir);
+			const { Measurements } = await import(/* @vite-ignore */ path.join(tempDir, "measurements.ts"));
+
+			const measurements = new Measurements();
+			measurements.sizes = [1];
+			measurements.scores = [50, 200]; // RestrictedInt maxInclusive=100
+
+			expect(() => serializer.toXml(measurements)).toThrow(/maxInclusive 100/);
+		});
+	});
+
+	describe("fixed.xsd", () => {
+		it("emits fixedValue options and applies them as defaults", async () => {
+			generateFixtureToDir("fixed.xsd", tempDir);
+			const content = readFileSync(path.join(tempDir, "manifest.ts"), "utf-8");
+			expect(content).toContain("fixedValue: 'jsonl'");
+			expect(content).toContain("fixedValue: '2.1'");
+
+			const { Manifest } = await import(/* @vite-ignore */ path.join(tempDir, "manifest.ts"));
+			const parsed = serializer.fromXml('<Manifest version="2.1"><Name>test</Name></Manifest>', Manifest);
+			expect(parsed.name).toBe("test");
+			// Missing Format element falls back to the fixed value
+			expect(parsed.format).toBe("jsonl");
+		});
+
+		it("rejects values that contradict the fixed value", async () => {
+			generateFixtureToDir("fixed.xsd", tempDir);
+			const { Manifest } = await import(/* @vite-ignore */ path.join(tempDir, "manifest.ts"));
+
+			expect(() =>
+				serializer.fromXml(`<Manifest version="2.1"><Format>xml</Format><Name>x</Name></Manifest>`, Manifest),
+			).toThrow(/does not equal the fixed value 'jsonl'/);
+		});
+	});
+
+	describe("choice.xsd", () => {
+		it("emits choiceGroup options for direct choice members", () => {
+			generateFixtureToDir("choice.xsd", tempDir);
+			const content = readFileSync(path.join(tempDir, "notification.ts"), "utf-8");
+
+			expect(content).toContain("choiceGroup: 'choice");
+		});
+
+		it("enforces exclusive choice at runtime", async () => {
+			generateFixtureToDir("choice.xsd", tempDir);
+			const { Notification } = await import(/* @vite-ignore */ path.join(tempDir, "notification.ts"));
+
+			const notification = new Notification();
+			notification.title = "Hello";
+			notification.email = "a@b.c";
+			notification.phone = "12345";
+
+			expect(() => serializer.toXml(notification)).toThrow(/Choice group/);
+
+			notification.phone = undefined;
+			const xml: string = serializer.toXml(notification);
+			expect(xml).toContain("<Email>a@b.c</Email>");
+		});
+	});
+});

--- a/packages/xml-poto-codegen/tests/integration/ordering-roundtrip.test.ts
+++ b/packages/xml-poto-codegen/tests/integration/ordering-roundtrip.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Declaration-order regression tests.
+ *
+ * Generated classes reference each other at module-evaluation time (extends
+ * clauses and decorator `type:` options), so importing the generated module is
+ * itself the assertion: out-of-order or circular declarations throw a TDZ
+ * ReferenceError at import before the fix. Each test then round-trips XML to
+ * confirm the emitted decorators (including `() => Foo` thunks) behave.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+
+import { XmlDecoratorSerializer } from "@cerios/xml-poto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ClassGenerator } from "../../src/generator/class-generator";
+import { writeGeneratedFiles } from "../../src/generator/file-writer";
+import { XsdParser } from "../../src/xsd/xsd-parser";
+import { XsdResolver } from "../../src/xsd/xsd-resolver";
+
+const FIXTURES = path.resolve(__dirname, "../fixtures");
+const TMP_DIR = path.resolve(__dirname, "../tmp-ordering-roundtrip");
+
+function generateFixture(
+	fixtureName: string,
+	outputDir: string,
+	style: "per-xsd" | "per-type",
+): { fileNames: string[] } {
+	const parser = new XsdParser();
+	const resolver = new XsdResolver();
+	const generator = new ClassGenerator({ xsdPath: fixtureName });
+
+	const schema = parser.parseFile(path.join(FIXTURES, fixtureName));
+	const resolved = resolver.resolve(schema);
+	const files =
+		style === "per-xsd" ? generator.generatePerXsd(resolved, "generated") : generator.generatePerType(resolved);
+	writeGeneratedFiles(outputDir, files);
+	return { fileNames: files.map((f) => f.fileName) };
+}
+
+describe("Generated code declaration order", () => {
+	let tempDir: string;
+	let serializer: XmlDecoratorSerializer;
+
+	beforeEach(() => {
+		// Unique directory per test to avoid Vitest module-cache collisions
+		tempDir = path.join(TMP_DIR, `test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		serializer = new XmlDecoratorSerializer();
+	});
+
+	afterEach(() => {
+		if (existsSync(TMP_DIR)) {
+			rmSync(TMP_DIR, { recursive: true, force: true });
+		}
+	});
+
+	describe("per-xsd output from an out-of-order XSD", () => {
+		it("writes dependencies before their dependents", () => {
+			generateFixture("out-of-order.xsd", tempDir, "per-xsd");
+			const content = readFileSync(path.join(tempDir, "generated.ts"), "utf-8");
+
+			const userAt = content.indexOf("class UserType");
+			const adminAt = content.indexOf("class AdminType");
+			const companyAt = content.indexOf("class CompanyType");
+			expect(userAt).toBeGreaterThanOrEqual(0);
+			expect(userAt).toBeLessThan(adminAt);
+			expect(adminAt).toBeLessThan(companyAt);
+		});
+
+		it("imports without TDZ errors and round-trips XML", async () => {
+			generateFixture("out-of-order.xsd", tempDir, "per-xsd");
+
+			// Pre-fix this import throws "Cannot access 'UserType' before initialization"
+			const module = await import(/* @vite-ignore */ path.join(tempDir, "generated.ts"));
+			// CompanyType carries @XmlRoot({ name: 'Company' }) from the root element
+			const { CompanyType, UserType, AdminType } = module;
+
+			const owner = new UserType();
+			owner.fullName = "Alice";
+			const admin = new AdminType();
+			admin.fullName = "Bob";
+			admin.permissions = "all";
+
+			const company = new CompanyType();
+			company.name = "Acme";
+			company.owner = owner;
+			company.admin = admin;
+
+			const xml: string = serializer.toXml(company);
+			const parsed = serializer.fromXml(xml, CompanyType);
+
+			expect(parsed.name).toBe("Acme");
+			expect(parsed.owner).toBeInstanceOf(UserType);
+			expect(parsed.owner.fullName).toBe("Alice");
+			expect(parsed.admin).toBeInstanceOf(AdminType);
+			expect(parsed.admin.permissions).toBe("all");
+		});
+	});
+
+	describe("per-xsd output from a circular XSD", () => {
+		it("imports without TDZ errors and round-trips recursive structures", async () => {
+			generateFixture("circular.xsd", tempDir, "per-xsd");
+
+			const module = await import(/* @vite-ignore */ path.join(tempDir, "generated.ts"));
+			const { Document, PersonType, ManagerType, SectionType } = module;
+
+			const manager = new ManagerType();
+			manager.name = "Carol";
+			manager.title = "CTO";
+
+			const person = new PersonType();
+			person.name = "Dave";
+			person.manager = manager;
+
+			const leaf = new SectionType();
+			leaf.heading = "Leaf";
+			const section = new SectionType();
+			section.heading = "Top";
+			section.section = [leaf];
+
+			const document = new Document();
+			document.person = person;
+			document.section = section;
+
+			const xml: string = serializer.toXml(document);
+			const parsed = serializer.fromXml(xml, Document);
+
+			expect(parsed.person).toBeInstanceOf(PersonType);
+			expect(parsed.person.manager).toBeInstanceOf(ManagerType);
+			expect(parsed.person.manager.title).toBe("CTO");
+			expect(parsed.section).toBeInstanceOf(SectionType);
+			expect(parsed.section.section?.[0]).toBeInstanceOf(SectionType);
+			expect(parsed.section.section?.[0].heading).toBe("Leaf");
+		});
+	});
+
+	describe("per-type output from a circular XSD, imported via the barrel", () => {
+		it("merges the extends-cycle classes into one module and round-trips", async () => {
+			const { fileNames } = generateFixture("circular.xsd", tempDir, "per-type");
+
+			// PersonType/ManagerType form an extends cycle → one shared module.
+			expect(fileNames).toContain("person-type.ts");
+			expect(fileNames).not.toContain("manager-type.ts");
+			// Self-recursive SectionType stays in its own file (thunk suffices).
+			expect(fileNames).toContain("section-type.ts");
+
+			const module = await import(/* @vite-ignore */ path.join(tempDir, "index.ts"));
+			const { PersonType, ManagerType } = module;
+
+			const manager = new ManagerType();
+			manager.name = "Erin";
+			manager.title = "Lead";
+
+			const person = new PersonType();
+			person.name = "Frank";
+			person.manager = manager;
+
+			const xml: string = serializer.toXml(person);
+			const parsed = serializer.fromXml(xml, PersonType);
+
+			expect(parsed.manager).toBeInstanceOf(ManagerType);
+			expect(parsed.manager.name).toBe("Erin");
+			expect(parsed.manager.title).toBe("Lead");
+		});
+	});
+});

--- a/packages/xml-poto-codegen/tests/integration/wsdl-generation.test.ts
+++ b/packages/xml-poto-codegen/tests/integration/wsdl-generation.test.ts
@@ -1,0 +1,63 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { GeneratedFile } from "../../src/generator/class-generator";
+import { ClassGenerator } from "../../src/generator/class-generator";
+import { XsdParser } from "../../src/xsd/xsd-parser";
+import type { ResolvedSchema } from "../../src/xsd/xsd-resolver";
+import { XsdResolver } from "../../src/xsd/xsd-resolver";
+
+const FIXTURES = path.resolve(__dirname, "../fixtures");
+
+function pipeline(fixtureName: string): { resolved: ResolvedSchema; files: GeneratedFile[] } {
+	const parser = new XsdParser();
+	const resolver = new XsdResolver();
+	const generator = new ClassGenerator({ xsdPath: fixtureName });
+	const schema = parser.parseFile(path.join(FIXTURES, fixtureName));
+	const resolved = resolver.resolve(schema);
+	const files = generator.generatePerType(resolved);
+	return { resolved, files };
+}
+
+describe("WSDL generation pipeline (service.wsdl)", () => {
+	it("resolves types from all embedded schemas", () => {
+		const { resolved } = pipeline("service.wsdl");
+
+		const classNames = resolved.types.map((t) => t.className);
+		expect(classNames).toContain("Identification");
+		expect(classNames).toContain("Record");
+		expect(classNames).toContain("ServiceRequest");
+		// From the second embedded schema
+		expect(classNames).toContain("ServiceFault");
+	});
+
+	it("resolves non-empty properties (guards against silent-empty output)", () => {
+		const { resolved } = pipeline("service.wsdl");
+
+		const emptyTypes = resolved.types.filter((t) => t.properties.length === 0).map((t) => t.className);
+		expect(emptyTypes).toEqual([]);
+
+		const identification = resolved.types.find((t) => t.className === "Identification")!;
+		const propNames = identification.properties.map((p) => p.propertyName);
+		expect(propNames).toContain("indicator");
+		expect(propNames).toContain("user");
+	});
+
+	it("generates decorated classes with the WSDL target namespace", () => {
+		const { files } = pipeline("service.wsdl");
+
+		const requestFile = files.find((f) => f.fileName === "service-request.ts");
+		expect(requestFile).toBeDefined();
+		expect(requestFile!.content).toContain("@XmlRoot(");
+		expect(requestFile!.content).toContain("http://example.com/service/v1");
+	});
+
+	it("resolves cross-schema tns type references to generated classes", () => {
+		const { resolved } = pipeline("service.wsdl");
+
+		const request = resolved.types.find((t) => t.className === "ServiceRequest")!;
+		const identificationProp = request.properties.find((p) => p.propertyName === "identification")!;
+		expect(identificationProp.tsType).toBe("Identification");
+	});
+});

--- a/packages/xml-poto-codegen/tests/integration/xsd-coverage.test.ts
+++ b/packages/xml-poto-codegen/tests/integration/xsd-coverage.test.ts
@@ -1,0 +1,269 @@
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { GeneratedFile } from "../../src/generator/class-generator";
+import { ClassGenerator } from "../../src/generator/class-generator";
+import { XsdParser } from "../../src/xsd/xsd-parser";
+import type { ResolvedSchema } from "../../src/xsd/xsd-resolver";
+import { XsdResolver } from "../../src/xsd/xsd-resolver";
+
+const FIXTURES = path.resolve(__dirname, "../fixtures");
+
+function pipeline(fixtureName: string): { resolved: ResolvedSchema; files: GeneratedFile[] } {
+	const parser = new XsdParser();
+	const resolver = new XsdResolver();
+	const generator = new ClassGenerator({ xsdPath: fixtureName });
+	const schema = parser.parseFile(path.join(FIXTURES, fixtureName));
+	const resolved = resolver.resolve(schema);
+	const files = generator.generatePerType(resolved);
+	return { resolved, files };
+}
+
+// ── xs:annotation / xs:documentation → JSDoc ────────────────────────────────
+
+describe("xs:documentation → JSDoc", () => {
+	it("parses documentation on schema, types, elements, and attributes", () => {
+		const parser = new XsdParser();
+		const schema = parser.parseFile(path.join(FIXTURES, "documentation.xsd"));
+
+		expect(schema.documentation).toBe("Schema-level documentation.");
+		expect(schema.simpleTypes[0].documentation).toBe("The processing status of an order.");
+		expect(schema.complexTypes[0].documentation).toContain("A customer with a name and status.");
+		expect(schema.complexTypes[0].sequence!.elements[0].documentation).toBe("The full name of the customer.");
+		expect(schema.complexTypes[0].attributes[0].documentation).toBe("Unique customer identifier.");
+		expect(schema.elements[0].documentation).toBe("Root element for a single customer.");
+	});
+
+	it("collapses internal whitespace in multi-line documentation", () => {
+		const parser = new XsdParser();
+		const schema = parser.parseFile(path.join(FIXTURES, "documentation.xsd"));
+
+		expect(schema.complexTypes[0].documentation).toBe(
+			"A customer with a name and status. Spans multiple lines in the source document.",
+		);
+	});
+
+	it("emits JSDoc for classes, properties, and enums", () => {
+		const { files } = pipeline("documentation.xsd");
+
+		const customer = files.find((f) => f.fileName === "customer-type.ts")!;
+		expect(customer.content).toContain(
+			"/** A customer with a name and status. Spans multiple lines in the source document. */",
+		);
+		expect(customer.content).toContain("/** The full name of the customer. */");
+		expect(customer.content).toContain("/** Unique customer identifier. */");
+
+		const status = files.find((f) => f.fileName === "status-type.ts")!;
+		expect(status.content).toContain("/** The processing status of an order. */");
+	});
+});
+
+// ── xs:length facet ─────────────────────────────────────────────────────────
+
+describe("xs:length facet", () => {
+	it("parses length on restrictions", () => {
+		const parser = new XsdParser();
+		const schema = parser.parseString(`<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:simpleType name="CountryCode">
+		<xs:restriction base="xs:string">
+			<xs:length value="2"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>`);
+
+		expect(schema.simpleTypes[0].restriction!.length).toBe(2);
+	});
+});
+
+// ── Multiple xs:pattern facets ──────────────────────────────────────────────
+
+describe("multiple xs:pattern facets", () => {
+	it("ORs multiple patterns into a single combined pattern", () => {
+		const parser = new XsdParser();
+		const schema = parser.parseString(`<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:simpleType name="PhoneOrFax">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="P[0-9]+"/>
+			<xs:pattern value="F[0-9]+"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>`);
+
+		expect(schema.simpleTypes[0].restriction!.pattern).toBe("(?:P[0-9]+)|(?:F[0-9]+)");
+	});
+});
+
+// ── complexContent restriction with choice/all ──────────────────────────────
+
+describe("complexContent restriction compositors", () => {
+	it("resolves choice inside a complexContent restriction", () => {
+		const { resolved } = pipeline("restriction-content.xsd");
+
+		const choiceShape = resolved.types.find((t) => t.className === "ChoiceShape")!;
+		expect(choiceShape.baseTypeName).toBe("BaseShape");
+		const propNames = choiceShape.properties.map((p) => p.propertyName);
+		expect(propNames).toContain("circle");
+		expect(propNames).toContain("square");
+		for (const prop of choiceShape.properties) {
+			expect(prop.required).toBe(false);
+		}
+	});
+
+	it("resolves all inside a complexContent restriction", () => {
+		const { resolved } = pipeline("restriction-content.xsd");
+
+		const allShape = resolved.types.find((t) => t.className === "AllShape")!;
+		const propNames = allShape.properties.map((p) => p.propertyName);
+		expect(propNames).toContain("width");
+		expect(propNames).toContain("height");
+	});
+});
+
+// ── xs:all with minOccurs ───────────────────────────────────────────────────
+
+describe("xs:all occurs", () => {
+	it("parses minOccurs on xs:all", () => {
+		const parser = new XsdParser();
+		const schema = parser.parseFile(path.join(FIXTURES, "all-occurs.xsd"));
+
+		expect(schema.elements[0].complexType!.all!.minOccurs).toBe(0);
+	});
+
+	it("makes all members optional when the all group has minOccurs=0", () => {
+		const { resolved } = pipeline("all-occurs.xsd");
+
+		const config = resolved.types.find((t) => t.className === "Config")!;
+		const requiredProps = config.properties.filter((p) => p.required !== false).map((p) => p.propertyName);
+		expect(requiredProps).toEqual([]);
+	});
+});
+
+// ── Prohibited attributes ───────────────────────────────────────────────────
+
+describe("prohibited attributes", () => {
+	it("omits use=prohibited attributes and records a coverage note", () => {
+		const { resolved } = pipeline("prohibited.xsd");
+
+		const finalDoc = resolved.types.find((t) => t.className === "FinalDocument")!;
+		const propNames = finalDoc.properties.map((p) => p.propertyName);
+		expect(propNames).not.toContain("draft");
+		expect(propNames).toContain("author");
+
+		expect(resolved.coverageNotes).toContainEqual(expect.stringContaining("draft"));
+	});
+});
+
+// ── Identity constraints and notations ──────────────────────────────────────
+
+describe("identity constraints and notations", () => {
+	it("parses key/unique constraints and notation declarations", () => {
+		const parser = new XsdParser();
+		const schema = parser.parseFile(path.join(FIXTURES, "identity-constraints.xsd"));
+
+		expect(schema.notations).toEqual(["jpeg"]);
+		const library = schema.elements[0];
+		expect(library.identityConstraints).toEqual([
+			{ kind: "key", name: "bookKey" },
+			{ kind: "unique", name: "uniqueIsbn" },
+		]);
+	});
+
+	it("emits coverage notes for identity constraints and notations", () => {
+		const { resolved } = pipeline("identity-constraints.xsd");
+
+		expect(resolved.coverageNotes).toContainEqual(expect.stringContaining("bookKey"));
+		expect(resolved.coverageNotes).toContainEqual(expect.stringContaining("uniqueIsbn"));
+		expect(resolved.coverageNotes).toContainEqual(expect.stringContaining("jpeg"));
+	});
+});
+
+// ── xs:redefine ─────────────────────────────────────────────────────────────
+
+describe("xs:redefine", () => {
+	it("merges the redefined schema like an include and warns", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const { resolved } = pipeline("redefine-main.xsd");
+
+			const classNames = resolved.types.map((t) => t.className);
+			expect(classNames).toContain("AddressType");
+			expect(classNames).toContain("Shipment");
+
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("xs:redefine"));
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+});
+
+// ── Remote schemaLocation warnings ──────────────────────────────────────────
+
+describe("remote and missing schemaLocation", () => {
+	it("warns for remote URLs instead of silently skipping", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const parser = new XsdParser();
+			parser.parseString(
+				`<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:import namespace="http://example.com/remote" schemaLocation="https://example.com/remote.xsd"/>
+</xs:schema>`,
+				FIXTURES,
+			);
+
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("remote URL"));
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("warns for missing local files instead of silently skipping", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const parser = new XsdParser();
+			parser.parseString(
+				`<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:include schemaLocation="does-not-exist.xsd"/>
+</xs:schema>`,
+				FIXTURES,
+			);
+
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("not found"));
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+});
+
+// ── xs:union initializer preference ─────────────────────────────────────────
+
+describe("xs:union", () => {
+	it("prefers the string member initializer for mixed unions", () => {
+		const parser = new XsdParser();
+		const resolver = new XsdResolver();
+		const schema = parser.parseString(`<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:simpleType name="NumberOrString">
+		<xs:union memberTypes="xs:integer xs:string"/>
+	</xs:simpleType>
+	<xs:element name="Root">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Value" type="NumberOrString"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>`);
+		const resolved = resolver.resolve(schema);
+
+		const root = resolved.types.find((t) => t.className === "Root")!;
+		const value = root.properties.find((p) => p.propertyName === "value")!;
+		expect(value.tsType).toBe("number | string");
+		expect(value.initializer).toBe("''");
+		expect(value.documentation).toContain("xs:union of xs:integer, xs:string");
+	});
+});

--- a/packages/xml-poto-codegen/tests/xsd/xsd-parser.test.ts
+++ b/packages/xml-poto-codegen/tests/xsd/xsd-parser.test.ts
@@ -702,7 +702,9 @@ describe("XsdParser", () => {
 <body><p>This is a web page, not an XSD file.</p></body>
 </html>`;
 
-			expect(() => parser.parseString(html)).toThrow("The provided content does not appear to be a valid XSD schema.");
+			expect(() => parser.parseString(html)).toThrow(
+				"The provided content does not appear to be a valid XSD schema or WSDL document.",
+			);
 		});
 
 		it("should throw when content is an HTML page (bare <html> root)", () => {
@@ -711,7 +713,9 @@ describe("XsdParser", () => {
 <body><pre>some content</pre></body>
 </html>`;
 
-			expect(() => parser.parseString(html)).toThrow("The provided content does not appear to be a valid XSD schema.");
+			expect(() => parser.parseString(html)).toThrow(
+				"The provided content does not appear to be a valid XSD schema or WSDL document.",
+			);
 		});
 
 		it("should throw a generic error for non-HTML XML that has no schema root", () => {
@@ -721,12 +725,14 @@ describe("XsdParser", () => {
   <from>Bob</from>
 </note>`;
 
-			expect(() => parser.parseString(xml)).toThrow("The provided content does not appear to be a valid XSD schema.");
+			expect(() => parser.parseString(xml)).toThrow(
+				"The provided content does not appear to be a valid XSD schema or WSDL document.",
+			);
 		});
 
 		it("should throw a generic error for plain text content", () => {
 			expect(() => parser.parseString("just some plain text")).toThrow(
-				"The provided content does not appear to be a valid XSD schema.",
+				"The provided content does not appear to be a valid XSD schema or WSDL document.",
 			);
 		});
 
@@ -796,6 +802,77 @@ describe("XsdParser", () => {
 
 			const schema = parser.parseString(xsd);
 			expect(schema.elements[0].name).toBe("HtmlReport");
+		});
+	});
+
+	describe("WSDL support (service.wsdl)", () => {
+		it("should extract and merge all schemas embedded in the WSDL types section", () => {
+			const schema = parser.parseFile(path.join(FIXTURES, "service.wsdl"));
+
+			const typeNames = schema.complexTypes.map((ct) => ct.name);
+			expect(typeNames).toContain("identification");
+			expect(typeNames).toContain("record");
+
+			// serviceRequest comes from the first schema, serviceFault from the second
+			const elementNames = schema.elements.map((e) => e.name);
+			expect(elementNames).toContain("serviceRequest");
+			expect(elementNames).toContain("serviceFault");
+		});
+
+		it("should parse element content of embedded schemas (not silently empty)", () => {
+			const schema = parser.parseFile(path.join(FIXTURES, "service.wsdl"));
+
+			const identification = schema.complexTypes.find((ct) => ct.name === "identification")!;
+			expect(identification.sequence).toBeDefined();
+			expect(identification.sequence!.elements).toHaveLength(2);
+			expect(identification.sequence!.elements[0].name).toBe("indicator");
+			expect(identification.sequence!.elements[0].type).toBe("xsd:string");
+		});
+
+		it("should inherit namespace declarations from the WSDL definitions root", () => {
+			const schema = parser.parseFile(path.join(FIXTURES, "service.wsdl"));
+
+			expect(schema.targetNamespace).toBe("http://example.com/service/v1");
+			expect(schema.namespaces.get("tns")).toBe("http://example.com/service/v1");
+			expect(schema.namespaces.get("xsd")).toBe("http://www.w3.org/2001/XMLSchema");
+		});
+
+		it("should parse nillable and occurs on embedded schema elements", () => {
+			const schema = parser.parseFile(path.join(FIXTURES, "service.wsdl"));
+
+			const record = schema.complexTypes.find((ct) => ct.name === "record")!;
+			expect(record.sequence!.elements[1].name).toBe("value");
+			expect(record.sequence!.elements[1].nillable).toBe(true);
+
+			const request = schema.elements.find((e) => e.name === "serviceRequest")!;
+			const records = request.complexType!.sequence!.elements[1];
+			expect(records.maxOccurs).toBe("unbounded");
+		});
+
+		it("should handle a prefixed wsdl:definitions root", () => {
+			const wsdl = `<?xml version="1.0"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  targetNamespace="http://example.com/prefixed">
+	<wsdl:types>
+		<xs:schema targetNamespace="http://example.com/prefixed">
+			<xs:element name="Ping" type="xs:string"/>
+		</xs:schema>
+	</wsdl:types>
+</wsdl:definitions>`;
+
+			const schema = parser.parseString(wsdl);
+			expect(schema.elements).toHaveLength(1);
+			expect(schema.elements[0].name).toBe("Ping");
+		});
+
+		it("should throw a clear error for a WSDL without embedded schemas", () => {
+			const wsdl = `<?xml version="1.0"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://example.com/empty">
+	<message name="Empty"/>
+</definitions>`;
+
+			expect(() => parser.parseString(wsdl)).toThrow("The WSDL document contains no XSD schemas.");
 		});
 	});
 });

--- a/packages/xml-poto-codegen/tests/xsd/xsd-resolver.test.ts
+++ b/packages/xml-poto-codegen/tests/xsd/xsd-resolver.test.ts
@@ -965,4 +965,32 @@ describe("XsdResolver", () => {
 			expect(version.kind).toBe("attribute");
 		});
 	});
+
+	describe("duplicate elements across choice branches", () => {
+		it("merges duplicates into one property that is optional unless required in every branch", () => {
+			const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="ReportType">
+		<xs:choice>
+			<xs:sequence>
+				<xs:element name="Intro" type="xs:string"/>
+				<xs:element name="Correction" type="xs:string" minOccurs="0" maxOccurs="13"/>
+			</xs:sequence>
+			<xs:sequence>
+				<xs:element name="Correction" type="xs:string" maxOccurs="13"/>
+			</xs:sequence>
+		</xs:choice>
+	</xs:complexType>
+</xs:schema>`;
+
+			const schema = parser.parseString(xsd);
+			const resolved = resolver.resolve(schema);
+			const report = resolved.types.find((t) => t.className === "ReportType")!;
+
+			const corrections = report.properties.filter((p) => p.xmlName === "Correction");
+			expect(corrections).toHaveLength(1);
+			// One branch allows the element to be absent → the merged property is optional
+			expect(corrections[0].required).not.toBe(true);
+		});
+	});
 });

--- a/packages/xml-poto-codegen/tsconfig.build.json
+++ b/packages/xml-poto-codegen/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		// No @cerios/xml-poto -> ../xml-poto/src alias here: the tsdown dts build
+		// must resolve the workspace dependency to its built dist types. With the
+		// source alias, TypeScript 7's tsgo declaration generator emits stray
+		// .d.ts files next to the xml-poto sources.
+		"paths": {}
+	}
+}

--- a/packages/xml-poto-codegen/tsdown.config.mts
+++ b/packages/xml-poto-codegen/tsdown.config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["./src/index.ts", "./src/cli.ts"],
+	tsconfig: "./tsconfig.build.json",
 	format: ["cjs", "esm"],
 	dts: true,
 	sourcemap: true,

--- a/packages/xml-poto-codegen/vitest.config.ts
+++ b/packages/xml-poto-codegen/vitest.config.ts
@@ -1,8 +1,42 @@
 import path from "node:path";
 
+import { transform } from "esbuild";
+import type { Plugin } from "vite";
 import { defineConfig } from "vitest/config";
 
+/**
+ * Vitest 4.1+ ships rolldown-vite, which transpiles TypeScript with oxc.
+ * Oxc only lowers legacy (experimentalDecorators) decorators; TC39 stage-3
+ * decorator syntax passes through untouched and crashes Node.js with
+ * "SyntaxError: Invalid or unexpected token". Transpile .ts modules with
+ * esbuild instead, which fully lowers stage-3 decorators. This also covers
+ * the generated classes the round-trip tests import from tests/tmp-*.
+ * Remove once oxc supports the decorators proposal transform.
+ */
+function esbuildStage3Decorators(): Plugin {
+	return {
+		name: "esbuild-stage3-decorators",
+		enforce: "pre",
+		async transform(code, id) {
+			const filePath = id.split("?")[0];
+			if (!filePath.endsWith(".ts") || filePath.endsWith(".d.ts")) {
+				return null;
+			}
+			const result = await transform(code, {
+				loader: "ts",
+				target: "es2022",
+				// Match tsc class-field semantics for tsconfig target es2019
+				tsconfigRaw: { compilerOptions: { useDefineForClassFields: false } },
+				sourcefile: filePath,
+				sourcemap: true,
+			});
+			return { code: result.code, map: result.map };
+		},
+	};
+}
+
 export default defineConfig({
+	plugins: [esbuildStage3Decorators()],
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),

--- a/packages/xml-poto/CHANGELOG.md
+++ b/packages/xml-poto/CHANGELOG.md
@@ -27,7 +27,6 @@
   When set to `true`, all `@XmlElement`, `@XmlAttribute`, `@XmlArray`, and `@XmlText` decorated fields are treated as required during deserialization unless the decorator explicitly sets `required: false`. This complements the existing per-field `required` option by providing a class-wide default, removing the need to mark every field individually.
 
   Key behaviours:
-
   - Fields with `required: false` are always optional regardless of this option.
   - Fields with a `defaultValue` in the decorator are exempt from the required check (the default is used instead).
   - TypeScript field initializers (e.g. `= ""`) have no effect on the required check; only `defaultValue` in the decorator suppresses the error.
@@ -52,14 +51,12 @@
   which broke CJS consumers and `@arethetypeswrong/cli` resolution.
 
   Updated in both packages:
-
   - `main`: `./dist/index.js` → `./dist/index.cjs`
   - `types`: `./dist/index.d.ts` → `./dist/index.d.cts`
   - `exports["."].require.default`: `./dist/index.js` → `./dist/index.cjs`
   - `exports["."].require.types`: `./dist/index.d.ts` → `./dist/index.d.cts`
 
   In `@cerios/xml-poto-codegen` the `bin` entry was also corrected:
-
   - `bin["xml-poto-codegen"]`: `dist/cli.js` → `dist/cli.cjs`
 
   ESM entry points (`.mjs` / `.d.mts`) were already correct and are unchanged.
@@ -76,7 +73,6 @@
   `[XmlType]` / `[XmlRoot]` name.
 
   The serializer now resolves an element's tag name using a 3-tier priority:
-
   1. Explicit name provided on the property's `@XmlElement` decorator.
   2. Class-level `@XmlElement` / `@XmlRoot` name of the referenced type.
   3. The property key (default).
@@ -98,13 +94,11 @@
 - c4f2ffd: Implement `form` namespace qualification for `@XmlElement`, `@XmlAttribute`, and `@XmlArray`.
 
   The `form` option (`"qualified"` | `"unqualified"`) now has runtime effect, matching the XSD `form` attribute semantics:
-
   - **`"qualified"`** — the element or attribute is serialized with its namespace prefix (e.g. `<ns:city>`).
   - **`"unqualified"`** — the prefix is suppressed even when a namespace is configured (e.g. `<city>`), matching local elements in schemas with `elementFormDefault="unqualified"`.
   - **default (undefined)** — existing behaviour is preserved: prefix applied when present for `@XmlElement`/`@XmlAttribute`; no prefix on `@XmlArray` containers.
 
   **Changes in `@cerios/xml-poto`:**
-
   - `XmlNamespaceUtil.buildElementName()` — respects `form` when building the prefixed element name. Cache key now includes `form` to avoid cross-contamination.
   - `XmlNamespaceUtil.buildAttributeName()` — same logic; parameter type extended to accept `form?`.
   - `XmlMappingUtil.serializeArrayValue()` — container element name is now prefixed when `form === "qualified"` and a namespace prefix is configured.
@@ -112,7 +106,6 @@
   - `XmlArrayOptions` and `XmlArrayMetadata` — `form` option added (was already present on `XmlElementOptions`/`XmlAttributeOptions`).
 
   **Changes in `@cerios/xml-poto-codegen`:**
-
   - `buildArrayDecorator()` — now emits `form: '...'` in generated `@XmlArray` decorators, consistent with `@XmlElement` and `@XmlAttribute`.
 
 ## 2.1.3
@@ -132,7 +125,6 @@
 - 0e1a3ee: Enforce @XmlArray for list properties — strict validation error when using @XmlElement for arrays
 
   **Breaking (strict mode):** When `strictValidation` is enabled, using `@XmlElement` on a property that receives multiple XML elements (producing an array) now throws a `[Strict Validation Error]`. The error message includes the property name, the XML element name, and a concrete fix suggesting `@XmlArray({ itemName: '...', type: YourItemClass })`.
-
   - `@XmlElement` no longer auto-deserializes repeated XML elements into typed array items. Arrays pass through as plain objects unless `@XmlArray` is used.
   - The error is thrown for any `@XmlElement` property receiving an array, even when a `type` is specified.
   - Mixed content arrays (`mixedContent: true`) are excluded from this validation and continue to work as before.
@@ -173,7 +165,6 @@
 ### Major Changes
 
 - 045a46b: **Switched linting toolchain from Biome to oxlint and removed deprecations**
-
   - Replaced Biome with oxlint across the project.
   - Updated linting configuration.
   - Refactored internal modules to reduce complexity.
@@ -225,7 +216,6 @@
   **Problem:** When two different classes were decorated with the same `@XmlElement` name (e.g., `@XmlElement("security")`), they would compete for the same global registry entry. Whichever class was imported last would overwrite the first, causing deserialization to use the wrong class.
 
   **Solution:** Implemented a context-aware element registration system that:
-
   - Tracks elements within their parent class context when explicit types are provided
   - Prevents registry collisions between classes with identical element names
   - Maintains full backward compatibility with existing code
@@ -273,7 +263,6 @@
   Classes with @XmlElement decorator are automatically discovered and instantiated during deserialization without explicit type parameters or property initialization.
 
   Features:
-
   - Namespace-aware lookup (strips prefixes like ns:element)
   - Dotted name handling (sender.identifier → identifier)
   - Naming convention variants (camelCase, PascalCase, special char removal)
@@ -296,14 +285,12 @@
 ### Minor Changes
 
 - fc4b289: **Added support for multiple namespace declarations on XML elements.**
-
   - You can now declare multiple namespaces on a single element using the new `namespaces` array property, while maintaining backward compatibility with the existing `namespace` property.
   - Enables XBRL-style documents and other complex XML structures where the root element declares all namespaces upfront, reducing redundant namespace declarations throughout the document tree.
   - All decorator interfaces (`XmlRoot`, `XmlElement`, `XmlAttribute`, `XmlArray`) and metadata structures now support the `namespaces` array pattern.
   - Comprehensive documentation and examples for multi-namespace scenarios, nested element patterns, and XBRL use cases have been added.
 
   **Improved XML namespace handling for nested elements.**
-
   - Nested elements now declare their own namespaces, matching C# XmlSerializer behavior.
   - Namespace context is propagated to child properties that don’t have explicit namespace declarations, ensuring proper inheritance.
   - Namespace collection is optimized to avoid redundant declarations from deeply nested objects.
@@ -314,19 +301,16 @@
 ### Minor Changes
 
 - e4a2c63: Performance Improvements:
-
   - 3x faster serialization/deserialization via optimized metadata lookups and caching
   - Removed public metadata getter functions (use direct getMetadata() instead)
   - Cached namespace collections and element/attribute name building
   - Refactored to flatMap for cleaner array operations
 
   Features:
-
   - Transform functions and class conversion methods
   - Automated release workflow with GitHub Actions + npm provenance
 
   Cleanup:
-
   - Removed manual initializeDynamicProperty functions (no longer needed)
   - Simplified namespace handling in DynamicElement
   - Migrated tests from Jest to Vitest
@@ -354,19 +338,16 @@
 ### Patch Changes
 
 - 101fbab: Added
-
   - Support for XML mapping of undecorated classes
   - Strict validation for nested object instantiation
 
   Fixed:
-
   - Circular reference detection logic refactored and improved
   - Issue with reusing instances resulting in empty elements after first use
   - Query initialization bugs
   - Nested queryables handling
 
   Changed:
-
   - Enhanced circular reference detection in XML mappingPlease enter a summary for your changes.
   - An empty message aborts the editor.
 
@@ -385,7 +366,6 @@
   This release significantly improves TypeScript IntelliSense performance and runtime efficiency through metadata storage consolidation:
 
   **Core Improvements:**
-
   - **Unified Metadata Storage**: Consolidated 9+ separate WeakMaps into a single `ClassMetadata` structure, reducing metadata lookups from multiple operations to just one per class
   - **Type-Safe Storage**: Introduced `TypedMetadataStorage<K, V>` wrapper for better type inference and IntelliSense autocomplete
   - **Symbol-Based Lazy Loading**: Enhanced `@XmlDynamic` to use `Symbol.for()` keys for cache and builder storage, preventing property collisions and improving memory efficiency
@@ -393,14 +373,12 @@
   - **Better Type Hints**: Added `Constructor<T>` type helper and `DeepReadonly<T>` utility for improved type safety and IntelliSense suggestions
 
   **Technical Details:**
-
   - Decorator metadata registration now uses centralized helper functions (`registerAttributeMetadata`, `registerFieldElementMetadata`, etc.)
   - Metadata getters optimized with single-lookup strategy using `getMetadata()` and `hasMetadata()` checks
   - Removed legacy constructor property fallback patterns (`__xmlAttributes`, `__xmlPropertyMappings`, etc.)
   - Enhanced `fromXml()` and `toXml()` method signatures with `const` generics for better type inference
 
   **Developer Experience:**
-
   - Faster IntelliSense autocomplete in editors
   - Reduced memory footprint for classes with many decorators
   - Improved type narrowing and inference in serializer methods

--- a/packages/xml-poto/README.md
+++ b/packages/xml-poto/README.md
@@ -300,6 +300,8 @@ class Article {
 
 ### Validation - Enforce Data Integrity
 
+All XSD facets are available on `@XmlElement`, `@XmlAttribute`, `@XmlText`, and `@XmlArray`, and are checked during both serialization and deserialization:
+
 ```typescript
 @XmlAttribute({
     name: 'email',
@@ -310,10 +312,35 @@ email: string = '';
 
 @XmlElement({
     name: 'status',
-    enum: ['active', 'inactive', 'pending']
+    enumValues: ['active', 'inactive', 'pending']
 })
 status: string = '';
+
+@XmlElement({ name: 'score', minInclusive: 0, maxInclusive: 100 })
+score: number = 0;
+
+@XmlElement({ name: 'sizes', list: { itemType: 'number' } })
+sizes: number[] = []; // <sizes>1 2 3</sizes>
+
+// Exclusive xs:choice: at most one of email/phone may be set
+@XmlElement({ name: 'phone', choiceGroup: 'contact', choiceRequired: true })
+phone?: string;
 ```
+
+Control how violations are handled with the unified `validationMode` option — `'strict'` (throw, default), `'warn'` (console warning), or `'off'` — and tune individual rules with `validationModeOverrides`:
+
+```typescript
+const serializer = new XmlDecoratorSerializer({
+    validationMode: 'strict',          // default for all rules
+    validationModeOverrides: {
+        pattern: 'warn',               // pattern violations only warn
+        fixedValue: 'off',             // fixed-value checks skipped
+        choiceGroup: 'warn',
+    },
+});
+```
+
+Also supported: `length`/`minLength`/`maxLength`, `minExclusive`/`maxExclusive`, `totalDigits`/`fractionDigits`, `whiteSpace` normalization, `fixedValue` constraints, `minOccurs`/`maxOccurs` on arrays, and `xsi:nil` round-trips for `isNullable` properties.
 
 [Learn more about Validation →](docs/features/validation.md)
 

--- a/packages/xml-poto/README.md
+++ b/packages/xml-poto/README.md
@@ -268,6 +268,24 @@ items: Item[] = [];
 
 [Learn more about Arrays →](docs/features/arrays.md)
 
+### Recursive & Circular Types - Lazy Type References
+
+The `type` option also accepts a `() => Constructor` thunk. Use it whenever the referenced class is not declared yet at decoration time — self-recursive types, mutually referencing classes, or a class declared later in the same file:
+
+```typescript
+@XmlElement({ name: "Section" })
+class Section {
+	@XmlElement({ name: "Title" })
+	title: string = "";
+
+	// Direct `type: Section` would throw — the class binding isn't initialized yet
+	@XmlArray({ itemName: "Section", type: () => Section })
+	children?: Section[];
+}
+```
+
+The thunk is resolved lazily on first use during (de)serialization.
+
 ### Namespaces - Full XML Namespace Support
 
 ```typescript

--- a/packages/xml-poto/README.md
+++ b/packages/xml-poto/README.md
@@ -331,12 +331,12 @@ Control how violations are handled with the unified `validationMode` option — 
 
 ```typescript
 const serializer = new XmlDecoratorSerializer({
-    validationMode: 'strict',          // default for all rules
-    validationModeOverrides: {
-        pattern: 'warn',               // pattern violations only warn
-        fixedValue: 'off',             // fixed-value checks skipped
-        choiceGroup: 'warn',
-    },
+	validationMode: "strict", // default for all rules
+	validationModeOverrides: {
+		pattern: "warn", // pattern violations only warn
+		fixedValue: "off", // fixed-value checks skipped
+		choiceGroup: "warn",
+	},
 });
 ```
 

--- a/packages/xml-poto/docs/features/mixed-content.md
+++ b/packages/xml-poto/docs/features/mixed-content.md
@@ -524,9 +524,7 @@ function validateMixedContent(content: any[]): boolean {
 }
 
 const para = new Paragraph();
-para.content = [
-	/* ... */
-];
+para.content = [/* ... */];
 
 if (validateMixedContent(para.content)) {
 	const xml = serializer.toXml(para);

--- a/packages/xml-poto/docs/features/mixed-content.md
+++ b/packages/xml-poto/docs/features/mixed-content.md
@@ -524,7 +524,9 @@ function validateMixedContent(content: any[]): boolean {
 }
 
 const para = new Paragraph();
-para.content = [/* ... */];
+para.content = [
+	/* ... */
+];
 
 if (validateMixedContent(para.content)) {
 	const xml = serializer.toXml(para);

--- a/packages/xml-poto/docs/features/validation.md
+++ b/packages/xml-poto/docs/features/validation.md
@@ -9,6 +9,9 @@ Learn how to validate XML data and convert values using patterns, enums, and cus
 - [Custom Converters](#custom-converters)
 - [Pattern Validation](#pattern-validation)
 - [Enum Validation](#enum-validation)
+- [XSD Facets](#xsd-facets)
+- [Validation Mode](#validation-mode)
+- [Lists, Choice Groups, and Occurs](#lists-choice-groups-and-occurs)
 - [Required Fields](#required-fields)
 - [Combining Validation Rules](#combining-validation-rules)
 - [Strict Validation Mode](#strict-validation-mode)
@@ -456,6 +459,96 @@ class Account {
 const account = new Account();
 account.role = UserRole.Admin; // ✅ Valid
 ```
+
+[↑ Back to top](#table-of-contents)
+
+## XSD Facets
+
+All XSD restriction facets are available on `@XmlElement`, `@XmlAttribute`, `@XmlText`, and `@XmlArray` (where array facets validate each item). Facets are checked during both serialization and deserialization:
+
+```typescript
+@XmlRoot({ name: "Payment" })
+class Payment {
+	// String length facets
+	@XmlElement({ name: "Country", length: 2, pattern: /^[A-Z]{2}$/ })
+	country: string = "";
+
+	@XmlElement({ name: "Beneficiary", minLength: 2, maxLength: 20 })
+	beneficiary: string = "";
+
+	// Numeric bounds and digit facets
+	@XmlElement({ name: "Total", minInclusive: 0, maxExclusive: 1000000, totalDigits: 8, fractionDigits: 2 })
+	total: number = 0;
+
+	// Whitespace normalization applied before validation: 'preserve' | 'replace' | 'collapse'
+	@XmlElement({ name: "Note", whiteSpace: "collapse" })
+	note: string = "";
+
+	// Fixed value: used as default when absent, must match when present
+	@XmlAttribute({ name: "version", fixedValue: "2.1" })
+	version: string = "2.1";
+}
+```
+
+[↑ Back to top](#table-of-contents)
+
+## Validation Mode
+
+All facet checks (including the `pattern`/`enumValues` checks above) are governed by a single `validationMode` setting on the serializer:
+
+- `"strict"` (default) — throw an error on violation
+- `"warn"` — log a `console.warn` and continue
+- `"off"` — skip validation entirely
+
+Individual rules can be tuned with `validationModeOverrides`. Each key names one rule; unlisted rules follow `validationMode`:
+
+```typescript
+const serializer = new XmlDecoratorSerializer({
+	validationMode: "strict", // default for all rules
+	validationModeOverrides: {
+		pattern: "warn", // pattern violations only warn
+		fixedValue: "off", // fixed-value checks skipped
+		choiceGroup: "warn", // choice-group violations only warn
+		maxOccurs: "off",
+	},
+});
+```
+
+Available rule keys: `pattern`, `enumValues`, `length`, `minLength`, `maxLength`, `minInclusive`, `maxInclusive`, `minExclusive`, `maxExclusive`, `totalDigits`, `fractionDigits`, `fixedValue`, `choiceGroup`, `minOccurs`, `maxOccurs`.
+
+When a value violates multiple rules, each violation is handled according to its own rule's mode — e.g. with `{ pattern: "off" }`, a value that breaks both `pattern` and `maxLength` still throws for `maxLength`. (`whiteSpace` is a normalization, not a validation rule.)
+
+[↑ Back to top](#table-of-contents)
+
+## Lists, Choice Groups, and Occurs
+
+**`xs:list`** — serialize an array as a single space-separated text value:
+
+```typescript
+@XmlElement({ name: "Sizes", list: { itemType: "number" } })
+sizes: number[] = []; // <Sizes>1 2 3</Sizes> ↔ [1, 2, 3]
+```
+
+The `list` option is available on `@XmlElement`, `@XmlAttribute`, and `@XmlText`. Length facets apply to the item count; other facets apply to each item.
+
+**Choice groups (`xs:choice`)** — enforce that at most one member of a group is set (and at least one, when `choiceRequired` is set):
+
+```typescript
+@XmlElement({ name: "Email", choiceGroup: "contact", choiceRequired: true })
+email?: string;
+
+@XmlElement({ name: "Phone", choiceGroup: "contact", choiceRequired: true })
+phone?: string;
+```
+
+**Occurs bounds** — validate array item counts with `minOccurs`/`maxOccurs` on `@XmlArray`:
+
+```typescript
+@XmlArray({ itemName: "Item", minOccurs: 1, maxOccurs: 10 })
+items: string[] = [];
+```
+
+**`xsi:nil` round-trip** — `isNullable` elements serialize `null` as `xsi:nil="true"` and deserialize it back to `null`.
 
 [↑ Back to top](#table-of-contents)
 

--- a/packages/xml-poto/package.json
+++ b/packages/xml-poto/package.json
@@ -65,6 +65,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.18.5",
 		"@types/node": "^26.1.1",
+		"esbuild": "^0.28.1",
 		"tsdown": "^0.22.9",
 		"typescript": "^7.0.2",
 		"vitest": "4.1.10"

--- a/packages/xml-poto/package.json
+++ b/packages/xml-poto/package.json
@@ -54,7 +54,7 @@
 		"./package.json": "./package.json"
 	},
 	"scripts": {
-		"build": "tsdown --config-loader bundle",
+		"build": "tsdown",
 		"check-exports": "attw --pack .",
 		"test": "vitest --run",
 		"test:coverage": "vitest --coverage",

--- a/packages/xml-poto/package.json
+++ b/packages/xml-poto/package.json
@@ -65,12 +65,9 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.18.5",
 		"@types/node": "^26.1.1",
-		"oxfmt": "^0.58.0",
-		"oxlint": "^1.73.0",
-		"oxlint-tsgolint": "^0.24.0",
-		"tsdown": "^0.21.10",
-		"typescript": "^6.0.3",
-		"vitest": "4.0.18"
+		"tsdown": "^0.22.9",
+		"typescript": "^7.0.2",
+		"vitest": "4.1.10"
 	},
 	"engines": {
 		"node": ">=20.19.0"

--- a/packages/xml-poto/src/decorators/storage/metadata-storage.ts
+++ b/packages/xml-poto/src/decorators/storage/metadata-storage.ts
@@ -124,6 +124,29 @@ const globalElementLookupCache = new Map<string, Constructor | undefined>();
 const constructorRegistry = new Map<string, Constructor>();
 
 /**
+ * Registrations deferred because the decorator received a `() => Constructor`
+ * thunk whose target class binding was still in its temporal dead zone at
+ * decoration time. Flushed lazily before any registry lookup, when all module
+ * evaluation (and thus all class definitions) has completed.
+ *
+ * IMPORTANT: every registry reader (`find*` function in this module) must call
+ * `flushPendingLazyRegistrations()` before consulting the registries.
+ */
+const pendingLazyRegistrations: Array<() => void> = [];
+
+/** Defer a registration until the first registry lookup (see pendingLazyRegistrations). */
+export function enqueueLazyRegistration(registration: () => void): void {
+	pendingLazyRegistrations.push(registration);
+}
+
+function flushPendingLazyRegistrations(): void {
+	while (pendingLazyRegistrations.length > 0) {
+		const registration = pendingLazyRegistrations.shift();
+		registration?.();
+	}
+}
+
+/**
  * Clear the element class lookup cache
  * Called when new classes are registered to ensure cache consistency
  */
@@ -175,6 +198,7 @@ export function registerConstructorByName(className: string, ctor: Constructor):
  * @returns Class constructor if found, undefined otherwise
  */
 export function findConstructorByName(className: string): Constructor | undefined {
+	flushPendingLazyRegistrations();
 	return constructorRegistry.get(className);
 }
 
@@ -190,6 +214,8 @@ export function findElementClass(
 	parentClass?: Constructor,
 	useContextAware = true,
 ): Constructor | undefined {
+	flushPendingLazyRegistrations();
+
 	let result: Constructor | undefined;
 
 	// If parent class is provided AND context-awareness is enabled, try context-aware lookup
@@ -279,6 +305,8 @@ export function deleteMetadata(target: Constructor): boolean {
  */
 export function findConstructorByAttributeMetadata(attributeKeys: string[], hasText: boolean): Constructor | undefined {
 	if (attributeKeys.length === 0 && !hasText) return undefined;
+
+	flushPendingLazyRegistrations();
 
 	const strippedKeys = attributeKeys.map((k) => k.substring(2)); // Remove @_ prefix
 	let match: Constructor | undefined;

--- a/packages/xml-poto/src/decorators/storage/type-ref.ts
+++ b/packages/xml-poto/src/decorators/storage/type-ref.ts
@@ -1,0 +1,64 @@
+import { type Constructor, enqueueLazyRegistration } from "./metadata-storage";
+
+/**
+ * A runtime type reference for decorator options: either a class constructor,
+ * or a zero-argument thunk returning one.
+ *
+ * Thunks enable forward and circular references. Decorator options are
+ * evaluated while the referenced class binding may still be in its temporal
+ * dead zone (e.g. a self-recursive type, or two classes referencing each
+ * other), so a direct constructor reference would throw at class-definition
+ * time. A thunk defers the lookup until (de)serialization:
+ *
+ * ```
+ * @XmlElement({ name: 'Section' })
+ * class Section {
+ *   @XmlArray({ itemName: 'Section', type: () => Section })
+ *   children?: Section[];
+ * }
+ * ```
+ */
+export type TypeRef<T = object> = Constructor<T> | (() => Constructor<T>);
+
+/**
+ * Distinguish a thunk from a constructor: arrow functions have no `prototype`
+ * property, while classes and function declarations always do.
+ *
+ * Caveat: a bound constructor (`Foo.bind(...)`) also lacks `prototype` and
+ * would be misdetected as a thunk — never pass bound constructors as `type`.
+ */
+export function isTypeThunk<T>(ref: TypeRef<T>): ref is () => Constructor<T> {
+	return typeof ref === "function" && !Object.prototype.hasOwnProperty.call(ref, "prototype");
+}
+
+/** Resolve a {@link TypeRef} to its constructor (invoking a thunk if needed). */
+export function resolveTypeRef<T>(ref: TypeRef<T> | undefined): Constructor<T> | undefined {
+	return ref !== undefined && isTypeThunk(ref) ? ref() : ref;
+}
+
+/**
+ * Run a registration callback with the resolved constructor. Direct
+ * constructors register immediately; thunks are deferred to the first registry
+ * lookup (they cannot be invoked at decoration time — the referenced class may
+ * still be in its temporal dead zone).
+ */
+export function withResolvedType(ref: TypeRef, register: (ctor: Constructor) => void): void {
+	if (isTypeThunk(ref)) {
+		enqueueLazyRegistration(() => register(ref()));
+	} else {
+		register(ref);
+	}
+}
+
+/**
+ * Resolve the `type` of a metadata object and cache the constructor back into
+ * it, so subsequent reads (and identity comparisons) see the plain constructor.
+ * Safe to call on every read: resolution is a one-time cost per metadata object.
+ */
+export function resolveMetadataType(meta: { type?: TypeRef } | undefined): Constructor | undefined {
+	if (!meta?.type) return undefined;
+	if (isTypeThunk(meta.type)) {
+		meta.type = meta.type();
+	}
+	return meta.type as Constructor;
+}

--- a/packages/xml-poto/src/decorators/storage/type-ref.ts
+++ b/packages/xml-poto/src/decorators/storage/type-ref.ts
@@ -60,5 +60,5 @@ export function resolveMetadataType(meta: { type?: TypeRef } | undefined): Const
 	if (isTypeThunk(meta.type)) {
 		meta.type = meta.type();
 	}
-	return meta.type as Constructor;
+	return meta.type;
 }

--- a/packages/xml-poto/src/decorators/types/metadata.ts
+++ b/packages/xml-poto/src/decorators/types/metadata.ts
@@ -1,11 +1,12 @@
 import { Constructor } from "../storage/metadata-storage";
 
+import { XmlListOptions, XmlValueFacets } from "./options";
 import { XmlNamespace } from "./xml-namespace";
 
 /**
  * Metadata types for XML decorators
  */
-export interface XmlElementMetadata {
+export interface XmlElementMetadata extends XmlValueFacets {
 	/** The XML element name */
 	name: string;
 	/**
@@ -50,12 +51,18 @@ export interface XmlElementMetadata {
 		/** Transform XML value to property value (deserialization) */
 		deserialize?: (value: string) => unknown;
 	};
+	/** Serialize/deserialize the element text as a space-separated list (xs:list) */
+	list?: XmlListOptions;
+	/** Choice group name: properties sharing a group form an exclusive xs:choice */
+	choiceGroup?: string;
+	/** Whether at least one member of the choice group must be set */
+	choiceRequired?: boolean;
 }
 
 /**
  * Metadata for XML attribute configuration
  */
-export interface XmlAttributeMetadata {
+export interface XmlAttributeMetadata extends XmlValueFacets {
 	/** The XML attribute name */
 	name: string;
 	/** XML namespaces for this attribute (first is primary, rest are additional declarations) */
@@ -69,10 +76,6 @@ export interface XmlAttributeMetadata {
 		serialize?: (value: unknown) => string;
 		deserialize?: (value: string) => unknown;
 	};
-	/** Validation pattern for the value */
-	pattern?: RegExp;
-	/** Allowed enumeration values */
-	enumValues?: readonly string[];
 	/** XML Schema data type */
 	dataType?: string;
 	/** Namespace form */
@@ -81,6 +84,8 @@ export interface XmlAttributeMetadata {
 	type?: Constructor;
 	/** Default value to use when attribute is missing during deserialization */
 	defaultValue?: unknown;
+	/** Serialize/deserialize the attribute value as a space-separated list (xs:list) */
+	list?: XmlListOptions;
 }
 
 /**
@@ -102,7 +107,7 @@ export interface XmlRootMetadata {
 /**
  * Metadata for XML text content configuration
  */
-export interface XmlTextMetadata {
+export interface XmlTextMetadata extends XmlValueFacets {
 	/** Custom type conversion functions */
 	converter?: {
 		serialize?: (value: unknown) => string;
@@ -116,12 +121,14 @@ export interface XmlTextMetadata {
 	dataType?: string;
 	/** Whether to wrap text content in CDATA section */
 	useCDATA?: boolean;
+	/** Serialize/deserialize the text content as a space-separated list (xs:list) */
+	list?: XmlListOptions;
 }
 
 /**
  * Array metadata
  */
-export interface XmlArrayMetadata {
+export interface XmlArrayMetadata extends XmlValueFacets {
 	/** Name for the array container element (overrides property name) */
 	containerName?: string;
 	/** Element name for individual array items */
@@ -148,6 +155,14 @@ export interface XmlArrayMetadata {
 	defaultValue?: unknown[];
 	/** When true, array items are serialized directly to parent without container element */
 	unwrapped?: boolean;
+	/** Minimum number of items (xs:minOccurs) */
+	minOccurs?: number;
+	/** Maximum number of items (xs:maxOccurs) */
+	maxOccurs?: number;
+	/** Choice group name: properties sharing a group form an exclusive xs:choice */
+	choiceGroup?: string;
+	/** Whether at least one member of the choice group must be set */
+	choiceRequired?: boolean;
 }
 
 /**

--- a/packages/xml-poto/src/decorators/types/metadata.ts
+++ b/packages/xml-poto/src/decorators/types/metadata.ts
@@ -1,4 +1,5 @@
 import { Constructor } from "../storage/metadata-storage";
+import { TypeRef } from "../storage/type-ref";
 
 import { XmlListOptions, XmlValueFacets } from "./options";
 import { XmlNamespace } from "./xml-namespace";
@@ -32,8 +33,8 @@ export interface XmlElementMetadata extends XmlValueFacets {
 	isNullable?: boolean;
 	/** Namespace form */
 	form?: "qualified" | "unqualified";
-	/** Runtime type for polymorphism */
-	type?: Constructor;
+	/** Runtime type for polymorphism (resolve via resolveMetadataType — may hold an unresolved thunk) */
+	type?: TypeRef;
 	/** Whether to wrap element content in CDATA section */
 	useCDATA?: boolean;
 	/** Union types for properties that can be multiple types */
@@ -80,8 +81,8 @@ export interface XmlAttributeMetadata extends XmlValueFacets {
 	dataType?: string;
 	/** Namespace form */
 	form?: "qualified" | "unqualified";
-	/** Runtime type for complex attributes */
-	type?: Constructor;
+	/** Runtime type for complex attributes (resolve via resolveMetadataType — may hold an unresolved thunk) */
+	type?: TypeRef;
 	/** Default value to use when attribute is missing during deserialization */
 	defaultValue?: unknown;
 	/** Serialize/deserialize the attribute value as a space-separated list (xs:list) */
@@ -133,8 +134,8 @@ export interface XmlArrayMetadata extends XmlValueFacets {
 	containerName?: string;
 	/** Element name for individual array items */
 	itemName?: string;
-	/** Runtime type for polymorphic arrays */
-	type?: Constructor;
+	/** Runtime type for polymorphic arrays (resolve via resolveMetadataType — may hold an unresolved thunk) */
+	type?: TypeRef;
 	/** XML namespaces for this array (first is primary, rest are additional declarations) */
 	namespaces?: XmlNamespace[];
 	/** Nesting level */

--- a/packages/xml-poto/src/decorators/types/options.ts
+++ b/packages/xml-poto/src/decorators/types/options.ts
@@ -4,9 +4,79 @@ import type { DeepReadonly } from "./type-utils";
 import type { XmlNamespace } from "./xml-namespace";
 
 /**
+ * How facet violations are handled during serialization/deserialization.
+ * - "strict": throw an error (default)
+ * - "warn": log a console warning and continue
+ * - "off": skip validation entirely
+ */
+export type XmlValidationMode = "strict" | "warn" | "off";
+
+/**
+ * The individual validation rules that can be tuned via the serializer's
+ * `validationModeOverrides` option. Each key corresponds to one facet or
+ * structural check.
+ */
+export type XmlValidationRule =
+	| "pattern"
+	| "enumValues"
+	| "length"
+	| "minLength"
+	| "maxLength"
+	| "minInclusive"
+	| "maxInclusive"
+	| "minExclusive"
+	| "maxExclusive"
+	| "totalDigits"
+	| "fractionDigits"
+	| "fixedValue"
+	| "choiceGroup"
+	| "minOccurs"
+	| "maxOccurs";
+
+/**
+ * XSD list configuration for values serialized as space-separated text
+ * (xs:list). `true` uses string items; an object selects the item type.
+ */
+export type XmlListOptions = boolean | { itemType?: "string" | "number" | "boolean" };
+
+/**
+ * XSD-style value constraints (facets) shared by element, attribute, text,
+ * and array-item values. Violations are handled according to the serializer's
+ * `validationModeOverrides` (per rule), else its `validationMode`, else "strict".
+ */
+export interface XmlValueFacets {
+	/** Validation pattern for the value (xs:pattern) */
+	pattern?: RegExp;
+	/** Allowed enumeration values (xs:enumeration) */
+	enumValues?: readonly string[];
+	/** Exact value length (xs:length) */
+	length?: number;
+	/** Minimum value length (xs:minLength) */
+	minLength?: number;
+	/** Maximum value length (xs:maxLength) */
+	maxLength?: number;
+	/** Minimum numeric value, inclusive (xs:minInclusive) */
+	minInclusive?: number;
+	/** Maximum numeric value, inclusive (xs:maxInclusive) */
+	maxInclusive?: number;
+	/** Minimum numeric value, exclusive (xs:minExclusive) */
+	minExclusive?: number;
+	/** Maximum numeric value, exclusive (xs:maxExclusive) */
+	maxExclusive?: number;
+	/** Maximum number of total digits for decimal values (xs:totalDigits) */
+	totalDigits?: number;
+	/** Maximum number of fraction digits for decimal values (xs:fractionDigits) */
+	fractionDigits?: number;
+	/** Whitespace normalization applied before validation (xs:whiteSpace) */
+	whiteSpace?: "preserve" | "replace" | "collapse";
+	/** XSD fixed value: the value must equal this constant; also used as default when absent */
+	fixedValue?: string | number | boolean;
+}
+
+/**
  * Options for XmlElement decorator
  */
-export interface XmlElementOptions {
+export interface XmlElementOptions extends XmlValueFacets {
 	/** The XML element name */
 	name?: string;
 	/** XML namespace with both prefix and URI */
@@ -42,12 +112,18 @@ export interface XmlElementOptions {
 		/** Transform XML value to property value (deserialization) */
 		deserialize?: (value: string) => unknown;
 	};
+	/** Serialize/deserialize the element text as a space-separated list (xs:list) */
+	list?: XmlListOptions;
+	/** Choice group name: properties sharing a group form an exclusive xs:choice */
+	choiceGroup?: string;
+	/** Whether at least one member of the choice group must be set */
+	choiceRequired?: boolean;
 }
 
 /**
  * Options for XmlAttribute decorator
  */
-export interface XmlAttributeOptions {
+export interface XmlAttributeOptions extends XmlValueFacets {
 	/** The XML attribute name */
 	name?: string;
 	/** XML namespace with both prefix and URI */
@@ -61,10 +137,6 @@ export interface XmlAttributeOptions {
 		serialize?: (value: unknown) => string;
 		deserialize?: (value: string) => unknown;
 	};
-	/** Validation pattern for the value */
-	pattern?: RegExp;
-	/** Allowed enumeration values */
-	enumValues?: readonly string[];
 	/** XML Schema data type */
 	dataType?: string;
 	/** Namespace form */
@@ -73,12 +145,14 @@ export interface XmlAttributeOptions {
 	type?: Constructor;
 	/** Default value to use when attribute is missing during deserialization */
 	defaultValue?: unknown;
+	/** Serialize/deserialize the attribute value as a space-separated list (xs:list) */
+	list?: XmlListOptions;
 }
 
 /**
  * Options for XmlText decorator
  */
-export interface XmlTextOptions {
+export interface XmlTextOptions extends XmlValueFacets {
 	/** Custom type conversion for text content */
 	converter?: {
 		serialize?: (value: unknown) => string;
@@ -92,6 +166,8 @@ export interface XmlTextOptions {
 	dataType?: string;
 	/** Whether to wrap text content in CDATA section */
 	useCDATA?: boolean;
+	/** Serialize/deserialize the text content as a space-separated list (xs:list) */
+	list?: XmlListOptions;
 }
 
 /**
@@ -115,7 +191,7 @@ export interface XmlRootOptions {
 /**
  * Array item options
  */
-export interface XmlArrayOptions {
+export interface XmlArrayOptions extends XmlValueFacets {
 	/**
 	 * Name for the array container element (overrides property name).
 	 * If not provided, array items will be unwrapped (no container).
@@ -152,6 +228,14 @@ export interface XmlArrayOptions {
 	 * This is automatically set to true when containerName is not provided.
 	 */
 	unwrapped?: boolean;
+	/** Minimum number of items (xs:minOccurs); checked according to the effective validation mode */
+	minOccurs?: number;
+	/** Maximum number of items (xs:maxOccurs); checked according to the effective validation mode */
+	maxOccurs?: number;
+	/** Choice group name: properties sharing a group form an exclusive xs:choice */
+	choiceGroup?: string;
+	/** Whether at least one member of the choice group must be set */
+	choiceRequired?: boolean;
 }
 
 /**

--- a/packages/xml-poto/src/decorators/types/options.ts
+++ b/packages/xml-poto/src/decorators/types/options.ts
@@ -1,4 +1,5 @@
 import type { Constructor } from "../storage/metadata-storage";
+import type { TypeRef } from "../storage/type-ref";
 
 import type { DeepReadonly } from "./type-utils";
 import type { XmlNamespace } from "./xml-namespace";
@@ -93,8 +94,8 @@ export interface XmlElementOptions extends XmlValueFacets {
 	isNullable?: boolean;
 	/** Namespace form */
 	form?: "qualified" | "unqualified";
-	/** Runtime type for polymorphism */
-	type?: Constructor;
+	/** Runtime type for polymorphism: a constructor, or a `() => Constructor` thunk for forward/circular references */
+	type?: TypeRef;
 	/** Whether to wrap element content in CDATA section (field decorator only) */
 	useCDATA?: boolean;
 	/** Union types for properties that can be multiple types (e.g., [String, Number]) */
@@ -141,8 +142,8 @@ export interface XmlAttributeOptions extends XmlValueFacets {
 	dataType?: string;
 	/** Namespace form */
 	form?: "qualified" | "unqualified";
-	/** Runtime type for complex attributes */
-	type?: Constructor;
+	/** Runtime type for complex attributes: a constructor, or a `() => Constructor` thunk for forward/circular references */
+	type?: TypeRef;
 	/** Default value to use when attribute is missing during deserialization */
 	defaultValue?: unknown;
 	/** Serialize/deserialize the attribute value as a space-separated list (xs:list) */
@@ -203,8 +204,8 @@ export interface XmlArrayOptions extends XmlValueFacets {
 	 * @example itemName: 'Book' -> <Book>...</Book>
 	 */
 	itemName?: string;
-	/** Runtime type for polymorphic arrays */
-	type?: Constructor;
+	/** Runtime type for polymorphic arrays: a constructor, or a `() => Constructor` thunk for forward/circular references */
+	type?: TypeRef;
 	/** Namespace for array items */
 	namespace?: XmlNamespace;
 	/** Additional namespaces to declare on the array container element */

--- a/packages/xml-poto/src/decorators/value-facets.ts
+++ b/packages/xml-poto/src/decorators/value-facets.ts
@@ -1,0 +1,23 @@
+import { XmlValueFacets } from "./types";
+
+/**
+ * Copy the shared XSD value facets from decorator options into metadata.
+ * Used by the @XmlElement, @XmlAttribute, @XmlText and @XmlArray factories.
+ */
+export function extractValueFacets(options: XmlValueFacets): XmlValueFacets {
+	return {
+		pattern: options.pattern,
+		enumValues: options.enumValues,
+		length: options.length,
+		minLength: options.minLength,
+		maxLength: options.maxLength,
+		minInclusive: options.minInclusive,
+		maxInclusive: options.maxInclusive,
+		minExclusive: options.minExclusive,
+		maxExclusive: options.maxExclusive,
+		totalDigits: options.totalDigits,
+		fractionDigits: options.fractionDigits,
+		whiteSpace: options.whiteSpace,
+		fixedValue: options.fixedValue,
+	};
+}

--- a/packages/xml-poto/src/decorators/xml-array.ts
+++ b/packages/xml-poto/src/decorators/xml-array.ts
@@ -2,6 +2,7 @@
 import { registerArrayMetadata } from "./storage";
 import { registerConstructorByName } from "./storage/metadata-storage";
 import { XmlArrayMetadata, XmlArrayOptions, XmlNamespace } from "./types";
+import { extractValueFacets } from "./value-facets";
 
 /**
  * XmlArray decorator for polymorphic array support
@@ -67,6 +68,7 @@ export function XmlArray(options: XmlArrayOptions = {}) {
 		const shouldUnwrap = options.unwrapped ?? !options.containerName;
 
 		const arrayMetadata: XmlArrayMetadata = {
+			...extractValueFacets(options),
 			containerName: options.containerName,
 			itemName: options.itemName,
 			type: options.type,
@@ -80,6 +82,10 @@ export function XmlArray(options: XmlArrayOptions = {}) {
 			required: options.required ?? false,
 			requiredExplicitlyFalse: options.required === false || undefined,
 			defaultValue: options.defaultValue,
+			minOccurs: options.minOccurs,
+			maxOccurs: options.maxOccurs,
+			choiceGroup: options.choiceGroup,
+			choiceRequired: options.choiceRequired,
 		};
 
 		// Return a field initializer that registers metadata once per decorator

--- a/packages/xml-poto/src/decorators/xml-array.ts
+++ b/packages/xml-poto/src/decorators/xml-array.ts
@@ -1,6 +1,7 @@
 /* eslint-disable typescript/no-explicit-any -- Array decorator requires any types for dynamic array handling */
 import { registerArrayMetadata } from "./storage";
 import { registerConstructorByName } from "./storage/metadata-storage";
+import { withResolvedType } from "./storage/type-ref";
 import { XmlArrayMetadata, XmlArrayOptions, XmlNamespace } from "./types";
 import { extractValueFacets } from "./value-facets";
 
@@ -97,7 +98,7 @@ export function XmlArray(options: XmlArrayOptions = {}) {
 
 			// Register type parameter class if provided for auto-discovery
 			if (options.type) {
-				registerConstructorByName(options.type.name, options.type);
+				withResolvedType(options.type, (typeCtor) => registerConstructorByName(typeCtor.name, typeCtor));
 			}
 
 			return initialValue;

--- a/packages/xml-poto/src/decorators/xml-attribute.ts
+++ b/packages/xml-poto/src/decorators/xml-attribute.ts
@@ -2,6 +2,7 @@
 import { registerAttributeMetadata } from "./storage";
 import { registerConstructorByName } from "./storage/metadata-storage";
 import { XmlAttributeMetadata, XmlAttributeOptions, XmlNamespace } from "./types";
+import { extractValueFacets } from "./value-facets";
 
 // Symbol to store pending attribute metadata that needs to be processed by class decorators
 const PENDING_ATTRIBUTE_SYMBOL = Symbol.for("pendingAttribute");
@@ -129,17 +130,17 @@ export function XmlAttribute(
 		}
 
 		const attributeMetadata: XmlAttributeMetadata = {
+			...extractValueFacets(options),
 			name: options.name ?? propertyKey,
 			namespaces: allNamespaces.length > 0 ? allNamespaces : undefined,
 			required: options.required ?? false,
 			requiredExplicitlyFalse: options.required === false || undefined,
 			converter: options.converter,
-			pattern: options.pattern,
-			enumValues: options.enumValues,
 			dataType: options.dataType,
 			form: options.form,
 			type: options.type,
 			defaultValue: options.defaultValue,
+			list: options.list,
 		};
 
 		// Store pending metadata in context.metadata for class decorators to process

--- a/packages/xml-poto/src/decorators/xml-element.ts
+++ b/packages/xml-poto/src/decorators/xml-element.ts
@@ -9,6 +9,7 @@ import {
 } from "./storage";
 import { getMetadata, registerConstructorByName, registerElementClass } from "./storage/metadata-storage";
 import { XmlElementMetadata, XmlElementOptions, XmlNamespace } from "./types";
+import { extractValueFacets } from "./value-facets";
 import { PENDING_DYNAMIC_SYMBOL } from "./xml-dynamic";
 
 // Symbol to store pending field element metadata that needs to be processed by class decorators
@@ -219,6 +220,7 @@ function buildElementMetadata(xmlName: string, options: any, nameExplicitlySet: 
 	}
 
 	return {
+		...extractValueFacets(options),
 		name: xmlName,
 		nameExplicitlySet: nameExplicitlySet || undefined,
 		namespaces: allNamespaces.length > 0 ? allNamespaces : undefined,
@@ -235,6 +237,9 @@ function buildElementMetadata(xmlName: string, options: any, nameExplicitlySet: 
 		defaultValue: options.defaultValue,
 		xmlSpace: options.xmlSpace,
 		transform: options.transform,
+		list: options.list,
+		choiceGroup: options.choiceGroup,
+		choiceRequired: options.choiceRequired,
 	};
 }
 

--- a/packages/xml-poto/src/decorators/xml-element.ts
+++ b/packages/xml-poto/src/decorators/xml-element.ts
@@ -8,6 +8,7 @@ import {
 	registerPropertyMapping,
 } from "./storage";
 import { getMetadata, registerConstructorByName, registerElementClass } from "./storage/metadata-storage";
+import { withResolvedType } from "./storage/type-ref";
 import { XmlElementMetadata, XmlElementOptions, XmlNamespace } from "./types";
 import { extractValueFacets } from "./value-facets";
 import { PENDING_DYNAMIC_SYMBOL } from "./xml-dynamic";
@@ -256,7 +257,7 @@ function registerClassForAutoDiscovery(target: any, elementMetadata: XmlElementM
 	registerConstructorByName(target.name, target);
 
 	if (options.type) {
-		registerConstructorByName(options.type.name, options.type);
+		withResolvedType(options.type, (ctor) => registerConstructorByName(ctor.name, ctor));
 	}
 }
 
@@ -288,7 +289,7 @@ function processPendingFieldElements(target: any, context: any): void {
 		registerPropertyMapping(target, propertyKey, xmlName);
 
 		if (metadata.type) {
-			registerElementClass(xmlName, metadata.type, target);
+			withResolvedType(metadata.type, (ctor) => registerElementClass(xmlName, ctor, target));
 		}
 	}
 }
@@ -428,9 +429,11 @@ function handleFieldDecorator(_target: any, context: any, nameOrOptions: any): (
 		registerPropertyMapping(ctor, propertyKey, xmlName);
 
 		if (options.type) {
-			registerConstructorByName(options.type.name, options.type);
 			const elementName = xmlName ?? String(context.name);
-			registerElementClass(elementName, options.type, ctor);
+			withResolvedType(options.type, (typeCtor) => {
+				registerConstructorByName(typeCtor.name, typeCtor);
+				registerElementClass(elementName, typeCtor, ctor);
+			});
 		}
 		return initialValue;
 	};

--- a/packages/xml-poto/src/decorators/xml-root.ts
+++ b/packages/xml-poto/src/decorators/xml-root.ts
@@ -9,6 +9,7 @@ import {
 	registerPropertyMapping,
 } from "./storage";
 import { registerConstructorByName, registerElementClass } from "./storage/metadata-storage";
+import { withResolvedType } from "./storage/type-ref";
 import { XmlNamespace, XmlRootMetadata, XmlRootOptions } from "./types";
 import { PENDING_DYNAMIC_SYMBOL } from "./xml-dynamic";
 
@@ -44,7 +45,7 @@ function processPendingFieldElements(context: ClassDecoratorContext, target: any
 		registerPropertyMapping(target, propertyKey, xmlName);
 
 		if (metadata.type) {
-			registerElementClass(xmlName, metadata.type, target);
+			withResolvedType(metadata.type, (ctor) => registerElementClass(xmlName, ctor, target));
 		}
 	}
 }

--- a/packages/xml-poto/src/decorators/xml-text.ts
+++ b/packages/xml-poto/src/decorators/xml-text.ts
@@ -2,6 +2,7 @@
 import { registerPropertyMapping, registerTextMetadata } from "./storage";
 import { registerConstructorByName } from "./storage/metadata-storage";
 import { XmlTextMetadata, XmlTextOptions } from "./types";
+import { extractValueFacets } from "./value-facets";
 
 /**
  * Decorator to map a class property to the text content of an XML element.
@@ -100,11 +101,13 @@ export function XmlText(
 	return <T, V>(_target: undefined, context: ClassFieldDecoratorContext<T, V>): ((initialValue: V) => V) => {
 		const propertyKey = String(context.name);
 		const textMetadata: XmlTextMetadata = {
+			...extractValueFacets(options),
 			converter: options.converter,
 			required: options.required ?? false,
 			requiredExplicitlyFalse: options.required === false || undefined,
 			dataType: options.dataType,
 			useCDATA: options.useCDATA,
+			list: options.list,
 		};
 
 		// Store metadata during first instance creation

--- a/packages/xml-poto/src/index.ts
+++ b/packages/xml-poto/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export type { Constructor } from "./decorators/storage/metadata-storage";
+export { isTypeThunk, resolveTypeRef, type TypeRef } from "./decorators/storage/type-ref";
 
 export type {
 	DecoratorKeys,

--- a/packages/xml-poto/src/serialization-options.ts
+++ b/packages/xml-poto/src/serialization-options.ts
@@ -1,3 +1,5 @@
+import type { XmlValidationMode, XmlValidationRule } from "./decorators/types/options";
+
 /**
  * Processing instruction (e.g., <?xml-stylesheet?>)
  */
@@ -54,13 +56,26 @@ export interface SerializationOptions {
 	strictValidation?: boolean;
 	/** Treat all @XmlElement, @XmlAttribute, @XmlArray and @XmlText properties as required unless required: false is explicitly set - default: false */
 	requireAllByDefault?: boolean;
+	/**
+	 * How XSD facet violations (pattern, enumValues, length/min/max facets, fixedValue)
+	 * and structural checks (choice groups, min/maxOccurs) are handled:
+	 * 'strict' throws (default), 'warn' logs a console warning, 'off' skips validation.
+	 * Individual rules can be tuned via validationModeOverrides.
+	 */
+	validationMode?: XmlValidationMode;
+	/**
+	 * Per-rule overrides of validationMode. Each key is a single validation rule;
+	 * unlisted rules follow validationMode.
+	 * @example { pattern: "warn", fixedValue: "off", choiceGroup: "warn" }
+	 */
+	validationModeOverrides?: Partial<Record<XmlValidationRule, XmlValidationMode>>;
 }
 
 /**
  * Default serialization options.
  */
 export const DEFAULT_SERIALIZATION_OPTIONS: Required<
-	Omit<SerializationOptions, "standalone" | "processingInstructions" | "docType">
+	Omit<SerializationOptions, "standalone" | "processingInstructions" | "docType" | "validationModeOverrides">
 > = {
 	ignoreAttributes: false,
 	attributeNamePrefix: "@_",
@@ -73,4 +88,5 @@ export const DEFAULT_SERIALIZATION_OPTIONS: Required<
 	emptyElementStyle: "self-closing",
 	strictValidation: false,
 	requireAllByDefault: false,
+	validationMode: "strict",
 };

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -14,6 +14,7 @@ import {
 	findElementClass,
 	getMetadata,
 } from "../decorators/storage/metadata-storage";
+import { resolveMetadataType } from "../decorators/storage/type-ref";
 import { DynamicElement } from "../query/dynamic-element";
 import { SerializationOptions } from "../serialization-options";
 
@@ -747,8 +748,9 @@ export class XmlMappingUtil {
 			let items = data[itemName];
 			if (!Array.isArray(items)) items = [items];
 
-			if (metadata.type) {
-				const itemType = metadata.type as new () => object;
+			const unwrappedItemType = resolveMetadataType(metadata);
+			if (unwrappedItemType) {
+				const itemType = unwrappedItemType as new () => object;
 				items = items.map((item: any) =>
 					typeof item === "object" && item !== null ? this.mapToObject(item, itemType) : item,
 				);
@@ -911,6 +913,8 @@ export class XmlMappingUtil {
 	 * proper typed class instead of silently returning "".
 	 */
 	private normalizeXmlValue(value: any, fieldMetadata?: XmlElementMetadata): any {
+		// Note: `type` may hold an unresolved thunk here — these checks only need truthiness,
+		// so resolveMetadataType is deliberately not called.
 		if (value !== null && typeof value === "object") {
 			if (Object.keys(value).length === 0) {
 				// Preserve {} for typed complex fields — handleComplexObject will create the proper instance
@@ -1003,8 +1007,9 @@ export class XmlMappingUtil {
 			value = Array.isArray(value[itemName]) ? value[itemName] : [value[itemName]];
 		}
 
-		if (Array.isArray(value) && arrayMeta[0].type) {
-			const arrayItemType = arrayMeta[0].type as new () => object;
+		const resolvedItemType = resolveMetadataType(arrayMeta[0]);
+		if (Array.isArray(value) && resolvedItemType) {
+			const arrayItemType = resolvedItemType as new () => object;
 			value = value.map((item: any) =>
 				typeof item === "object" && item !== null ? this.mapToObject(item, arrayItemType) : item,
 			);
@@ -1034,8 +1039,9 @@ export class XmlMappingUtil {
 		}
 
 		const fieldMetadata = fieldElementMetadata[propertyKey];
-		if (fieldMetadata?.type) {
-			return this.mapToObject(value, fieldMetadata.type as new () => object);
+		const declaredType = resolveMetadataType(fieldMetadata);
+		if (declaredType) {
+			return this.mapToObject(value, declaredType as new () => object);
 		}
 
 		const propertyValue = instance[propertyKey];
@@ -1564,10 +1570,11 @@ export class XmlMappingUtil {
 
 		if (!fieldMetadata && !allArrayMetadata[propertyKey] && hasDynamicElement) return;
 
-		if (fieldMetadata?.type) {
-			const nestedMetadata = getMetadata(fieldMetadata.type);
+		const declaredType = resolveMetadataType(fieldMetadata);
+		if (declaredType) {
+			const nestedMetadata = getMetadata(declaredType);
 			if (nestedMetadata.queryables.length > 0) {
-				const expectedTypeName = fieldMetadata.type.name;
+				const expectedTypeName = declaredType.name;
 				throw new Error(
 					`[Strict Validation Error] Property '${propertyKey}' is not properly instantiated.\n\n` +
 						`Expected: ${expectedTypeName} instance\n` +
@@ -2117,7 +2124,7 @@ export class XmlMappingUtil {
 
 		const processedItems = value.map((item: any): any => {
 			if (typeof item === "object" && item !== null) {
-				const itemType = firstMetadata.type ?? item.constructor;
+				const itemType = resolveMetadataType(firstMetadata) ?? item.constructor;
 				const itemElementMeta = getOrCreateDefaultElementMetadata(itemType);
 				const itemElementName = this.namespaceUtil.buildElementName(itemElementMeta);
 				const mappedObject = this.mapFromObject(item, itemElementName, itemElementMeta);
@@ -2225,8 +2232,8 @@ export class XmlMappingUtil {
 	 * Add xsi:type attribute if enabled and runtime type differs from declared type
 	 */
 	private addXsiType(elementContent: any, fieldMetadata: XmlElementMetadata | undefined, valueConstructor: any): any {
-		if (!this.options.useXsiType || !fieldMetadata?.type || valueConstructor === fieldMetadata.type)
-			return elementContent;
+		const declaredType = this.options.useXsiType ? resolveMetadataType(fieldMetadata) : undefined;
+		if (!this.options.useXsiType || !declaredType || valueConstructor === declaredType) return elementContent;
 
 		const runtimeTypeName = valueConstructor.name;
 		if (typeof elementContent === "object" && elementContent !== null) {

--- a/packages/xml-poto/src/utils/xml-mapping-util.ts
+++ b/packages/xml-poto/src/utils/xml-mapping-util.ts
@@ -1,5 +1,13 @@
 /* eslint-disable typescript/no-explicit-any, typescript/explicit-function-return-type -- Mapping util works with dynamic any types for XML processing */
-import { XmlArrayMetadata, XmlAttributeMetadata, XmlElementMetadata, XSI_NAMESPACE } from "../decorators";
+import {
+	XmlArrayMetadata,
+	XmlAttributeMetadata,
+	XmlElementMetadata,
+	XmlValidationMode,
+	XmlValidationRule,
+	XmlValueFacets,
+	XSI_NAMESPACE,
+} from "../decorators";
 import {
 	findConstructorByAttributeMetadata,
 	findConstructorByName,
@@ -33,6 +41,126 @@ export class XmlMappingUtil {
 	 */
 	resetVisitedObjects(): void {
 		this.visitedObjects = new WeakSet();
+	}
+
+	/**
+	 * Resolve the validation mode for a specific rule: the serializer's per-rule
+	 * override wins, then its global validationMode, then "strict".
+	 */
+	private modeForRule(rule: XmlValidationRule): XmlValidationMode {
+		return this.options.validationModeOverrides?.[rule] ?? this.options.validationMode ?? "strict";
+	}
+
+	/**
+	 * Report a validation violation according to the effective mode:
+	 * strict → throw, warn → console.warn, off → ignore.
+	 */
+	private reportViolation(message: string, mode: XmlValidationMode): void {
+		if (mode === "strict") {
+			throw new Error(message);
+		}
+		if (mode === "warn") {
+			console.warn(message);
+		}
+	}
+
+	/**
+	 * Validate a value against a property's XSD facets, handling each violated
+	 * rule according to its own effective validation mode.
+	 */
+	private validateFacetsForProperty(value: any, facets: XmlValueFacets, label: string): void {
+		for (const violation of XmlValidationUtil.validateFacets(value, facets)) {
+			this.reportViolation(
+				`Invalid value '${value}' for ${label}: ${violation.message}`,
+				this.modeForRule(violation.rule),
+			);
+		}
+	}
+
+	/**
+	 * Validate choice groups: at most one member of a group may be set, and at
+	 * least one must be set when any member declares choiceRequired.
+	 */
+	private validateChoiceGroups(
+		fieldElementMetadata: Record<string, XmlElementMetadata>,
+		allArrayMetadata: Record<string, XmlArrayMetadata[]>,
+		isSet: (propertyKey: string) => boolean,
+		contextName: string,
+	): void {
+		const groups = new Map<string, string[]>();
+		const metadataFor = (key: string): XmlElementMetadata | XmlArrayMetadata | undefined =>
+			fieldElementMetadata[key] ?? allArrayMetadata[key]?.[0];
+
+		const addMember = (group: string, key: string): void => {
+			const members = groups.get(group);
+			if (members) {
+				if (!members.includes(key)) members.push(key);
+			} else {
+				groups.set(group, [key]);
+			}
+		};
+		for (const key in fieldElementMetadata) {
+			const group = fieldElementMetadata[key].choiceGroup;
+			if (group) addMember(group, key);
+		}
+		for (const key in allArrayMetadata) {
+			const group = allArrayMetadata[key]?.[0]?.choiceGroup;
+			if (group) addMember(group, key);
+		}
+
+		const mode = this.modeForRule("choiceGroup");
+		if (mode === "off") return;
+
+		for (const [group, keys] of groups) {
+			const setKeys = keys.filter(isSet);
+			if (setKeys.length > 1) {
+				this.reportViolation(
+					`Choice group '${group}' in '${contextName}': only one of [${keys.join(", ")}] may be set, but [${setKeys.join(", ")}] are set`,
+					mode,
+				);
+			}
+			const required = keys.some((key) => metadataFor(key)?.choiceRequired);
+			if (setKeys.length === 0 && required) {
+				this.reportViolation(
+					`Choice group '${group}' in '${contextName}': one of [${keys.join(", ")}] must be set`,
+					mode,
+				);
+			}
+		}
+	}
+
+	/**
+	 * Validate array min/maxOccurs item counts, each according to its own rule mode.
+	 */
+	private validateArrayOccurs(value: any[], metadata: XmlArrayMetadata, contextName: string): void {
+		if (metadata.minOccurs === undefined && metadata.maxOccurs === undefined) return;
+
+		const name = metadata.containerName ?? metadata.itemName ?? contextName;
+		if (metadata.minOccurs !== undefined && value.length < metadata.minOccurs) {
+			this.reportViolation(
+				`Array '${name}' has ${value.length} item(s), but minOccurs is ${metadata.minOccurs}`,
+				this.modeForRule("minOccurs"),
+			);
+		}
+		if (metadata.maxOccurs !== undefined && value.length > metadata.maxOccurs) {
+			this.reportViolation(
+				`Array '${name}' has ${value.length} item(s), but maxOccurs is ${metadata.maxOccurs}`,
+				this.modeForRule("maxOccurs"),
+			);
+		}
+	}
+
+	/**
+	 * Detect an xsi:nil="true" marker on a parsed element object.
+	 */
+	private isXsiNil(value: any): boolean {
+		if (typeof value !== "object" || value === null) return false;
+		for (const key of Object.keys(value)) {
+			if (key === "@_nil" || key === `@_${XSI_NAMESPACE.prefix}:nil` || /^@_[\w.-]+:nil$/.test(key)) {
+				if (value[key] === "true" || value[key] === true) return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -277,6 +405,29 @@ export class XmlMappingUtil {
 		this.mapDynamicElements(instance, targetClass, data, elementMetadata, propertyMappings, fieldElementMetadata);
 		this.checkRequiredElements(data, fieldElementMetadata, targetClass);
 		this.checkRequiredArrays(allArrayMetadata, foundProperties, targetClass);
+		this.validateChoiceGroups(
+			fieldElementMetadata,
+			allArrayMetadata,
+			(propertyKey) => {
+				if (!foundProperties.has(propertyKey)) return false;
+				// Empty elements (<tag/>) deserialize to "" and count as absent
+				const memberValue = (instance as any)[propertyKey];
+				return memberValue !== undefined && memberValue !== null && memberValue !== "";
+			},
+			targetClass.name || "Unknown",
+		);
+		for (const propertyKey in allArrayMetadata) {
+			const arrayMeta = allArrayMetadata[propertyKey]?.[0];
+			if (!arrayMeta) continue;
+			const arrayValue = (instance as any)[propertyKey];
+			if (Array.isArray(arrayValue) && foundProperties.has(propertyKey)) {
+				this.validateArrayOccurs(arrayValue, arrayMeta, propertyKey);
+				for (const item of arrayValue) {
+					if (typeof item === "object" && item !== null) continue;
+					this.validateFacetsForProperty(item, arrayMeta, `array '${arrayMeta.containerName ?? propertyKey}' item`);
+				}
+			}
+		}
 
 		if (this.options.strictValidation) {
 			this.performStrictValidation(
@@ -315,6 +466,9 @@ export class XmlMappingUtil {
 			if (value === undefined && attrMetadata.defaultValue !== undefined) {
 				value = attrMetadata.defaultValue;
 			}
+			if (value === undefined && attrMetadata.fixedValue !== undefined) {
+				value = attrMetadata.fixedValue;
+			}
 			const isAttrRequired =
 				attrMetadata.required || (this.options.requireAllByDefault && !attrMetadata.requiredExplicitlyFalse);
 			if (value === undefined && isAttrRequired) {
@@ -322,14 +476,44 @@ export class XmlMappingUtil {
 				throw new Error(`Required attribute '${attributeName}' is missing in element '${className}'`);
 			}
 			if (value !== undefined) {
-				value = XmlValidationUtil.applyConverter(value, attrMetadata.converter, "deserialize");
-				if (!XmlValidationUtil.validateValue(value, attrMetadata)) {
-					throw new Error(`Invalid value '${value}' for attribute '${attributeName}'`);
-				}
-				instance[propertyKey] = XmlValidationUtil.convertToPropertyType(value, instance, propertyKey);
+				instance[propertyKey] = this.deserializeAttributeValue(
+					value,
+					attrMetadata,
+					instance,
+					propertyKey,
+					attributeName,
+				);
 				foundProperties.add(propertyKey);
 			}
 		}
+	}
+
+	/**
+	 * Apply converter, whiteSpace, xs:list splitting, facet validation, and type
+	 * conversion to a raw attribute value.
+	 */
+	private deserializeAttributeValue(
+		value: any,
+		attrMetadata: XmlAttributeMetadata,
+		instance: any,
+		propertyKey: string,
+		attributeName: string,
+	): any {
+		value = XmlValidationUtil.applyConverter(value, attrMetadata.converter, "deserialize");
+		if (typeof value === "string" && attrMetadata.whiteSpace) {
+			value = XmlValidationUtil.applyWhiteSpace(value, attrMetadata.whiteSpace);
+		}
+		if (attrMetadata.list && (typeof value === "string" || typeof value === "number" || typeof value === "boolean")) {
+			value = XmlValidationUtil.splitList(String(value), attrMetadata.list);
+		}
+		this.validateFacetsForProperty(value, attrMetadata, `attribute '${attributeName}'`);
+		let converted = Array.isArray(value)
+			? value
+			: XmlValidationUtil.convertToPropertyType(value, instance, propertyKey);
+		if (typeof converted === "string" && attrMetadata.dataType && instance[propertyKey] === undefined) {
+			converted = XmlValidationUtil.coerceByDataType(converted, attrMetadata.dataType);
+		}
+		return converted;
 	}
 
 	/**
@@ -343,7 +527,10 @@ export class XmlMappingUtil {
 		if (!textMetadata) return;
 
 		let textValue: any;
-		if (data.__cdata !== undefined) {
+		if (typeof data === "string" || typeof data === "number" || typeof data === "boolean") {
+			// Text-only elements parse to a primitive instead of an object
+			textValue = data;
+		} else if (data.__cdata !== undefined) {
 			textValue = data.__cdata;
 		} else if (data["#text"] !== undefined) {
 			textValue = data["#text"];
@@ -355,17 +542,44 @@ export class XmlMappingUtil {
 		}
 
 		if (textValue !== undefined) {
-			if (textMetadata.metadata.converter) {
-				textValue = XmlValidationUtil.applyConverter(textValue, textMetadata.metadata.converter, "deserialize");
-			}
-			instance[textMetadata.propertyKey] = XmlValidationUtil.convertToPropertyType(
+			instance[textMetadata.propertyKey] = this.deserializeTextValue(
 				textValue,
+				textMetadata.metadata,
 				instance,
 				textMetadata.propertyKey,
 			);
+		} else if (textMetadata.metadata.fixedValue !== undefined) {
+			instance[textMetadata.propertyKey] = textMetadata.metadata.fixedValue;
 		} else if (textMetadata.metadata.required) {
 			throw new Error(`Required text content is missing`);
 		}
+	}
+
+	/**
+	 * Apply converter, whiteSpace, xs:list splitting, facet validation, and type
+	 * conversion to raw text content.
+	 */
+	private deserializeTextValue(textValue: any, meta: any, instance: any, propertyKey: string): any {
+		if (meta.converter) {
+			textValue = XmlValidationUtil.applyConverter(textValue, meta.converter, "deserialize");
+		}
+		if (typeof textValue === "string" && meta.whiteSpace) {
+			textValue = XmlValidationUtil.applyWhiteSpace(textValue, meta.whiteSpace);
+		}
+		if (
+			meta.list &&
+			(typeof textValue === "string" || typeof textValue === "number" || typeof textValue === "boolean")
+		) {
+			textValue = XmlValidationUtil.splitList(String(textValue), meta.list);
+		}
+		this.validateFacetsForProperty(textValue, meta, "text content");
+		let converted = Array.isArray(textValue)
+			? textValue
+			: XmlValidationUtil.convertToPropertyType(textValue, instance, propertyKey);
+		if (typeof converted === "string" && meta.dataType && instance[propertyKey] === undefined) {
+			converted = XmlValidationUtil.coerceByDataType(converted, meta.dataType);
+		}
+		return converted;
 	}
 
 	/**
@@ -608,6 +822,11 @@ export class XmlMappingUtil {
 	): any {
 		let value = rawValue;
 
+		// xsi:nil="true" on a nullable element deserializes to null
+		if (fieldElementMetadata[propertyKey]?.isNullable && this.isXsiNil(value)) {
+			return null;
+		}
+
 		// Normalize empty objects and simple text nodes
 		// Pass field metadata so typed complex fields preserve {} instead of collapsing to ""
 		value = this.normalizeXmlValue(value, fieldElementMetadata[propertyKey]);
@@ -640,8 +859,14 @@ export class XmlMappingUtil {
 			xmlToPropertyMap,
 		);
 
-		// Apply deserialize transform
-		const fieldMetadata = fieldElementMetadata[propertyKey];
+		return this.finalizeElementValue(value, fieldElementMetadata[propertyKey]);
+	}
+
+	/**
+	 * Final deserialization steps for an element value: transform, mixed-content
+	 * conversion, and XSD facet handling for primitives.
+	 */
+	private finalizeElementValue(value: any, fieldMetadata: XmlElementMetadata | undefined): any {
 		if (fieldMetadata?.transform?.deserialize && (typeof value === "string" || typeof value === "number")) {
 			value = fieldMetadata.transform.deserialize(String(value));
 		}
@@ -651,6 +876,31 @@ export class XmlMappingUtil {
 			value = this.deserializeMixedContent(value);
 		}
 
+		// Apply XSD facet handling to primitive element values
+		if (fieldMetadata && (typeof value === "string" || typeof value === "number" || typeof value === "boolean")) {
+			value = this.applyElementValueFacets(value, fieldMetadata);
+		}
+
+		return value;
+	}
+
+	/**
+	 * Apply whiteSpace normalization, xs:list splitting, and facet validation to
+	 * a primitive element value during deserialization.
+	 */
+	private applyElementValueFacets(value: any, fieldMetadata: XmlElementMetadata): any {
+		if (typeof value === "string" && fieldMetadata.whiteSpace) {
+			value = XmlValidationUtil.applyWhiteSpace(value, fieldMetadata.whiteSpace);
+		}
+		if (fieldMetadata.list) {
+			value = XmlValidationUtil.splitList(String(value), fieldMetadata.list);
+		}
+		// An empty element on a non-required property represents "absent" —
+		// do not apply value facets to it (keeps undefined → <tag/> → back round-trips valid).
+		const isAbsentOptional = value === "" && fieldMetadata.required !== true;
+		if (!isAbsentOptional) {
+			this.validateFacetsForProperty(value, fieldMetadata, `element '${fieldMetadata.name}'`);
+		}
 		return value;
 	}
 
@@ -854,12 +1104,18 @@ export class XmlMappingUtil {
 	 * Convert a deserialized value to its final type
 	 */
 	private convertFinalValue(value: any, fieldMetadata: any, instance: any, propertyKey: string): any {
-		if (value !== undefined && typeof value === "object" && value !== null) return value;
+		// Preserve explicit null from xsi:nil deserialization
+		if (value === null) return null;
+		if (value !== undefined && typeof value === "object") return value;
 
 		if (fieldMetadata?.unionTypes && fieldMetadata.unionTypes.length > 0) {
 			return XmlValidationUtil.tryConvertToUnionType(value, fieldMetadata.unionTypes);
 		}
-		return XmlValidationUtil.convertToPropertyType(value, instance, propertyKey);
+		let converted = XmlValidationUtil.convertToPropertyType(value, instance, propertyKey);
+		if (typeof converted === "string" && fieldMetadata?.dataType && instance[propertyKey] === undefined) {
+			converted = XmlValidationUtil.coerceByDataType(converted, fieldMetadata.dataType);
+		}
+		return converted;
 	}
 
 	/**
@@ -872,8 +1128,12 @@ export class XmlMappingUtil {
 	): void {
 		for (const propertyKey in fieldElementMetadata) {
 			const fieldMetadata = fieldElementMetadata[propertyKey];
-			if (foundProperties.has(propertyKey) || fieldMetadata.defaultValue === undefined) continue;
-			instance[propertyKey] = fieldMetadata.defaultValue;
+			if (foundProperties.has(propertyKey)) continue;
+			if (fieldMetadata.defaultValue !== undefined) {
+				instance[propertyKey] = fieldMetadata.defaultValue;
+			} else if (fieldMetadata.fixedValue !== undefined) {
+				instance[propertyKey] = fieldMetadata.fixedValue;
+			}
 		}
 	}
 
@@ -1036,7 +1296,7 @@ export class XmlMappingUtil {
 			const fieldMetadata = fieldElementMetadata[propertyKey];
 			const isRequired =
 				fieldMetadata.required || (this.options.requireAllByDefault && !fieldMetadata.requiredExplicitlyFalse);
-			if (isRequired && fieldMetadata.defaultValue === undefined) {
+			if (isRequired && fieldMetadata.defaultValue === undefined && fieldMetadata.fixedValue === undefined) {
 				const xmlName = this.namespaceUtil.buildElementName(fieldMetadata);
 				if (data[xmlName] === undefined) {
 					throw new Error(`Required element '${fieldMetadata.name}' is missing in element '${elementName}'`);
@@ -1443,6 +1703,17 @@ export class XmlMappingUtil {
 
 		this.serializeAttributes(obj, result, attributeMetadata, ignoredProps);
 		this.serializeTextContent(obj, result, textMetadata);
+		this.validateChoiceGroups(
+			fieldElementMetadata,
+			arrayMetadata,
+			(propertyKey) => {
+				const memberValue = obj[propertyKey];
+				return (
+					memberValue !== undefined && memberValue !== null && !(Array.isArray(memberValue) && memberValue.length === 0)
+				);
+			},
+			ctor.name ?? "Unknown",
+		);
 		const commentsByTarget = this.buildCommentsByTarget(obj, commentsMetadata);
 
 		const excludedKeys = this.buildSerializationExcludedKeys(attributeMetadata, textMetadata, commentsMetadata);
@@ -1612,6 +1883,13 @@ export class XmlMappingUtil {
 		const comment = commentsByTarget.get(key);
 		if (comment) result[`?_${xmlName}`] = comment;
 
+		// xs:list element: serialize the array as a single space-separated text element
+		if (Array.isArray(value) && fieldMetadata?.list) {
+			this.validateFacetsForProperty(value, fieldMetadata, `element '${fieldMetadata.name}'`);
+			this.serializePrimitiveValue(XmlValidationUtil.joinList(value), xmlName, fieldMetadata, result);
+			return;
+		}
+
 		if (Array.isArray(value)) {
 			this.serializeArrayValue(value, key, xmlName, obj, result);
 		} else if (typeof value === "object" && value !== null) {
@@ -1637,14 +1915,19 @@ export class XmlMappingUtil {
 			let value = obj[propertyKey];
 			if (value === null || value === undefined) {
 				if (this.options.omitNullValues) continue;
-				value = "";
+				value = attrMetadata.fixedValue ?? "";
 			}
 
 			value = XmlValidationUtil.applyConverter(value, attrMetadata.converter, "serialize");
+			if (typeof value === "string" && attrMetadata.whiteSpace) {
+				value = XmlValidationUtil.applyWhiteSpace(value, attrMetadata.whiteSpace);
+			}
 			if (typeof value === "boolean") value = value.toString();
 
-			if (!XmlValidationUtil.validateValue(value, attrMetadata)) {
-				throw new Error(`Invalid value '${value}' for attribute '${attrMetadata.name}'`);
+			this.validateFacetsForProperty(value, attrMetadata, `attribute '${attrMetadata.name}'`);
+
+			if (Array.isArray(value) && attrMetadata.list) {
+				value = XmlValidationUtil.joinList(value);
 			}
 
 			const attributeName = this.namespaceUtil.buildAttributeName(attrMetadata);
@@ -1663,11 +1946,22 @@ export class XmlMappingUtil {
 		if (!textMetadata) return;
 
 		let textValue = obj[textMetadata.propertyKey];
+		if (textValue === undefined && textMetadata.metadata.fixedValue !== undefined) {
+			textValue = textMetadata.metadata.fixedValue;
+		}
 		if (textValue !== undefined) {
-			if (textMetadata.metadata.converter) {
-				textValue = XmlValidationUtil.applyConverter(textValue, textMetadata.metadata.converter, "serialize");
+			const meta = textMetadata.metadata;
+			if (meta.converter) {
+				textValue = XmlValidationUtil.applyConverter(textValue, meta.converter, "serialize");
 			}
-			if (textMetadata.metadata.useCDATA) {
+			if (typeof textValue === "string" && meta.whiteSpace) {
+				textValue = XmlValidationUtil.applyWhiteSpace(textValue, meta.whiteSpace);
+			}
+			this.validateFacetsForProperty(textValue, meta, "text content");
+			if (Array.isArray(textValue) && meta.list) {
+				textValue = XmlValidationUtil.joinList(textValue);
+			}
+			if (meta.useCDATA) {
 				result.__cdata = textValue;
 			} else {
 				result["#text"] = textValue;
@@ -1805,6 +2099,10 @@ export class XmlMappingUtil {
 		}
 
 		const firstMetadata = arrayMetadata[0];
+
+		this.validateArrayOccurs(value, firstMetadata, key);
+		this.validateArrayItemFacets(value, firstMetadata, key);
+
 		const rawContainerName = firstMetadata.containerName ?? xmlName;
 
 		// Apply namespace prefix to container name when form is 'qualified',
@@ -1834,6 +2132,22 @@ export class XmlMappingUtil {
 			result[containerName] = { [itemName]: processedItems };
 		} else {
 			result[containerName] = processedItems;
+		}
+	}
+
+	/**
+	 * Validate primitive array items against the array's XSD facets, handling
+	 * each violated rule according to its own effective validation mode.
+	 */
+	private validateArrayItemFacets(value: any[], metadata: XmlArrayMetadata, key: string): void {
+		for (const item of value) {
+			if (typeof item === "object" && item !== null) continue;
+			for (const violation of XmlValidationUtil.validateFacets(item, metadata)) {
+				this.reportViolation(
+					`Invalid item '${item}' in array '${metadata.containerName ?? key}': ${violation.message}`,
+					this.modeForRule(violation.rule),
+				);
+			}
 		}
 	}
 
@@ -1965,6 +2279,8 @@ export class XmlMappingUtil {
 		fieldMetadata: XmlElementMetadata | undefined,
 		result: any,
 	): void {
+		value = this.prepareValidatedPrimitive(value, fieldMetadata);
+
 		if (fieldMetadata?.useCDATA && value !== null && value !== undefined) {
 			const cdataObj: any = { __cdata: String(value) };
 			if (fieldMetadata.xmlSpace) cdataObj[`@_xml:space`] = fieldMetadata.xmlSpace;
@@ -1974,6 +2290,23 @@ export class XmlMappingUtil {
 		} else {
 			result[xmlName] = value;
 		}
+	}
+
+	/**
+	 * Apply whiteSpace normalization and facet validation to a primitive value
+	 * before it is written to the result.
+	 */
+	private prepareValidatedPrimitive(value: any, fieldMetadata: XmlElementMetadata | undefined): any {
+		if (!fieldMetadata || value === null || value === undefined) return value;
+
+		if (typeof value === "string" && fieldMetadata.whiteSpace) {
+			value = XmlValidationUtil.applyWhiteSpace(value, fieldMetadata.whiteSpace);
+		}
+		// Joined xs:list values were already validated against the array form
+		if (!fieldMetadata.list) {
+			this.validateFacetsForProperty(value, fieldMetadata, `element '${fieldMetadata.name}'`);
+		}
+		return value;
 	}
 
 	/**

--- a/packages/xml-poto/src/utils/xml-validation-util.ts
+++ b/packages/xml-poto/src/utils/xml-validation-util.ts
@@ -1,5 +1,11 @@
 /* eslint-disable typescript/no-explicit-any -- Validation utils work with dynamic values of unknown type */
-import { XmlAttributeMetadata } from "../decorators";
+import { XmlAttributeMetadata, XmlListOptions, XmlValidationRule, XmlValueFacets } from "../decorators";
+
+/** A single facet violation, identifying which validation rule failed. */
+export interface XmlFacetViolation {
+	rule: XmlValidationRule;
+	message: string;
+}
 
 /**
  * Utility class for XML validation operations.
@@ -60,19 +66,206 @@ export class XmlValidationUtil {
 	 * Validate value against pattern and enum constraints.
 	 */
 	static validateValue(value: any, metadata: XmlAttributeMetadata): boolean {
-		if (metadata.pattern && typeof value === "string") {
-			if (!metadata.pattern.test(value)) {
-				return false;
+		return XmlValidationUtil.validateFacets(value, metadata).length === 0;
+	}
+
+	/**
+	 * Validate a value against XSD facets (pattern, enumValues, length family,
+	 * numeric bounds, digit counts, fixedValue).
+	 * Returns ALL violations (one per rule) so callers can handle each rule
+	 * according to its own validation mode.
+	 * Arrays (xs:list values) are length-checked as item counts; other facets
+	 * apply to each item.
+	 */
+	static validateFacets(value: any, facets: XmlValueFacets): XmlFacetViolation[] {
+		const violations: XmlFacetViolation[] = [];
+
+		if (Array.isArray(value)) {
+			XmlValidationUtil.validateLengthFacets(value.length, facets, "item count", violations);
+			for (const item of value) {
+				XmlValidationUtil.validateScalarFacets(item, facets, violations);
+			}
+		} else {
+			XmlValidationUtil.validateScalarFacets(value, facets, violations);
+			if (typeof value === "string") {
+				XmlValidationUtil.validateLengthFacets(value.length, facets, "length", violations);
 			}
 		}
 
-		if (metadata.enumValues && metadata.enumValues.length > 0) {
-			if (!metadata.enumValues.includes(value)) {
-				return false;
-			}
+		return XmlValidationUtil.deduplicateByRule(violations);
+	}
+
+	/** Keep only the first violation per rule (list items can repeat rules). */
+	private static deduplicateByRule(violations: XmlFacetViolation[]): XmlFacetViolation[] {
+		if (violations.length <= 1) return violations;
+		const seen = new Set<XmlValidationRule>();
+		return violations.filter((v) => {
+			if (seen.has(v.rule)) return false;
+			seen.add(v.rule);
+			return true;
+		});
+	}
+
+	private static validateScalarFacets(value: any, facets: XmlValueFacets, violations: XmlFacetViolation[]): void {
+		if (facets.pattern && typeof value === "string" && !facets.pattern.test(value)) {
+			violations.push({ rule: "pattern", message: `does not match pattern ${facets.pattern}` });
 		}
 
-		return true;
+		if (facets.enumValues && facets.enumValues.length > 0 && !facets.enumValues.includes(value)) {
+			violations.push({
+				rule: "enumValues",
+				message: `is not one of the allowed values [${facets.enumValues.join(", ")}]`,
+			});
+		}
+
+		if (facets.fixedValue !== undefined && !XmlValidationUtil.matchesFixedValue(value, facets.fixedValue)) {
+			violations.push({ rule: "fixedValue", message: `does not equal the fixed value '${facets.fixedValue}'` });
+		}
+
+		XmlValidationUtil.validateNumericFacets(value, facets, violations);
+	}
+
+	/**
+	 * Compare a value with an XSD fixed value. Compares numerically when both
+	 * sides are numeric so parsed values like 1 still match "1.0".
+	 */
+	private static matchesFixedValue(value: any, fixedValue: string | number | boolean): boolean {
+		const bothNumeric =
+			typeof value !== "boolean" &&
+			String(value).trim() !== "" &&
+			!Number.isNaN(Number(value)) &&
+			!Number.isNaN(Number(fixedValue));
+		return bothNumeric ? Number(value) === Number(fixedValue) : String(value) === String(fixedValue);
+	}
+
+	private static validateNumericFacets(value: any, facets: XmlValueFacets, violations: XmlFacetViolation[]): void {
+		const hasNumericFacet =
+			facets.minInclusive !== undefined ||
+			facets.maxInclusive !== undefined ||
+			facets.minExclusive !== undefined ||
+			facets.maxExclusive !== undefined ||
+			facets.totalDigits !== undefined ||
+			facets.fractionDigits !== undefined;
+		if (!hasNumericFacet) return;
+
+		const num = Number(value);
+		if (Number.isNaN(num) || String(value).trim() === "") return;
+
+		XmlValidationUtil.validateBoundFacets(num, facets, violations);
+		XmlValidationUtil.validateDigitFacets(num, facets, violations);
+	}
+
+	private static validateBoundFacets(num: number, facets: XmlValueFacets, violations: XmlFacetViolation[]): void {
+		if (facets.minInclusive !== undefined && num < facets.minInclusive) {
+			violations.push({ rule: "minInclusive", message: `is less than minInclusive ${facets.minInclusive}` });
+		}
+		if (facets.maxInclusive !== undefined && num > facets.maxInclusive) {
+			violations.push({ rule: "maxInclusive", message: `is greater than maxInclusive ${facets.maxInclusive}` });
+		}
+		if (facets.minExclusive !== undefined && num <= facets.minExclusive) {
+			violations.push({ rule: "minExclusive", message: `is not greater than minExclusive ${facets.minExclusive}` });
+		}
+		if (facets.maxExclusive !== undefined && num >= facets.maxExclusive) {
+			violations.push({ rule: "maxExclusive", message: `is not less than maxExclusive ${facets.maxExclusive}` });
+		}
+	}
+
+	private static validateDigitFacets(num: number, facets: XmlValueFacets, violations: XmlFacetViolation[]): void {
+		if (facets.totalDigits === undefined && facets.fractionDigits === undefined) {
+			return;
+		}
+		const [integerPart, fractionPart = ""] = Math.abs(num).toString().split(".");
+		const totalDigits = integerPart.replace(/^0+(?=\d)/, "").length + fractionPart.length;
+		if (facets.totalDigits !== undefined && totalDigits > facets.totalDigits) {
+			violations.push({ rule: "totalDigits", message: `has more than ${facets.totalDigits} total digits` });
+		}
+		if (facets.fractionDigits !== undefined && fractionPart.length > facets.fractionDigits) {
+			violations.push({
+				rule: "fractionDigits",
+				message: `has more than ${facets.fractionDigits} fraction digits`,
+			});
+		}
+	}
+
+	private static validateLengthFacets(
+		actual: number,
+		facets: XmlValueFacets,
+		unit: string,
+		violations: XmlFacetViolation[],
+	): void {
+		if (facets.length !== undefined && actual !== facets.length) {
+			violations.push({ rule: "length", message: `has ${unit} ${actual}, expected exactly ${facets.length}` });
+		}
+		if (facets.minLength !== undefined && actual < facets.minLength) {
+			violations.push({ rule: "minLength", message: `has ${unit} ${actual}, expected at least ${facets.minLength}` });
+		}
+		if (facets.maxLength !== undefined && actual > facets.maxLength) {
+			violations.push({ rule: "maxLength", message: `has ${unit} ${actual}, expected at most ${facets.maxLength}` });
+		}
+	}
+
+	/**
+	 * Apply xs:whiteSpace normalization to a string value.
+	 * 'replace' maps tabs/newlines to spaces; 'collapse' additionally squeezes
+	 * runs of spaces and trims; 'preserve' returns the value unchanged.
+	 */
+	static applyWhiteSpace(value: string, mode: "preserve" | "replace" | "collapse"): string {
+		if (mode === "preserve") return value;
+		const replaced = value.replace(/[\t\r\n]/g, " ");
+		if (mode === "replace") return replaced;
+		return replaced.replace(/ {2,}/g, " ").trim();
+	}
+
+	/**
+	 * Coerce a raw string value based on the declared XSD dataType.
+	 * Only used as a fallback when the property type cannot be inferred from
+	 * its current runtime value.
+	 */
+	static coerceByDataType(value: any, dataType: string): any {
+		if (typeof value !== "string") return value;
+
+		const localType = dataType.includes(":") ? dataType.substring(dataType.indexOf(":") + 1) : dataType;
+
+		if (NUMERIC_XSD_TYPES.has(localType)) {
+			const num = Number(value);
+			return Number.isNaN(num) || value.trim() === "" ? value : num;
+		}
+
+		if (localType === "boolean") {
+			if (value === "true" || value === "1") return true;
+			if (value === "false" || value === "0") return false;
+			return value;
+		}
+
+		return value;
+	}
+
+	/**
+	 * Split an xs:list text value (space-separated) into typed items.
+	 */
+	static splitList(text: string, list: XmlListOptions): (string | number | boolean)[] {
+		const itemType = typeof list === "object" ? (list.itemType ?? "string") : "string";
+		const items = text.trim().split(/\s+/).filter(Boolean);
+
+		if (itemType === "number") {
+			return items.map((item) => {
+				const num = Number(item);
+				return Number.isNaN(num) ? item : num;
+			});
+		}
+		if (itemType === "boolean") {
+			return items.map((item) =>
+				item === "true" || item === "1" ? true : item === "false" || item === "0" ? false : item,
+			);
+		}
+		return items;
+	}
+
+	/**
+	 * Join xs:list items into a space-separated text value.
+	 */
+	static joinList(items: unknown[]): string {
+		return items.map((item) => String(item)).join(" ");
 	}
 
 	/**
@@ -143,3 +336,23 @@ export class XmlValidationUtil {
 		return null;
 	}
 }
+
+/** XSD built-in types coerced to number by coerceByDataType */
+const NUMERIC_XSD_TYPES = new Set([
+	"integer",
+	"int",
+	"long",
+	"short",
+	"byte",
+	"decimal",
+	"float",
+	"double",
+	"nonNegativeInteger",
+	"nonPositiveInteger",
+	"positiveInteger",
+	"negativeInteger",
+	"unsignedInt",
+	"unsignedLong",
+	"unsignedShort",
+	"unsignedByte",
+]);

--- a/packages/xml-poto/tests/decorators/type-ref.test.ts
+++ b/packages/xml-poto/tests/decorators/type-ref.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import { XmlArray, XmlElement, XmlRoot, XmlSerializer } from "../../src";
+import { findConstructorByName } from "../../src/decorators/storage/metadata-storage";
+import { isTypeThunk, resolveMetadataType, resolveTypeRef } from "../../src/decorators/storage/type-ref";
+
+describe("TypeRef (lazy type references)", () => {
+	describe("isTypeThunk / resolveTypeRef", () => {
+		class Plain {}
+		abstract class AbstractPlain {}
+		function LegacyCtor(this: unknown): void {
+			// ES5-style constructor function
+		}
+
+		it("detects classes and function declarations as constructors", () => {
+			expect(isTypeThunk(Plain)).toBe(false);
+			expect(isTypeThunk(AbstractPlain)).toBe(false);
+			expect(isTypeThunk(LegacyCtor as unknown as new () => object)).toBe(false);
+		});
+
+		it("detects arrow functions as thunks", () => {
+			expect(isTypeThunk(() => Plain)).toBe(true);
+		});
+
+		it("resolves constructors and thunks alike", () => {
+			expect(resolveTypeRef(Plain)).toBe(Plain);
+			expect(resolveTypeRef(() => Plain)).toBe(Plain);
+			expect(resolveTypeRef(undefined)).toBeUndefined();
+		});
+
+		it("resolveMetadataType caches the resolved constructor back into the metadata", () => {
+			const meta: { type?: unknown } = { type: () => Plain };
+			expect(resolveMetadataType(meta as { type?: never })).toBe(Plain);
+			expect(meta.type).toBe(Plain);
+			expect(resolveMetadataType(undefined)).toBeUndefined();
+			expect(resolveMetadataType({})).toBeUndefined();
+		});
+	});
+
+	describe("self-recursive types", () => {
+		@XmlRoot({ name: "Section" })
+		@XmlElement({ name: "Section" })
+		class Section {
+			@XmlElement({ name: "Title" })
+			title?: string;
+
+			@XmlArray({ containerName: "Children", itemName: "Section", type: () => Section })
+			children?: Section[];
+		}
+
+		it("round-trips a nested tree of the same class", () => {
+			const serializer = new XmlSerializer();
+
+			const leaf = new Section();
+			leaf.title = "Leaf";
+
+			const mid = new Section();
+			mid.title = "Middle";
+			mid.children = [leaf];
+
+			const root = new Section();
+			root.title = "Root";
+			root.children = [mid];
+
+			const xml = serializer.toXml(root);
+			const parsed = serializer.fromXml(xml, Section);
+
+			expect(parsed.title).toBe("Root");
+			expect(parsed.children?.[0]).toBeInstanceOf(Section);
+			expect(parsed.children?.[0].title).toBe("Middle");
+			expect(parsed.children?.[0].children?.[0]).toBeInstanceOf(Section);
+			expect(parsed.children?.[0].children?.[0].title).toBe("Leaf");
+		});
+	});
+
+	describe("mutually recursive types (genuine forward reference)", () => {
+		// `type: () => LazyEmployee` references a class declared LATER in this file —
+		// a direct reference here would be a TS error and a runtime TDZ ReferenceError.
+		@XmlRoot({ name: "Department" })
+		class LazyDepartment {
+			@XmlElement({ name: "Name" })
+			name?: string;
+
+			@XmlElement({ name: "Head", type: () => LazyEmployee })
+			head?: LazyEmployee;
+		}
+
+		@XmlElement({ name: "Employee" })
+		class LazyEmployee {
+			@XmlElement({ name: "FullName" })
+			fullName?: string;
+
+			@XmlElement({ name: "Dept", type: () => LazyDepartment })
+			dept?: LazyDepartment;
+		}
+
+		it("round-trips both directions of the cycle", () => {
+			const serializer = new XmlSerializer();
+
+			const homeBase = new LazyDepartment();
+			homeBase.name = "Engineering";
+
+			const head = new LazyEmployee();
+			head.fullName = "Alex";
+			head.dept = homeBase;
+
+			const department = new LazyDepartment();
+			department.name = "Research";
+			department.head = head;
+
+			const xml = serializer.toXml(department);
+			const parsed = serializer.fromXml(xml, LazyDepartment);
+
+			expect(parsed.name).toBe("Research");
+			expect(parsed.head).toBeInstanceOf(LazyEmployee);
+			expect(parsed.head?.fullName).toBe("Alex");
+			expect(parsed.head?.dept).toBeInstanceOf(LazyDepartment);
+			expect(parsed.head?.dept?.name).toBe("Engineering");
+		});
+
+		it("registers thunk-referenced classes for auto-discovery on first lookup", () => {
+			// The decorator could not register LazyEmployee eagerly (it was in TDZ);
+			// the pending registration must flush on the first registry read.
+			expect(findConstructorByName("LazyEmployee")).toBe(LazyEmployee);
+			expect(findConstructorByName("LazyDepartment")).toBe(LazyDepartment);
+		});
+	});
+
+	describe("xsi:type with thunk-declared types", () => {
+		@XmlElement({ name: "BaseShape" })
+		class BaseShape {
+			@XmlElement({ name: "Id" })
+			id?: string;
+		}
+
+		@XmlElement({ name: "Circle" })
+		class Circle extends BaseShape {
+			@XmlElement({ name: "Radius" })
+			radius?: number;
+		}
+
+		@XmlRoot({ name: "Drawing" })
+		class Drawing {
+			@XmlElement({ name: "Shape", type: () => BaseShape })
+			shape?: BaseShape;
+		}
+
+		it("emits xsi:type when the runtime type differs from the thunk-declared type", () => {
+			const serializer = new XmlSerializer({ useXsiType: true });
+
+			const drawing = new Drawing();
+			const circle = new Circle();
+			circle.id = "c1";
+			circle.radius = 4;
+			drawing.shape = circle;
+
+			const xml = serializer.toXml(drawing);
+			expect(xml).toContain('xsi:type="Circle"');
+		});
+
+		it("omits xsi:type when the runtime type matches the thunk-declared type", () => {
+			const serializer = new XmlSerializer({ useXsiType: true });
+
+			const drawing = new Drawing();
+			const shape = new BaseShape();
+			shape.id = "s1";
+			drawing.shape = shape;
+
+			const xml = serializer.toXml(drawing);
+			expect(xml).not.toContain("xsi:type");
+		});
+	});
+
+	describe("backward compatibility with direct constructors", () => {
+		@XmlElement({ name: "Address" })
+		class PlainAddress {
+			@XmlElement({ name: "City" })
+			city?: string;
+		}
+
+		@XmlRoot({ name: "Company" })
+		class PlainCompany {
+			@XmlElement({ name: "Address", type: PlainAddress })
+			address?: PlainAddress;
+		}
+
+		it("still round-trips with a non-thunk type option", () => {
+			const serializer = new XmlSerializer();
+
+			const company = new PlainCompany();
+			company.address = new PlainAddress();
+			company.address.city = "Utrecht";
+
+			const xml = serializer.toXml(company);
+			const parsed = serializer.fromXml(xml, PlainCompany);
+
+			expect(parsed.address).toBeInstanceOf(PlainAddress);
+			expect(parsed.address?.city).toBe("Utrecht");
+		});
+	});
+});

--- a/packages/xml-poto/tests/decorators/xml-choice-group.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-choice-group.test.ts
@@ -1,0 +1,125 @@
+/* eslint-disable typescript/no-explicit-any, typescript/explicit-function-return-type -- Test file with dynamic mock data */
+import { describe, expect, it, vi } from "vitest";
+
+import { XmlDecoratorSerializer, XmlElement, XmlRoot } from "../../src";
+
+describe("Choice groups (xs:choice)", () => {
+	@XmlRoot({ name: "Notification" })
+	class Notification {
+		@XmlElement()
+		title: string = "";
+
+		@XmlElement({ choiceGroup: "contact", choiceRequired: true })
+		email?: string;
+
+		@XmlElement({ choiceGroup: "contact", choiceRequired: true })
+		phone?: string;
+	}
+
+	it("should accept exactly one choice member", () => {
+		const serializer = new XmlDecoratorSerializer();
+		const notification = serializer.fromXml(
+			"<Notification><title>Hi</title><email>a@b.c</email></Notification>",
+			Notification,
+		);
+		expect(notification.email).toBe("a@b.c");
+		expect(notification.phone).toBeUndefined();
+	});
+
+	it("should throw when multiple choice members are set during deserialization", () => {
+		const serializer = new XmlDecoratorSerializer();
+		expect(() =>
+			serializer.fromXml(
+				"<Notification><title>Hi</title><email>a@b.c</email><phone>123</phone></Notification>",
+				Notification,
+			),
+		).toThrow(/Choice group 'contact'.*only one of/);
+	});
+
+	it("should throw when a required choice has no member set", () => {
+		const serializer = new XmlDecoratorSerializer();
+		expect(() => serializer.fromXml("<Notification><title>Hi</title></Notification>", Notification)).toThrow(
+			/Choice group 'contact'.*must be set/,
+		);
+	});
+
+	it("should throw when multiple choice members are set during serialization", () => {
+		const serializer = new XmlDecoratorSerializer();
+		const notification = new Notification();
+		notification.title = "Hi";
+		notification.email = "a@b.c";
+		notification.phone = "123";
+		expect(() => serializer.toXml(notification)).toThrow(/Choice group 'contact'.*only one of/);
+	});
+
+	it("should serialize a valid single choice member", () => {
+		const serializer = new XmlDecoratorSerializer();
+		const notification = new Notification();
+		notification.title = "Hi";
+		notification.phone = "123";
+		const xml = serializer.toXml(notification);
+		expect(xml).toContain("<phone>123</phone>");
+		expect(xml).not.toContain("<email>");
+	});
+
+	it("should only warn under validationMode 'warn'", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const serializer = new XmlDecoratorSerializer({ validationMode: "warn" });
+			const notification = serializer.fromXml(
+				"<Notification><title>Hi</title><email>a@b.c</email><phone>123</phone></Notification>",
+				Notification,
+			);
+			expect(notification.email).toBe("a@b.c");
+			// Untyped optional properties keep the parser's numeric coercion
+			expect(notification.phone).toBe(123 as any);
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Choice group 'contact'"));
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("should only warn with validationModeOverrides.choiceGroup while other rules stay strict", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const serializer = new XmlDecoratorSerializer({
+				validationModeOverrides: { choiceGroup: "warn" },
+			});
+			const notification = serializer.fromXml(
+				"<Notification><title>Hi</title><email>a@b.c</email><phone>123</phone></Notification>",
+				Notification,
+			);
+			expect(notification.email).toBe("a@b.c");
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Choice group 'contact'"));
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("should skip choice validation with validationModeOverrides.choiceGroup 'off'", () => {
+		const serializer = new XmlDecoratorSerializer({
+			validationModeOverrides: { choiceGroup: "off" },
+		});
+		const notification = serializer.fromXml(
+			"<Notification><title>Hi</title><email>a@b.c</email><phone>123</phone></Notification>",
+			Notification,
+		);
+		expect(notification.email).toBe("a@b.c");
+	});
+
+	it("should not affect classes without choice groups", () => {
+		@XmlRoot({ name: "Plain" })
+		class Plain {
+			@XmlElement()
+			a?: string;
+
+			@XmlElement()
+			b?: string;
+		}
+
+		const serializer = new XmlDecoratorSerializer();
+		const plain = serializer.fromXml("<Plain><a>one</a><b>two</b></Plain>", Plain);
+		expect(plain.a).toBe("one");
+		expect(plain.b).toBe("two");
+	});
+});

--- a/packages/xml-poto/tests/decorators/xml-facets.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-facets.test.ts
@@ -1,0 +1,352 @@
+/* eslint-disable typescript/no-explicit-any, typescript/explicit-function-return-type -- Test file with dynamic mock data */
+import { describe, expect, it, vi } from "vitest";
+
+import { XmlAttribute, XmlDecoratorSerializer, XmlElement, XmlRoot, XmlText } from "../../src";
+
+describe("XSD Facets", () => {
+	describe("element facets", () => {
+		it("should throw on element pattern violation during deserialization", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ pattern: /^[A-Z]{2}$/ })
+				code: string = "";
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			expect(() => serializer.fromXml("<Doc><code>abc</code></Doc>", Doc)).toThrow(/does not match pattern/);
+			expect(serializer.fromXml("<Doc><code>NL</code></Doc>", Doc).code).toBe("NL");
+		});
+
+		it("should throw on element enumValues violation during serialization", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ enumValues: ["red", "green"] })
+				color: string = "red";
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			const doc = new Doc();
+			doc.color = "blue";
+			expect(() => serializer.toXml(doc)).toThrow(/is not one of the allowed values/);
+
+			doc.color = "green";
+			expect(serializer.toXml(doc)).toContain("<color>green</color>");
+		});
+
+		it("should enforce minLength/maxLength/length on elements", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ minLength: 2, maxLength: 4 })
+				name: string = "ab";
+
+				@XmlElement({ length: 2 })
+				iso: string = "NL";
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			expect(() => serializer.fromXml("<Doc><name>a</name><iso>NL</iso></Doc>", Doc)).toThrow(/at least 2/);
+			expect(() => serializer.fromXml("<Doc><name>abcde</name><iso>NL</iso></Doc>", Doc)).toThrow(/at most 4/);
+			expect(() => serializer.fromXml("<Doc><name>abc</name><iso>NLD</iso></Doc>", Doc)).toThrow(/exactly 2/);
+
+			const doc = serializer.fromXml("<Doc><name>abc</name><iso>BE</iso></Doc>", Doc);
+			expect(doc.name).toBe("abc");
+			expect(doc.iso).toBe("BE");
+		});
+
+		it("should enforce numeric bounds facets", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ minInclusive: 0, maxInclusive: 100 })
+				score: number = 0;
+
+				@XmlElement({ minExclusive: 0, maxExclusive: 10 })
+				rating: number = 5;
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			expect(() => serializer.fromXml("<Doc><score>-1</score><rating>5</rating></Doc>", Doc)).toThrow(
+				/less than minInclusive 0/,
+			);
+			expect(() => serializer.fromXml("<Doc><score>101</score><rating>5</rating></Doc>", Doc)).toThrow(
+				/greater than maxInclusive 100/,
+			);
+			expect(() => serializer.fromXml("<Doc><score>50</score><rating>0</rating></Doc>", Doc)).toThrow(
+				/not greater than minExclusive 0/,
+			);
+			expect(() => serializer.fromXml("<Doc><score>50</score><rating>10</rating></Doc>", Doc)).toThrow(
+				/not less than maxExclusive 10/,
+			);
+
+			const doc = serializer.fromXml("<Doc><score>100</score><rating>9.5</rating></Doc>", Doc);
+			expect(doc.score).toBe(100);
+			expect(doc.rating).toBe(9.5);
+		});
+
+		it("should enforce totalDigits and fractionDigits", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ totalDigits: 5, fractionDigits: 2 })
+				amount: number = 0;
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			expect(() => serializer.fromXml("<Doc><amount>123456</amount></Doc>", Doc)).toThrow(/more than 5 total digits/);
+			expect(() => serializer.fromXml("<Doc><amount>1.234</amount></Doc>", Doc)).toThrow(/more than 2 fraction digits/);
+			expect(serializer.fromXml("<Doc><amount>123.45</amount></Doc>", Doc).amount).toBe(123.45);
+		});
+
+		it("should apply whiteSpace normalization before validation", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ whiteSpace: "collapse", pattern: /^[a-z]+ [a-z]+$/ })
+				text: string = "";
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			const doc = serializer.fromXml("<Doc><text>  hello\t\n   world  </text></Doc>", Doc);
+			expect(doc.text).toBe("hello world");
+		});
+	});
+
+	describe("attribute facets (extended)", () => {
+		it("should keep existing pattern/enumValues attribute behavior (throws by default)", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlAttribute({ pattern: /^\d+$/ })
+				id: string = "1";
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			expect(() => serializer.fromXml(`<Doc id="abc"/>`, Doc)).toThrow(/Invalid value 'abc' for attribute 'id'/);
+			expect(serializer.fromXml(`<Doc id="42"/>`, Doc).id).toBe("42");
+		});
+
+		it("should enforce new facets on attributes", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlAttribute({ maxLength: 3 })
+				tag: string = "";
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			expect(() => serializer.fromXml(`<Doc tag="abcd"/>`, Doc)).toThrow(/at most 3/);
+			expect(serializer.fromXml(`<Doc tag="abc"/>`, Doc).tag).toBe("abc");
+		});
+	});
+
+	describe("text facets", () => {
+		it("should enforce facets on @XmlText content", () => {
+			@XmlRoot({ name: "Code" })
+			class Code {
+				@XmlText({ pattern: /^[A-Z]+$/ })
+				value: string = "";
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			expect(() => serializer.fromXml("<Code>abc</Code>", Code)).toThrow(/does not match pattern/);
+			expect(serializer.fromXml("<Code>ABC</Code>", Code).value).toBe("ABC");
+		});
+	});
+
+	describe("fixedValue", () => {
+		it("should use fixedValue as default when element is missing", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ fixedValue: "1.0" })
+				version: string = "";
+
+				@XmlElement()
+				name: string = "";
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			const doc = serializer.fromXml("<Doc><name>x</name></Doc>", Doc);
+			expect(doc.version).toBe("1.0");
+		});
+
+		it("should throw when a value does not equal the fixed value", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ fixedValue: "v1" })
+				version: string = "v1";
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			expect(() => serializer.fromXml("<Doc><version>v2</version></Doc>", Doc)).toThrow(
+				/does not equal the fixed value 'v1'/,
+			);
+			expect(serializer.fromXml("<Doc><version>v1</version></Doc>", Doc).version).toBe("v1");
+		});
+
+		it("should match numeric fixed values regardless of formatting", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ fixedValue: "1.0" })
+				version: string = "1.0";
+			}
+
+			// The parser coerces "1.0" to 1; the fixed-value check compares numerically
+			const serializer = new XmlDecoratorSerializer();
+			expect(() => serializer.fromXml("<Doc><version>1.0</version></Doc>", Doc)).not.toThrow();
+			expect(() => serializer.fromXml("<Doc><version>2.0</version></Doc>", Doc)).toThrow(
+				/does not equal the fixed value '1.0'/,
+			);
+		});
+
+		it("should serialize fixedValue for missing attribute values", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlAttribute({ fixedValue: "fixed" })
+				kind?: string;
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			expect(serializer.toXml(new Doc())).toContain(`kind="fixed"`);
+		});
+	});
+
+	describe("validationMode", () => {
+		it("should warn instead of throw with serializer validationMode 'warn'", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ pattern: /^[A-Z]+$/ })
+				code: string = "";
+			}
+
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				const serializer = new XmlDecoratorSerializer({ validationMode: "warn" });
+				const doc = serializer.fromXml("<Doc><code>abc</code></Doc>", Doc);
+				expect(doc.code).toBe("abc");
+				expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("does not match pattern"));
+			} finally {
+				warnSpy.mockRestore();
+			}
+		});
+
+		it("should skip validation entirely with validationMode 'off'", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ pattern: /^[A-Z]+$/ })
+				code: string = "";
+			}
+
+			const serializer = new XmlDecoratorSerializer({ validationMode: "off" });
+			expect(serializer.fromXml("<Doc><code>abc</code></Doc>", Doc).code).toBe("abc");
+		});
+
+		it("should relax existing attribute pattern validation via validationMode", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlAttribute({ pattern: /^\d+$/ })
+				id: string = "";
+			}
+
+			const serializer = new XmlDecoratorSerializer({ validationMode: "off" });
+			expect(serializer.fromXml(`<Doc id="abc"/>`, Doc).id).toBe("abc");
+		});
+	});
+
+	describe("validationModeOverrides", () => {
+		it("should apply a per-rule override while other rules follow the global mode", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ pattern: /^[a-z ]+$/, maxLength: 5 })
+				code: string = "";
+			}
+
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				const serializer = new XmlDecoratorSerializer({
+					validationModeOverrides: { pattern: "warn" },
+				});
+
+				// Violates only pattern → warns, keeps value
+				const doc = serializer.fromXml("<Doc><code>UP</code></Doc>", Doc);
+				expect(doc.code).toBe("UP");
+				expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("does not match pattern"));
+
+				// Violates maxLength (not overridden) → still throws
+				expect(() => serializer.fromXml("<Doc><code>toolongvalue</code></Doc>", Doc)).toThrow(/at most 5/);
+			} finally {
+				warnSpy.mockRestore();
+			}
+		});
+
+		it("should still enforce other rules when one rule is 'off' and both are violated", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ pattern: /^[a-z]+$/, maxLength: 5 })
+				code: string = "";
+			}
+
+			const serializer = new XmlDecoratorSerializer({
+				validationModeOverrides: { pattern: "off" },
+			});
+
+			// "TOOLONGVALUE" violates both pattern (off) and maxLength (strict)
+			expect(() => serializer.fromXml("<Doc><code>TOOLONGVALUE</code></Doc>", Doc)).toThrow(/at most 5/);
+
+			// Violating only the disabled rule passes
+			expect(serializer.fromXml("<Doc><code>ABC</code></Doc>", Doc).code).toBe("ABC");
+		});
+
+		it("should let a per-rule override win over a lenient global validationMode", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ pattern: /^[A-Z]+$/ })
+				code: string = "";
+			}
+
+			const serializer = new XmlDecoratorSerializer({
+				validationMode: "off",
+				validationModeOverrides: { pattern: "strict" },
+			});
+			expect(() => serializer.fromXml("<Doc><code>abc</code></Doc>", Doc)).toThrow(/does not match pattern/);
+		});
+
+		it("should relax the existing attribute pattern check per rule", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlAttribute({ pattern: /^\d+$/, maxLength: 10 })
+				id: string = "";
+			}
+
+			const serializer = new XmlDecoratorSerializer({
+				validationModeOverrides: { pattern: "off" },
+			});
+			expect(serializer.fromXml(`<Doc id="abc"/>`, Doc).id).toBe("abc");
+		});
+
+		it("should apply overrides to fixedValue independently", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ fixedValue: "v1" })
+				version: string = "v1";
+			}
+
+			const serializer = new XmlDecoratorSerializer({
+				validationModeOverrides: { fixedValue: "off" },
+			});
+			expect(serializer.fromXml("<Doc><version>v2</version></Doc>", Doc).version).toBe("v2");
+		});
+	});
+
+	describe("dataType coercion", () => {
+		it("should coerce optional untyped properties based on dataType", () => {
+			@XmlRoot({ name: "Doc" })
+			class Doc {
+				@XmlElement({ dataType: "xs:int" })
+				count?: number;
+
+				@XmlElement({ dataType: "xs:boolean" })
+				active?: boolean;
+			}
+
+			const serializer = new XmlDecoratorSerializer();
+			const doc = serializer.fromXml("<Doc><count>42</count><active>true</active></Doc>", Doc);
+			expect(doc.count).toBe(42);
+			expect(doc.active).toBe(true);
+		});
+	});
+});

--- a/packages/xml-poto/tests/decorators/xml-list.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-list.test.ts
@@ -1,0 +1,114 @@
+/* eslint-disable typescript/no-explicit-any, typescript/explicit-function-return-type -- Test file with dynamic mock data */
+import { describe, expect, it } from "vitest";
+
+import { XmlAttribute, XmlDecoratorSerializer, XmlElement, XmlRoot, XmlText } from "../../src";
+
+describe("xs:list support", () => {
+	it("should round-trip a number list element", () => {
+		@XmlRoot({ name: "Product" })
+		class Product {
+			@XmlElement({ list: { itemType: "number" } })
+			sizes: number[] = [];
+		}
+
+		const serializer = new XmlDecoratorSerializer();
+		const product = new Product();
+		product.sizes = [1, 2, 3];
+
+		const xml = serializer.toXml(product);
+		expect(xml).toContain("<sizes>1 2 3</sizes>");
+
+		const restored = serializer.fromXml(xml, Product);
+		expect(restored.sizes).toEqual([1, 2, 3]);
+	});
+
+	it("should round-trip a string list element with list: true", () => {
+		@XmlRoot({ name: "Doc" })
+		class Doc {
+			@XmlElement({ list: true })
+			tags: string[] = [];
+		}
+
+		const serializer = new XmlDecoratorSerializer();
+		const doc = new Doc();
+		doc.tags = ["alpha", "beta", "gamma"];
+
+		const xml = serializer.toXml(doc);
+		expect(xml).toContain("<tags>alpha beta gamma</tags>");
+
+		const restored = serializer.fromXml(xml, Doc);
+		expect(restored.tags).toEqual(["alpha", "beta", "gamma"]);
+	});
+
+	it("should round-trip a list attribute", () => {
+		@XmlRoot({ name: "Doc" })
+		class Doc {
+			@XmlAttribute({ list: { itemType: "number" } })
+			ids: number[] = [];
+		}
+
+		const serializer = new XmlDecoratorSerializer();
+		const doc = new Doc();
+		doc.ids = [10, 20];
+
+		const xml = serializer.toXml(doc);
+		expect(xml).toContain(`ids="10 20"`);
+
+		const restored = serializer.fromXml(xml, Doc);
+		expect(restored.ids).toEqual([10, 20]);
+	});
+
+	it("should round-trip list text content", () => {
+		@XmlRoot({ name: "Values" })
+		class Values {
+			@XmlText({ list: { itemType: "boolean" } })
+			flags: boolean[] = [];
+		}
+
+		const serializer = new XmlDecoratorSerializer();
+		const values = new Values();
+		values.flags = [true, false, true];
+
+		const xml = serializer.toXml(values);
+		expect(xml).toContain(">true false true</Values>");
+
+		const restored = serializer.fromXml(xml, Values);
+		expect(restored.flags).toEqual([true, false, true]);
+	});
+
+	it("should deserialize a single-item list to a one-element array", () => {
+		@XmlRoot({ name: "Doc" })
+		class Doc {
+			@XmlElement({ list: { itemType: "number" } })
+			sizes: number[] = [];
+		}
+
+		const serializer = new XmlDecoratorSerializer();
+		const doc = serializer.fromXml("<Doc><sizes>7</sizes></Doc>", Doc);
+		expect(doc.sizes).toEqual([7]);
+	});
+
+	it("should apply length facets to the list item count", () => {
+		@XmlRoot({ name: "Doc" })
+		class Doc {
+			@XmlElement({ list: { itemType: "number" }, minLength: 2, maxLength: 3 })
+			sizes: number[] = [];
+		}
+
+		const serializer = new XmlDecoratorSerializer();
+		expect(() => serializer.fromXml("<Doc><sizes>1</sizes></Doc>", Doc)).toThrow(/at least 2/);
+		expect(() => serializer.fromXml("<Doc><sizes>1 2 3 4</sizes></Doc>", Doc)).toThrow(/at most 3/);
+		expect(serializer.fromXml("<Doc><sizes>1 2</sizes></Doc>", Doc).sizes).toEqual([1, 2]);
+	});
+
+	it("should validate item facets against each list item", () => {
+		@XmlRoot({ name: "Doc" })
+		class Doc {
+			@XmlElement({ list: { itemType: "number" }, maxInclusive: 10 })
+			sizes: number[] = [];
+		}
+
+		const serializer = new XmlDecoratorSerializer();
+		expect(() => serializer.fromXml("<Doc><sizes>5 20</sizes></Doc>", Doc)).toThrow(/greater than maxInclusive 10/);
+	});
+});

--- a/packages/xml-poto/tests/decorators/xsi-nil.test.ts
+++ b/packages/xml-poto/tests/decorators/xsi-nil.test.ts
@@ -1,0 +1,137 @@
+/* eslint-disable typescript/no-explicit-any, typescript/explicit-function-return-type -- Test file with dynamic mock data */
+import { describe, expect, it, vi } from "vitest";
+
+import { XmlDecoratorSerializer, XmlElement, XmlRoot } from "../../src";
+
+describe("xsi:nil round-trip", () => {
+	@XmlRoot({ name: "Record" })
+	class Record {
+		@XmlElement()
+		name: string = "";
+
+		@XmlElement({ isNullable: true })
+		value: string | null = null;
+	}
+
+	it("should serialize null to xsi:nil='true'", () => {
+		const serializer = new XmlDecoratorSerializer();
+		const record = new Record();
+		record.name = "test";
+		record.value = null;
+
+		const xml = serializer.toXml(record);
+		expect(xml).toContain(`xsi:nil="true"`);
+	});
+
+	it("should deserialize xsi:nil='true' back to null", () => {
+		const serializer = new XmlDecoratorSerializer();
+		const record = serializer.fromXml(
+			`<Record><name>test</name><value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></Record>`,
+			Record,
+		);
+		expect(record.name).toBe("test");
+		expect(record.value).toBeNull();
+	});
+
+	it("should round-trip null through serialize + deserialize", () => {
+		const serializer = new XmlDecoratorSerializer();
+		const record = new Record();
+		record.name = "roundtrip";
+		record.value = null;
+
+		const restored = serializer.fromXml(serializer.toXml(record), Record);
+		expect(restored.name).toBe("roundtrip");
+		expect(restored.value).toBeNull();
+	});
+
+	it("should handle custom xsi prefixes", () => {
+		const serializer = new XmlDecoratorSerializer();
+		const record = serializer.fromXml(
+			`<Record><name>x</name><value custom:nil="true" xmlns:custom="http://www.w3.org/2001/XMLSchema-instance"/></Record>`,
+			Record,
+		);
+		expect(record.value).toBeNull();
+	});
+
+	it("should not deserialize to null when isNullable is not set", () => {
+		@XmlRoot({ name: "Plain" })
+		class Plain {
+			@XmlElement()
+			value: string = "";
+		}
+
+		const serializer = new XmlDecoratorSerializer();
+		const plain = serializer.fromXml(
+			`<Plain><value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></Plain>`,
+			Plain,
+		);
+		expect(plain.value).not.toBeNull();
+	});
+
+	it("should not treat nil='false' as null", () => {
+		const serializer = new XmlDecoratorSerializer();
+		const record = serializer.fromXml(
+			`<Record><name>x</name><value xsi:nil="false" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">text</value></Record>`,
+			Record,
+		);
+		expect(record.value).not.toBeNull();
+	});
+});
+
+describe("array minOccurs/maxOccurs", () => {
+	it("should enforce occurs bounds on arrays", async () => {
+		const { XmlArray } = await import("../../src");
+
+		@XmlRoot({ name: "Order" })
+		class Order {
+			@XmlArray({ itemName: "Item", minOccurs: 1, maxOccurs: 2 })
+			items: string[] = [];
+		}
+
+		const serializer = new XmlDecoratorSerializer();
+
+		expect(() => serializer.fromXml("<Order><Item>a</Item><Item>b</Item><Item>c</Item></Order>", Order)).toThrow(
+			/maxOccurs is 2/,
+		);
+
+		const order = serializer.fromXml("<Order><Item>a</Item></Order>", Order);
+		expect(order.items).toEqual(["a"]);
+
+		const tooMany = new Order();
+		tooMany.items = ["a", "b", "c"];
+		expect(() => serializer.toXml(tooMany)).toThrow(/maxOccurs is 2/);
+
+		const tooFew = new Order();
+		tooFew.items = [];
+		expect(() => serializer.toXml(tooFew)).toThrow(/minOccurs is 1/);
+	});
+
+	it("should tune minOccurs and maxOccurs independently via validationModeOverrides", async () => {
+		const { XmlArray } = await import("../../src");
+
+		@XmlRoot({ name: "Order" })
+		class Order {
+			@XmlArray({ itemName: "Item", minOccurs: 1, maxOccurs: 2 })
+			items: string[] = [];
+		}
+
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const serializer = new XmlDecoratorSerializer({
+				validationModeOverrides: { maxOccurs: "warn" },
+			});
+
+			// maxOccurs violation only warns
+			const order = serializer.fromXml("<Order><Item>a</Item><Item>b</Item><Item>c</Item></Order>", Order);
+			expect(order.items).toEqual(["a", "b", "c"]);
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("maxOccurs is 2"));
+
+			// minOccurs stays strict
+			const tooFew = new Order();
+			tooFew.items = [];
+			expect(() => serializer.toXml(tooFew)).toThrow(/minOccurs is 1/);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+});

--- a/packages/xml-poto/vitest.config.ts
+++ b/packages/xml-poto/vitest.config.ts
@@ -1,8 +1,41 @@
 import path from "node:path";
 
+import { transform } from "esbuild";
+import type { Plugin } from "vite";
 import { defineConfig } from "vitest/config";
 
+/**
+ * Vitest 4.1+ ships rolldown-vite, which transpiles TypeScript with oxc.
+ * Oxc only lowers legacy (experimentalDecorators) decorators; TC39 stage-3
+ * decorator syntax passes through untouched and crashes Node.js with
+ * "SyntaxError: Invalid or unexpected token". Transpile .ts modules with
+ * esbuild instead, which fully lowers stage-3 decorators.
+ * Remove once oxc supports the decorators proposal transform.
+ */
+function esbuildStage3Decorators(): Plugin {
+	return {
+		name: "esbuild-stage3-decorators",
+		enforce: "pre",
+		async transform(code, id) {
+			const filePath = id.split("?")[0];
+			if (!filePath.endsWith(".ts") || filePath.endsWith(".d.ts")) {
+				return null;
+			}
+			const result = await transform(code, {
+				loader: "ts",
+				target: "es2022",
+				// Match tsc class-field semantics for tsconfig target es2019
+				tsconfigRaw: { compilerOptions: { useDefineForClassFields: false } },
+				sourcefile: filePath,
+				sourcemap: true,
+			});
+			return { code: result.code, map: result.map };
+		},
+	};
+}
+
 export default defineConfig({
+	plugins: [esbuildStage3Decorators()],
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
WSDL support, XSD facet validation, and dependency-ordered codegen
This PR adds WSDL input support and full XSD facet coverage across both packages, plus fixes for generated code that previously failed to compile.

@cerios/xml-poto (minor)
XSD validation

Facet options on @XmlElement, @XmlAttribute, @XmlText, and @XmlArray: pattern, enumValues, length, min/maxLength, min/maxInclusive, min/maxExclusive, totalDigits, fractionDigits, whiteSpace, and fixedValue — validated on both serialization and deserialization.
New unified validationMode serializer option ("strict" | "warn" | "off", default "strict"), with per-rule tuning via validationModeOverrides (e.g. { pattern: "warn", fixedValue: "off" }). Existing behavior is unchanged by default.
xs:list support (list option): arrays round-trip as space-separated text, with optional typed items.
xs:choice enforcement via choiceGroup / choiceRequired; minOccurs/maxOccurs item-count validation on @XmlArray.
xsi:nil="true" now deserializes back to null for isNullable elements; dataType now coerces optional primitives; fixedValue doubles as a default when absent.
Lazy type references

The type option now also accepts a () => Constructor thunk (TypeRef), making forward, circular, and self references safe — plain { type: Section } throws a ReferenceError (temporal dead zone) with standard TC39 decorators when the class isn't defined yet. Resolution is lazy with write-back caching; plain constructors are unchanged.
@cerios/xml-poto-codegen (minor)
WSDL input & complete facet emission

Files with a <definitions> root are detected automatically; all XSD schemas embedded in <types> are extracted and merged (fixes "No XSD schema root element found" for WSDL documents).
All the facets above are now emitted as decorator options instead of "not enforced" warnings; xs:list, xs:choice groups, bounded maxOccurs, and xs:annotation → JSDoc are covered, along with complexContent restrictions, xs:all, xs:redefine, prohibited attributes, and explicit warnings for remote/missing schemaLocation.
Dependency-ordered output (compile fix)

Classes are emitted in topological order (based on extends and type: references), fixing class X used before its declaration errors and runtime TDZ crashes for schemas that declare types alphabetically. Ordering is stable: valid schemas produce unchanged output.
Circular/self references are emitted as lazy () => Foo thunks; in per-type mode, cyclically extends-linked classes are merged into one file.
Also fixes mis-typed enum initializers (now definite-assignment assertions) and duplicate properties from elements appearing in multiple choice branches.

Compatibility: @cerios/xml-poto-codegen requires the @cerios/xml-poto release from this PR (new validation options and TypeRef). Defaults are backward compatible.