### PR TITLE
Deprecate `useXmlRoot`; it is removed in the next major.

### DIFF
--- a/.changeset/deprecate-use-xml-root.md
+++ b/.changeset/deprecate-use-xml-root.md
@@ -1,0 +1,14 @@
+---
+"@cerios/xml-poto-codegen": minor
+---
+
+Deprecate `useXmlRoot`; it is removed in the next major.
+
+The option exists so a schema subset can be embedded in a document it does not own,
+rather than standing alone as a root. Nothing needs it any more: `SoapSerializer` wraps
+and unwraps `Envelope`/`Body` around an `@XmlRoot` payload, and an `@XmlRoot` class embeds
+fine as a member type — the referencing `@XmlElement({ name })` decides the tag.
+
+Behaviour is unchanged: `useXmlRoot: false` still flattens the model to class-level
+`@XmlElement` everywhere. Setting the option at all, to either value, now prints a
+deprecation warning during generation.

--- a/packages/xml-poto-codegen/README.md
+++ b/packages/xml-poto-codegen/README.md
@@ -181,15 +181,15 @@ export default config;
 
 ### Global options
 
-| Option                  | Type                                       | Description                                                                     |
-| ----------------------- | ------------------------------------------ | ------------------------------------------------------------------------------- |
-| `sources`               | `XsdSource[]`                              | Array of XSD sources to process                                                 |
-| `defaultOutputStyle`    | `'per-type' \| 'per-xsd'`                  | Default output style for all sources (default: `'per-type'`)                    |
-| `enumStyle`             | `'union' \| 'enum' \| 'const-object'`      | Default enum generation style (default: `'union'`)                              |
-| `useXmlRoot`            | `boolean`                                  | Emit `@XmlRoot` for root elements; `@XmlElement` when `false` (default: `true`) |
-| `elementForm`           | `'schema' \| 'qualified' \| 'unqualified'` | How local elements are namespace-qualified (default: `'schema'`)                |
-| `bigIntegerAs`          | `'number' \| 'string'`                     | How over-wide integer types are generated (default: `'number'`)                 |
-| `requiredPropertyStyle` | `'schema' \| 'definite' \| 'initialized'`  | How required properties are declared (default: `'schema'`)                      |
+| Option                  | Type                                       | Description                                                           |
+| ----------------------- | ------------------------------------------ | --------------------------------------------------------------------- |
+| `sources`               | `XsdSource[]`                              | Array of XSD sources to process                                       |
+| `defaultOutputStyle`    | `'per-type' \| 'per-xsd'`                  | Default output style for all sources (default: `'per-type'`)          |
+| `enumStyle`             | `'union' \| 'enum' \| 'const-object'`      | Default enum generation style (default: `'union'`)                    |
+| `useXmlRoot`            | `boolean`                                  | **Deprecated** — see [Deprecations](#-deprecations) (default: `true`) |
+| `elementForm`           | `'schema' \| 'qualified' \| 'unqualified'` | How local elements are namespace-qualified (default: `'schema'`)      |
+| `bigIntegerAs`          | `'number' \| 'string'`                     | How over-wide integer types are generated (default: `'number'`)       |
+| `requiredPropertyStyle` | `'schema' \| 'definite' \| 'initialized'`  | How required properties are declared (default: `'schema'`)            |
 
 ### Source options
 
@@ -201,7 +201,7 @@ Every option below overrides its global counterpart for that source.
 | `outputPath`            | `string`                                   | Output path. `per-type`: directory. `per-xsd`: `.ts` file path |
 | `outputStyle`           | `'per-type' \| 'per-xsd'`                  | `'per-type'`: one file per class. `'per-xsd'`: all in one file |
 | `enumStyle`             | `'union' \| 'enum' \| 'const-object'`      | Enum generation style for this source                          |
-| `useXmlRoot`            | `boolean`                                  | Emit `@XmlRoot` for root elements, or `@XmlElement`            |
+| `useXmlRoot`            | `boolean`                                  | **Deprecated** — see [Deprecations](#-deprecations)            |
 | `elementForm`           | `'schema' \| 'qualified' \| 'unqualified'` | How local elements are namespace-qualified                     |
 | `bigIntegerAs`          | `'number' \| 'string'`                     | How over-wide integer types are generated                      |
 | `requiredPropertyStyle` | `'schema' \| 'definite' \| 'initialized'`  | How required properties are declared                           |
@@ -330,7 +330,7 @@ negative `maxInclusive`/`maxExclusive`, or an enumeration not listing it. A prop
 | XSD Concept                           | Generated Code                                                                                                            |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | Root element + complexType            | `@XmlRoot({ name: '...' })`                                                                                               |
-| Named complexType                     | `@XmlType({ name: '...' })` class (`@XmlElement` when `useXmlRoot: false`)                                                |
+| Named complexType                     | `@XmlType({ name: '...' })` class (`@XmlElement` under the deprecated `useXmlRoot: false`)                                |
 | Element in sequence                   | `@XmlElement({ name: '...' })`                                                                                            |
 | `xs:element ref` / `xs:attribute ref` | Resolved to the referenced global declaration's type and facets; always namespace-qualified                               |
 | Repeating `xs:choice`/`xs:sequence`   | One `@XmlArray({ items })` collection, keeping the document order of the differently named siblings                       |
@@ -468,6 +468,41 @@ npx xml-poto-codegen generate
 3. **Pin your enum style per-source** — Override `enumStyle` at the source level when different schemas need different patterns.
 
 4. **Regenerate after schema changes** — Run `npx xml-poto-codegen generate` whenever your XSD files are updated.
+
+## ⚠️ Deprecations
+
+### `useXmlRoot` — removed in the next major
+
+The option exists so a schema can be embedded in a document it does not own, rather than standing
+alone as a root. Nothing needs it any more:
+
+- **SOAP** — `SoapSerializer` wraps and unwraps `Envelope`/`Body` around an `@XmlRoot` payload, so
+  there are no hand-written wrapper classes to embed into.
+- **Embedding by hand** — an `@XmlRoot` class works as a member type as it is. The referencing
+  `@XmlElement({ name: '...' })` decides the tag, and the class namespace is picked up either way.
+
+```ts
+// Was: generate with useXmlRoot: false, then reference GbavVraag from your own class.
+// Now: generate with the default, and either
+const soap = new SoapSerializer();
+soap.toXml(vraag); // <soapenv:Envelope><soapenv:Body><tns:gbavVraag>…
+
+// …or embed it yourself — @XmlRoot does not get in the way:
+@XmlRoot({ name: "Batch" })
+class Batch {
+	@XmlElement({ name: "vraag", type: () => GbavVraag })
+	vraag!: GbavVraag;
+}
+```
+
+Setting `useXmlRoot` at all — to `true` or to `false` — prints a deprecation warning during
+generation. Its behaviour is unchanged until it is removed: `useXmlRoot: false` still emits a
+class-level `@XmlElement` for every type instead of `@XmlRoot`/`@XmlType`.
+
+> Why flat mode is worse than the default, beyond simply being redundant: a class-level
+> `@XmlElement` establishes a namespace context, so a type's primitive members come out
+> qualified (`<tns:adresVraag>`) where `@XmlRoot`/`@XmlType` leaves them bare, and an inline
+> complexType claims a schema type identity the XSD never declared. Prefer the default.
 
 ## 🤝 Contributing
 

--- a/packages/xml-poto-codegen/src/commands/generate.ts
+++ b/packages/xml-poto-codegen/src/commands/generate.ts
@@ -44,11 +44,27 @@ function resolveSourceOptions(source: XsdSource, config: XmlPotoCodegenConfig): 
 	return {
 		outputStyle: source.outputStyle ?? config.defaultOutputStyle ?? "per-type",
 		enumStyle: source.enumStyle ?? config.enumStyle ?? "union",
+		// eslint-disable-next-line typescript/no-deprecated -- honouring the option until it is removed
 		useXmlRoot: source.useXmlRoot ?? config.useXmlRoot ?? true,
 		elementForm: source.elementForm ?? config.elementForm ?? "schema",
 		bigIntegerAs: source.bigIntegerAs ?? config.bigIntegerAs ?? "number",
 		requiredPropertyStyle: source.requiredPropertyStyle ?? config.requiredPropertyStyle ?? "schema",
 	};
+}
+
+/**
+ * Warn that `useXmlRoot` is on its way out, whichever value it was given: `true` is
+ * the default and `false` is the mode being retired, so neither is worth writing down.
+ */
+export function reportUseXmlRootDeprecation(source: XsdSource, config: XmlPotoCodegenConfig): void {
+	// eslint-disable-next-line typescript/no-deprecated -- reading the option is the point here
+	if (source.useXmlRoot === undefined && config.useXmlRoot === undefined) return;
+
+	console.warn(
+		"  Warning: 'useXmlRoot' is deprecated and is removed in the next major. " +
+			"Remove it from your config: root elements get @XmlRoot, SoapSerializer wraps " +
+			"Envelope/Body around them, and an @XmlRoot class embeds fine as a member type.",
+	);
 }
 
 async function runGenerate(): Promise<void> {
@@ -66,6 +82,7 @@ async function runGenerate(): Promise<void> {
 			resolveSourceOptions(source, config);
 
 		console.log(`\nProcessing: ${xsdPath}`);
+		reportUseXmlRootDeprecation(source, config);
 
 		// Parse XSD
 		const schema = parser.parseFile(xsdPath);

--- a/packages/xml-poto-codegen/src/config/config-types.ts
+++ b/packages/xml-poto-codegen/src/config/config-types.ts
@@ -64,7 +64,15 @@ export interface XsdSource {
 	outputStyle?: "per-type" | "per-xsd";
 	/** Enum generation style for this source. Overrides the global setting. */
 	enumStyle?: EnumStyle;
-	/** Whether to emit @XmlRoot for root elements. When false, @XmlElement is used instead. Overrides the global setting. */
+	/**
+	 * Whether to emit @XmlRoot for root elements. When false, @XmlElement is used instead.
+	 * Overrides the global setting.
+	 *
+	 * @deprecated Nothing needs this any more: `SoapSerializer` wraps and unwraps
+	 * Envelope/Body around an @XmlRoot payload, and an @XmlRoot class embeds fine as a
+	 * member type — the referencing @XmlElement({ name }) decides the tag. Remove the
+	 * option; it is removed in the next major.
+	 */
 	useXmlRoot?: boolean;
 	/** How local elements are qualified. Overrides the global setting. */
 	elementForm?: ElementForm;
@@ -84,7 +92,15 @@ export interface XmlPotoCodegenConfig {
 	defaultOutputStyle?: "per-type" | "per-xsd";
 	/** Default enum generation style. Defaults to 'union'. */
 	enumStyle?: EnumStyle;
-	/** Whether to emit @XmlRoot for root elements. When false, @XmlElement is used instead. Defaults to true. */
+	/**
+	 * Whether to emit @XmlRoot for root elements. When false, @XmlElement is used instead.
+	 * Defaults to true.
+	 *
+	 * @deprecated Nothing needs this any more: `SoapSerializer` wraps and unwraps
+	 * Envelope/Body around an @XmlRoot payload, and an @XmlRoot class embeds fine as a
+	 * member type — the referencing @XmlElement({ name }) decides the tag. Remove the
+	 * option; it is removed in the next major.
+	 */
 	useXmlRoot?: boolean;
 	/** How local elements are qualified. Defaults to 'schema'. */
 	elementForm?: ElementForm;

--- a/packages/xml-poto-codegen/src/generator/decorator-mapper.ts
+++ b/packages/xml-poto-codegen/src/generator/decorator-mapper.ts
@@ -19,9 +19,9 @@ const CLASS_INDENT_LEVEL = 0;
  * redundant namespace declaration on every nested object. A complexType declared
  * inline on an element is a type definition too, but an anonymous one: it gets
  * `@XmlType({ anonymous: true })`, which keeps the namespace fallback but withholds
- * the schema type identity it does not have. When `useXmlRoot` is false the model is
- * flattened to class-level `@XmlElement` everywhere (the caller opted out of the
- * root/type distinction).
+ * the schema type identity it does not have. When `useXmlRoot` is false (deprecated)
+ * the model is flattened to class-level `@XmlElement` everywhere (the caller opted out
+ * of the root/type distinction).
  */
 export function mapClassDecorator(type: ResolvedType, useXmlRoot = true): string {
 	if (type.isRootElement) {

--- a/packages/xml-poto-codegen/tests/integration/generate-command.test.ts
+++ b/packages/xml-poto-codegen/tests/integration/generate-command.test.ts
@@ -106,3 +106,35 @@ describe("reportCoverageWarnings — resolved schema metadata for unsupported fe
 		warnSpy.mockRestore();
 	});
 });
+
+describe("reportUseXmlRootDeprecation", () => {
+	const source = { xsdPath: "./a.xsd", outputPath: "./out" };
+
+	it.each([
+		["per source", { ...source, useXmlRoot: false }, { sources: [] }],
+		["per source, set to the default", { ...source, useXmlRoot: true }, { sources: [] }],
+		["globally", source, { sources: [], useXmlRoot: false }],
+		["globally, set to the default", source, { sources: [], useXmlRoot: true }],
+	])("warns when useXmlRoot is set %s", async (_label, src, config) => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { reportUseXmlRootDeprecation } = await import("../../src/commands/generate");
+
+		reportUseXmlRootDeprecation(src, config);
+
+		expect(warnSpy).toHaveBeenCalledOnce();
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'useXmlRoot' is deprecated"));
+
+		warnSpy.mockRestore();
+	});
+
+	it("stays silent when useXmlRoot is absent from the config", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { reportUseXmlRootDeprecation } = await import("../../src/commands/generate");
+
+		reportUseXmlRootDeprecation(source, { sources: [] });
+
+		expect(warnSpy).not.toHaveBeenCalled();
+
+		warnSpy.mockRestore();
+	});
+});


### PR DESCRIPTION
useXmlRoot is not needed anymore because now we have @XmlType and a separate SoapSerializer that handles the soap envelope and body for you