### PR TITLE
better naming for anonymous inline types

### DIFF
--- a/.changeset/anonymous-inline-type-naming.md
+++ b/.changeset/anonymous-inline-type-naming.md
@@ -1,0 +1,19 @@
+---
+"@cerios/xml-poto-codegen": minor
+---
+
+Name an anonymous inline complexType after the type that declares it when its own
+name is taken, and mark it anonymous.
+
+`<element name="Foo">` with an inline complexType wants the class name `FooType`,
+which collides with the named complexType `FooType` under the convention most
+schemas follow. The loser used to become `FooType2`, a name that says nothing about
+which of the two it is. It is now named after where it was declared —
+`TijdvakCorrectieCollectieveAangifte` rather than `CollectieveAangifteType2` — and
+the coverage note explains the anonymous case in its own terms. Only names that
+actually collide change; an inline type with its preferred name free keeps it, as
+does a collision between two _named_ types, which has no declaring type to borrow.
+
+Inline complexTypes are now emitted as `@XmlType({ anonymous: true })`, so they no
+longer claim a schema type identity the XSD never declared. This requires
+`@cerios/xml-poto` 2.6.0 or later.

--- a/.changeset/anonymous-xml-type.md
+++ b/.changeset/anonymous-xml-type.md
@@ -1,0 +1,14 @@
+---
+"@cerios/xml-poto": minor
+---
+
+Add `anonymous` to `@XmlType`, mirroring C# `[XmlType(AnonymousType=true)]`.
+
+An XSD complexType declared inline on an element has no type name of its own, so
+the only `name` a class can carry for it is the _element's_. Registering that name
+let such a class answer lookups meant for whatever type the schema really names
+there — resolving an `xsi:type="prefix:Local"` that names no schema type, and
+claiming the element name in the auto-discovery registry, which is last-writer-wins.
+
+`@XmlType({ anonymous: true })` keeps the name/namespace as the members' fallback
+but leaves the class out of both name-keyed registries. Default is unchanged.

--- a/packages/xml-poto-codegen/src/generator/decorator-mapper.ts
+++ b/packages/xml-poto-codegen/src/generator/decorator-mapper.ts
@@ -16,9 +16,12 @@ const CLASS_INDENT_LEVEL = 0;
  * definition (schema type identity, not a global element declaration), so it gets
  * `@XmlType` — this lets the serializer treat the type's namespace as a fallback
  * that qualifies referencing elements and declare it once, instead of emitting a
- * redundant namespace declaration on every nested object. When `useXmlRoot` is
- * false the model is flattened to class-level `@XmlElement` everywhere (the caller
- * opted out of the root/type distinction).
+ * redundant namespace declaration on every nested object. A complexType declared
+ * inline on an element is a type definition too, but an anonymous one: it gets
+ * `@XmlType({ anonymous: true })`, which keeps the namespace fallback but withholds
+ * the schema type identity it does not have. When `useXmlRoot` is false the model is
+ * flattened to class-level `@XmlElement` everywhere (the caller opted out of the
+ * root/type distinction).
  */
 export function mapClassDecorator(type: ResolvedType, useXmlRoot = true): string {
 	if (type.isRootElement) {
@@ -41,6 +44,13 @@ export function mapClassDecorator(type: ResolvedType, useXmlRoot = true): string
 	}
 
 	if (useXmlRoot) {
+		// A complexType declared inline on an element names no schema type, so it must
+		// not answer lookups for the element name it happens to carry. Only @XmlType
+		// takes this option — the flattened @XmlElement form below declares an element,
+		// where the question does not arise.
+		if (type.isAnonymousType) {
+			opts.anonymous = true;
+		}
 		return buildDecorator("XmlType", opts, CLASS_INDENT_LEVEL);
 	}
 

--- a/packages/xml-poto-codegen/src/xsd/xsd-resolver.ts
+++ b/packages/xml-poto-codegen/src/xsd/xsd-resolver.ts
@@ -53,6 +53,12 @@ export interface ResolvedType {
 	derivedTypeNames?: string[];
 	/** Whether this is a root element (gets @XmlRoot instead of @XmlElement) */
 	isRootElement: boolean;
+	/**
+	 * Whether the complexType was declared inline on an element rather than named at
+	 * the top level. Such a type has no schema type identity, so its `@XmlType` is
+	 * emitted with `anonymous: true` and stays out of the runtime's name registries.
+	 */
+	isAnonymousType?: boolean;
 	/** mixed content model */
 	mixed?: boolean;
 	/** Namespace info */
@@ -307,6 +313,16 @@ interface ResolvedAttributeGroup {
 	anyAttribute?: boolean;
 }
 
+/**
+ * Second-choice class name for an anonymous type whose preferred one is taken,
+ * plus the element it was declared on so the coverage note can name it (see
+ * claimClassName).
+ */
+interface AnonymousNameFallback {
+	className: string;
+	elementName: string;
+}
+
 /** Decimal digits a JavaScript number represents exactly (Number.MAX_SAFE_INTEGER has 16). */
 const SAFE_INTEGER_DIGITS = 15;
 
@@ -364,6 +380,13 @@ export class XsdResolver {
 	private activeTargetNamespace?: string;
 	private activeElementFormDefault?: "qualified" | "unqualified";
 	private activeAttributeFormDefault?: "qualified" | "unqualified";
+	/**
+	 * Class name of the type currently being resolved, so an anonymous type declared
+	 * on one of its elements can be named after where it lives when its own preferred
+	 * name is taken (see resolveElementTypeInfo). Scoped like the namespace fields
+	 * above, which keeps it correct for an anonymous type nested inside another.
+	 */
+	private activeOwnerClassName?: string;
 
 	resolve(schema: XsdSchema): ResolvedSchema {
 		this.schema = schema;
@@ -551,12 +574,17 @@ export class XsdResolver {
 	 * and two elements in different parents may each carry an inline complexType of
 	 * the same name. Both used to collapse onto one class, silently giving every
 	 * reference to the second the content model of the first. Colliding names are
-	 * now suffixed and reported instead.
+	 * now disambiguated and reported instead.
+	 *
+	 * `fallback` is a second choice to try before resorting to a numeric suffix. An
+	 * anonymous type passes the name of where it was declared (see
+	 * resolveElementTypeInfo), which says far more than a trailing '2'; a named type
+	 * has no such context and passes nothing.
 	 *
 	 * Claims are keyed by object identity, so asking twice for the same type is
 	 * idempotent.
 	 */
-	private claimClassName(preferred: string, ct: XsdComplexType): string {
+	private claimClassName(preferred: string, ct: XsdComplexType, fallback?: AnonymousNameFallback): string {
 		const existing = this.classNameByType.get(ct);
 		if (existing) return existing;
 
@@ -577,9 +605,23 @@ export class XsdResolver {
 			return preferred;
 		}
 
+		if (fallback && fallback.className !== preferred && !this.takenClassNames.has(fallback.className)) {
+			this.coverageNotes.push(
+				`The inline complexType on element '${fallback.elementName}' maps to the class name ` +
+					`'${preferred}', already used by another complex type; it was generated as ` +
+					`'${fallback.className}', after the type that declares it. Being anonymous, it is not ` +
+					`referenced by name anywhere.`,
+			);
+
+			this.takenClassNames.add(fallback.className);
+			this.classNameByType.set(ct, fallback.className);
+			return fallback.className;
+		}
+
+		const base = fallback?.className ?? preferred;
 		let suffix = 2;
-		while (this.takenClassNames.has(`${preferred}${suffix}`)) suffix++;
-		const claimed = `${preferred}${suffix}`;
+		while (this.takenClassNames.has(`${base}${suffix}`)) suffix++;
+		const claimed = `${base}${suffix}`;
 
 		this.coverageNotes.push(
 			`Two distinct complex types both map to the class name '${preferred}'` +
@@ -701,17 +743,21 @@ export class XsdResolver {
 		const savedNamespace = this.activeTargetNamespace;
 		const savedElementForm = this.activeElementFormDefault;
 		const savedAttributeForm = this.activeAttributeFormDefault;
+		const savedOwner = this.activeOwnerClassName;
 		if (ct.sourceNamespace !== undefined) {
 			this.activeTargetNamespace = ct.sourceNamespace;
 			this.activeElementFormDefault = ct.sourceElementFormDefault;
 			this.activeAttributeFormDefault = ct.sourceAttributeFormDefault;
 		}
+		// Mirrors the class name resolveComplexTypeInScope is about to settle on.
+		this.activeOwnerClassName = classNameOverride ?? toPascalCase(name);
 		try {
 			return this.resolveComplexTypeInScope(ct, name, isRoot, classNameOverride);
 		} finally {
 			this.activeTargetNamespace = savedNamespace;
 			this.activeElementFormDefault = savedElementForm;
 			this.activeAttributeFormDefault = savedAttributeForm;
+			this.activeOwnerClassName = savedOwner;
 		}
 	}
 
@@ -1444,9 +1490,16 @@ export class XsdResolver {
 	/** Resolve the type information for an element declaration */
 	private resolveElementTypeInfo(el: XsdElement, name: string): ResolvedTypeInfo {
 		if (el.complexType) {
-			// Inline complex type — will need to generate a class for it
-			const inlineTypeName = this.claimClassName(toPascalCase(name) + "Type", el.complexType);
-			this.addResolvedType(this.resolveComplexType(el.complexType, name, false, inlineTypeName));
+			// Inline complex type — will need to generate a class for it. `<Element>Type`
+			// is the natural name but collides with the named type `<Element>Type` under
+			// the convention most schemas follow, so where the type was declared is the
+			// fallback: 'TijdvakCorrectieCollectieveAangifte' over 'CollectieveAangifteType2'.
+			const local = toPascalCase(name);
+			const inlineTypeName = this.claimClassName(local + "Type", el.complexType, this.anonymousFallback(local, name));
+			const inlineType = this.resolveComplexType(el.complexType, name, false, inlineTypeName);
+			// The type is declared inline, so it has no schema type identity to claim.
+			inlineType.isAnonymousType = true;
+			this.addResolvedType(inlineType);
 			return {
 				tsType: inlineTypeName,
 				initializer: this.initializerFor(inlineTypeName, el.complexType.abstract),
@@ -1462,6 +1515,21 @@ export class XsdResolver {
 		}
 		// No type means xs:anyType
 		return { tsType: "string", initializer: "''" };
+	}
+
+	/**
+	 * Name an anonymous type after the type that declares it, for when its own
+	 * preferred name is taken. The owner's trailing 'Type' is dropped so the result
+	 * reads as a path rather than stuttering: TijdvakCorrectieType + CollectieveAangifte
+	 * → TijdvakCorrectieCollectieveAangifte.
+	 *
+	 * Returns undefined at the top level, where there is no declaring type to name.
+	 */
+	private anonymousFallback(pascalName: string, elementName: string): AnonymousNameFallback | undefined {
+		const owner = this.activeOwnerClassName;
+		if (!owner) return undefined;
+		const ownerStem = owner.length > "Type".length && owner.endsWith("Type") ? owner.slice(0, -"Type".length) : owner;
+		return { className: ownerStem + pascalName, elementName };
 	}
 
 	/** Populate array-specific fields (item name/type and occurs bounds) */

--- a/packages/xml-poto-codegen/tests/generator/decorator-mapper.test.ts
+++ b/packages/xml-poto-codegen/tests/generator/decorator-mapper.test.ts
@@ -103,6 +103,43 @@ describe("DecoratorMapper", () => {
 			expect(result).toContain("form: 'qualified'");
 		});
 
+		it("should mark an inline complexType's @XmlType anonymous", () => {
+			const type: ResolvedType = {
+				className: "TijdvakCorrectieCollectieveAangifte",
+				xmlName: "CollectieveAangifte",
+				properties: [],
+				isRootElement: false,
+				isAnonymousType: true,
+			};
+
+			const result = mapClassDecorator(type);
+			expect(result).toContain("@XmlType");
+			expect(result).toContain("anonymous: true");
+		});
+
+		it("should not mark a named complexType's @XmlType anonymous", () => {
+			const type: ResolvedType = {
+				className: "AddressType",
+				xmlName: "AddressType",
+				properties: [],
+				isRootElement: false,
+			};
+
+			expect(mapClassDecorator(type)).not.toContain("anonymous");
+		});
+
+		it("should not pass anonymous to the flat @XmlElement form, which takes no such option", () => {
+			const type: ResolvedType = {
+				className: "TijdvakCorrectieCollectieveAangifte",
+				xmlName: "CollectieveAangifte",
+				properties: [],
+				isRootElement: false,
+				isAnonymousType: true,
+			};
+
+			expect(mapClassDecorator(type, false)).not.toContain("anonymous");
+		});
+
 		it("should include isNullable in flat @XmlElement when rootNillable is set and useXmlRoot is false", () => {
 			const type: ResolvedType = {
 				className: "Order",

--- a/packages/xml-poto-codegen/tests/integration/reference-resolution.test.ts
+++ b/packages/xml-poto-codegen/tests/integration/reference-resolution.test.ts
@@ -145,15 +145,49 @@ describe("class name collisions", () => {
 		expect(resolved.coverageNotes?.join("\n")).toContain("ShippingType");
 	});
 
+	it("names the loser of an inline collision after the type that declares it", () => {
+		const resolved = resolveInline(`
+			<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+				<xs:element name="Order">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Shipping">
+								<xs:complexType>
+									<xs:sequence><xs:element name="Street" type="xs:string"/></xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Invoice">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Shipping">
+								<xs:complexType>
+									<xs:sequence><xs:element name="Carrier" type="xs:string"/></xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:schema>`);
+
+		// The first claims ShippingType; the second says where it came from rather
+		// than carrying a bare 'ShippingType2'.
+		expect(resolved.types.map((t) => t.className)).toContain("InvoiceShipping");
+		expect(resolved.types.map((t) => t.className)).not.toContain("ShippingType2");
+	});
+
 	it("keeps an inline type apart from the named type it shadows (real UPA schema)", () => {
 		// upa_2026_request.xsd declares complexType CollectieveAangifteType with two
 		// members, and separately an element CollectieveAangifte whose inline type has
-		// only one. Both map to the name 'CollectieveAangifteType': the inline one used
-		// to be dropped, leaving that element typed with a member the schema forbids there.
+		// only one. Both want the name 'CollectieveAangifteType': the inline one used
+		// to be dropped, leaving that element typed with a member the schema forbids
+		// there. It is now named after TijdvakCorrectieType, which declares it.
 		const resolved = resolveFixture("upa_2026_request.xsd");
 
 		const named = typeNamed(resolved, "CollectieveAangifteType");
-		const inline = typeNamed(resolved, "CollectieveAangifteType2");
+		const inline = typeNamed(resolved, "TijdvakCorrectieCollectieveAangifte");
 
 		expect(named.properties.map((p) => p.propertyName)).toEqual([
 			"totaalRegelingen",
@@ -161,6 +195,41 @@ describe("class name collisions", () => {
 		]);
 		expect(inline.properties.map((p) => p.propertyName)).toEqual(["totaalRegelingen"]);
 		expect(resolved.coverageNotes?.join("\n")).toContain("CollectieveAangifteType");
+	});
+
+	it("leaves an inline type that collides with nothing under its natural name", () => {
+		// Only the colliding name changes: TijdvakAangifte's inline type has the field
+		// to itself and stays TijdvakAangifteType.
+		const resolved = resolveFixture("upa_2026_request.xsd");
+
+		expect(resolved.types.map((t) => t.className)).toContain("TijdvakAangifteType");
+	});
+
+	it("still falls back to a numeric suffix when the declaring type's name is taken too", () => {
+		const resolved = resolveInline(`
+			<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+				<xs:complexType name="ShippingType">
+					<xs:sequence><xs:element name="Street" type="xs:string"/></xs:sequence>
+				</xs:complexType>
+				<xs:complexType name="OrderShipping">
+					<xs:sequence><xs:element name="Carrier" type="xs:string"/></xs:sequence>
+				</xs:complexType>
+				<xs:element name="Order">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Shipping">
+								<xs:complexType>
+									<xs:sequence><xs:element name="Tracking" type="xs:string"/></xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:schema>`);
+
+		const inline = typeNamed(resolved, "OrderShipping2");
+
+		expect(inline.properties.map((p) => p.propertyName)).toEqual(["tracking"]);
 	});
 
 	it("does not split an xs:redefine pair, whose shared name is intentional", () => {

--- a/packages/xml-poto-codegen/tests/integration/upa-roundtrip.test.ts
+++ b/packages/xml-poto-codegen/tests/integration/upa-roundtrip.test.ts
@@ -135,6 +135,60 @@ describe("UPA 2026 round trip", () => {
 		});
 	});
 
+	// ── anonymous inline complexTypes ──────────────────────────────────────────
+
+	describe("an inline complexType shadowing a named one", () => {
+		// TijdvakCorrectieType declares <CollectieveAangifte> with an inline type of its
+		// own, narrower than the named CollectieveAangifteType the rest of the schema
+		// uses. Both want the class name 'CollectieveAangifteType'.
+		it("names the inline type after the type that declares it", () => {
+			const files = new ClassGenerator({ xsdPath: UPA }).generatePerType(resolveUpa());
+
+			expect(files.map((f) => f.fileName)).toContain("tijdvak-correctie-collectieve-aangifte.ts");
+			expect(files.map((f) => f.fileName)).not.toContain("collectieve-aangifte-type2.ts");
+		});
+
+		it("declares the inline type anonymous, so it claims no schema type identity", () => {
+			const files = new ClassGenerator({ xsdPath: UPA }).generatePerType(resolveUpa());
+			const inline = files.find((f) => f.fileName === "tijdvak-correctie-collectieve-aangifte.ts")!;
+			const named = files.find((f) => f.fileName === "collectieve-aangifte-type.ts")!;
+
+			expect(inline.content).toContain("anonymous: true");
+			// The named type does name a schema type, and keeps its identity.
+			expect(named.content).toContain("name: 'CollectieveAangifteType'");
+			expect(named.content).not.toContain("anonymous");
+		});
+
+		it("keeps each <CollectieveAangifte> on its own content model", async () => {
+			generateUpa(tempDir);
+			const PensioenAangifte = await load(tempDir, "pensioen-aangifte", "PensioenAangifte");
+
+			// SaldoCorrectiesVoorgaandAangifteTijdvak exists only on the named type, which
+			// VolledigeAangifte uses — the inline one under TijdvakCorrectie forbids it.
+			const xml =
+				`<upa:PensioenAangifte xmlns:upa="${NS}" Version="1.0">${berichtXml()}` +
+				`<upa:AdministratieveEenheid><upa:LhNr>123456789L01</upa:LhNr>` +
+				`<upa:NmIP>Werkgever BV</upa:NmIP><upa:TvkCd>MND</upa:TvkCd>` +
+				`<upa:TijdvakAangifte><upa:DatAanvTv>2026-01-01</upa:DatAanvTv>` +
+				`<upa:DatEindTv>2026-01-31</upa:DatEindTv>` +
+				`<upa:VolledigeAangifte><upa:CollectieveAangifte>` +
+				`<upa:SaldoCorrectiesVoorgaandAangifteTijdvak><upa:DatAanvTv>2026-01-01</upa:DatAanvTv>` +
+				`<upa:DatEindTv>2026-01-31</upa:DatEindTv></upa:SaldoCorrectiesVoorgaandAangifteTijdvak>` +
+				`</upa:CollectieveAangifte></upa:VolledigeAangifte>` +
+				`</upa:TijdvakAangifte><upa:TijdvakCorrectie><upa:DatAanvTv>2026-02-01</upa:DatAanvTv>` +
+				`<upa:DatEindTv>2026-02-28</upa:DatEindTv><upa:CollectieveAangifte/></upa:TijdvakCorrectie>` +
+				`</upa:AdministratieveEenheid></upa:PensioenAangifte>`;
+
+			const parsed = serializer.fromXml(xml, PensioenAangifte);
+			const volledige = parsed.administratieveEenheid.tijdvakAangifte.volledigeAangifte;
+			const correctie = parsed.administratieveEenheid.tijdvakCorrectie[0];
+
+			expect(volledige.collectieveAangifte.saldoCorrectiesVoorgaandAangifteTijdvak).toHaveLength(1);
+			// The inline type has no such member to be filled in from anywhere.
+			expect(correctie.collectieveAangifte.saldoCorrectiesVoorgaandAangifteTijdvak).toBeUndefined();
+		});
+	});
+
 	// ── named enum vocabularies ────────────────────────────────────────────────
 
 	describe("named enum simpleTypes", () => {

--- a/packages/xml-poto/docs/core-concepts.md
+++ b/packages/xml-poto/docs/core-concepts.md
@@ -213,10 +213,20 @@ interface XmlTypeOptions {
 	namespace?: XmlNamespace; // Primary namespace (URI and optional prefix)
 	namespaces?: XmlNamespace[]; // Additional namespaces to declare
 	form?: "qualified" | "unqualified"; // Namespace form for the type's members
+	anonymous?: boolean; // The type is declared inline on an element, not named
 }
 ```
 
 `@XmlType` does **not** qualify local child elements on its own — that is decided by each member's `form`. See [Type Identity with @XmlType](features/namespaces.md#type-identity-with-xmltype).
+
+**Anonymous types.** An XSD complexType written inline on an element has no type name of its own, so the best `name` available is the element's. `anonymous: true` — mirroring C# `[XmlType(AnonymousType=true)]` — keeps that name and namespace as the members' fallback but leaves the class out of the name-keyed registries: it never resolves an `xsi:type="prefix:Local"` and never claims the element name during auto-discovery, both of which belong to whatever type the schema really names there. Codegen sets it automatically for inline complexTypes.
+
+```typescript
+@XmlType({ name: "CollectieveAangifte", anonymous: true, namespace: { uri: "…", prefix: "upa" } })
+class TijdvakCorrectieCollectieveAangifte {
+	// ...
+}
+```
 
 ### @XmlInclude
 

--- a/packages/xml-poto/src/decorators/types/options.ts
+++ b/packages/xml-poto/src/decorators/types/options.ts
@@ -240,6 +240,18 @@ export interface XmlTypeOptions {
 	namespaces?: XmlNamespace[];
 	/** Namespace form for the type's members */
 	form?: "qualified" | "unqualified";
+	/**
+	 * The class stands for an XSD *anonymous* type — one declared inline on an
+	 * element rather than as a named schema type — mirroring C#
+	 * `[XmlType(AnonymousType=true)]`.
+	 *
+	 * Such a type has no schema type identity of its own, so it is left out of the
+	 * name-keyed registries: it never resolves an `xsi:type="prefix:Local"` and never
+	 * claims the element name during auto-discovery. Its `name`/`namespace` still
+	 * serve as the usual fallback for members pointing at it and for the root element
+	 * when it is serialized directly.
+	 */
+	anonymous?: boolean;
 }
 
 /**

--- a/packages/xml-poto/src/decorators/xml-type.ts
+++ b/packages/xml-poto/src/decorators/xml-type.ts
@@ -28,7 +28,10 @@ import { processPendingAttributes, processPendingFieldElements, processPendingQu
  *   `XmlSerializer` derives root defaults from `[XmlType]`).
  *
  * Codegen emits `@XmlType` for XSD complex types (which are type definitions, not
- * global element declarations), reserving `@XmlRoot` for global/root elements.
+ * global element declarations), reserving `@XmlRoot` for global/root elements. A
+ * complexType declared inline on an element is emitted with `anonymous: true`,
+ * which keeps the name/namespace fallback but withholds the schema type identity
+ * such a type does not have (see {@link XmlTypeOptions.anonymous}).
  *
  * @param options Type identity configuration
  * @returns A class decorator that stores type-identity metadata
@@ -70,16 +73,24 @@ export function XmlType(
 		// Store as class-level type-identity metadata (fallback, not a wrapper)
 		getMetadata(target).xmlType = typeMetadata;
 
-		// Register for auto-discovery during deserialization, matching class @XmlElement
-		const prefix = typeMetadata.namespaces?.[0]?.prefix;
-		const fullName = prefix ? `${prefix}:${typeMetadata.name}` : typeMetadata.name;
-		registerElementClass(fullName, target);
+		// Always safe: keyed by the class binding's own (unique) name, not by a schema name.
 		registerConstructorByName(target.name, target);
 
-		// Register the schema-qualified type name so xsi:type="prefix:Local" resolves to
-		// this class during polymorphic deserialization (keyed by namespace URI).
-		const uri = typeMetadata.namespaces?.[0]?.uri;
-		if (uri) registerTypeByQualifiedName(uri, typeMetadata.name, target);
+		// An anonymous type has no schema type identity, so it stays out of both
+		// name-keyed registries: its `name` is the name of the element it was declared
+		// under, and claiming that would let it answer lookups meant for whatever type
+		// the schema really names there.
+		if (!options.anonymous) {
+			// Register for auto-discovery during deserialization, matching class @XmlElement
+			const prefix = typeMetadata.namespaces?.[0]?.prefix;
+			const fullName = prefix ? `${prefix}:${typeMetadata.name}` : typeMetadata.name;
+			registerElementClass(fullName, target);
+
+			// Register the schema-qualified type name so xsi:type="prefix:Local" resolves to
+			// this class during polymorphic deserialization (keyed by namespace URI).
+			const uri = typeMetadata.namespaces?.[0]?.uri;
+			if (uri) registerTypeByQualifiedName(uri, typeMetadata.name, target);
+		}
 
 		// Flush metadata collected during field decoration
 		processPendingAttributes(context, target);

--- a/packages/xml-poto/tests/decorators/xml-type.test.ts
+++ b/packages/xml-poto/tests/decorators/xml-type.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { XmlDecoratorSerializer } from "../../src";
 import { getMetadata } from "../../src/decorators/storage";
+import { findElementClass, findTypeByQualifiedName } from "../../src/decorators/storage/metadata-storage";
 import { XmlElement } from "../../src/decorators/xml-element";
 import { XmlType } from "../../src/decorators/xml-type";
 
@@ -76,5 +77,69 @@ describe("@XmlType decorator", () => {
 		// form: 'qualified' says "qualify me"; the type supplies the URI/prefix,
 		// mirroring what xsd.exe emits for elementFormDefault="qualified".
 		expect(xml).toContain("<p:name>John</p:name>");
+	});
+
+	// An XSD complexType declared inline on an element has no type name of its own.
+	// Codegen still needs the class-level namespace fallback, but the `name` it can
+	// supply is the *element's* — so the class must not answer lookups under it.
+	describe("anonymous: true", () => {
+		it("should keep the name/namespace metadata, which stays the members' fallback", () => {
+			@XmlType({ name: "Shipping", anonymous: true, namespace: { uri: NS, prefix: "p" } })
+			class OrderShipping {
+				@XmlElement({ name: "carrier", form: "qualified" })
+				carrier!: string;
+			}
+
+			expect(getMetadata(OrderShipping).xmlType?.name).toBe("Shipping");
+
+			const shipping = new OrderShipping();
+			shipping.carrier = "PostNL";
+
+			const xml = serializer.toXml(shipping);
+			expect(xml).toContain("<p:Shipping");
+			expect(xml).toContain("<p:carrier>PostNL</p:carrier>");
+		});
+
+		it("should not register the element name for auto-discovery", () => {
+			@XmlType({ name: "Tracking", anonymous: true, namespace: { uri: NS, prefix: "p" } })
+			class OrderTracking {
+				@XmlElement({ name: "code" })
+				code!: string;
+			}
+
+			expect(OrderTracking).toBeDefined();
+			expect(findElementClass("p:Tracking")).toBeUndefined();
+		});
+
+		it("should not resolve an xsi:type naming it", () => {
+			@XmlType({ name: "Handling", anonymous: true, namespace: { uri: NS, prefix: "p" } })
+			class OrderHandling {
+				@XmlElement({ name: "code" })
+				code!: string;
+			}
+
+			expect(OrderHandling).toBeDefined();
+			expect(findTypeByQualifiedName(NS, "Handling")).toBeUndefined();
+		});
+
+		it("should leave a named type of the same name in possession of both registries", () => {
+			@XmlType({ name: "Delivery", namespace: { uri: NS, prefix: "p" } })
+			class DeliveryType {
+				@XmlElement({ name: "eta" })
+				eta!: string;
+			}
+
+			// Declared second: without the guard this would overwrite the entry above,
+			// since registerElementClass is last-writer-wins.
+			@XmlType({ name: "Delivery", anonymous: true, namespace: { uri: NS, prefix: "p" } })
+			class OrderDelivery {
+				@XmlElement({ name: "slot" })
+				slot!: string;
+			}
+
+			expect(OrderDelivery).toBeDefined();
+			expect(findElementClass("p:Delivery")).toBe(DeliveryType);
+			expect(findTypeByQualifiedName(NS, "Delivery")).toBe(DeliveryType);
+		});
 	});
 });


### PR DESCRIPTION
What was happening
Two genuinely different content models both wanted the class name CollectieveAangifteType: the global <complexType name="CollectieveAangifteType">, and an anonymous inline <complexType> on the local element CollectieveAangifte inside TijdvakCorrectieType. The resolver names inline types PascalCase(element) + "Type", which under the FooType convention collides by construction, and the loser got a bare …Type2. Its @XmlType name came from the element, so it claimed a schema type the XSD never declares.

What changed
Naming ([xsd-resolver.ts](vscode-webview://0fnlceoq61hgto8hjde280ohfc90c7mlluhpu9sb1umekhiiuagk/packages/xml-poto-codegen/src/xsd/xsd-resolver.ts)) — claimClassName takes an optional fallback; an anonymous type passes the type that declares it, tracked in a new activeOwnerClassName scoped with the same save/restore pattern the namespace fields already use, so nesting stays correct. CollectieveAangifteType2 → TijdvakCorrectieCollectieveAangifte, and the coverage note now explains the anonymous case in its own terms instead of talking about name references that cannot exist.

Only colliding names change. TijdvakAangifteType and SaldoCorrectiesRegelingenType are untouched, as is the numeric suffix for two named types (nothing to borrow a name from) — the pre-existing UPA round-trip tests passed unmodified, which is the evidence for that.

Type identity — new anonymous?: boolean on XmlTypeOptions, mirroring [XmlType(AnonymousType=true)]. It keeps xmlType metadata (the namespace fallback is load-bearing for elementFormDefault="qualified") but skips registerElementClass and registerTypeByQualifiedName. Codegen sets it for every inline complexType. That closes the squat on the global element registry — worth noting it is last-writer-wins with no first-wins guard, unlike its two sibling registries, so the anonymous class was displacing whatever upa:CollectieveAangifte had been registered before it.